### PR TITLE
Fix: maintenance/announcement banner clears in other browsers

### DIFF
--- a/frontend/src/hooks/useAppConfig.ts
+++ b/frontend/src/hooks/useAppConfig.ts
@@ -55,10 +55,15 @@ export function useAppConfig() {
   return useQuery({
     queryKey: PUBLIC_KEY,
     queryFn: async () => (await api.get<PublicAppConfig>('/app-config')).data,
-    // /app-config is hit on every cold load before /users/me — if we
-    // refetch on every focus, the Mantine theme would flicker on tab
-    // switches. The admin Branding form invalidates this key on save.
-    staleTime: Infinity,
+    // Other browsers never see the admin's invalidateQueries on save —
+    // staleTime: Infinity would leave a regular user stuck on the
+    // MaintenancePage or staring at an outdated AnnouncementBanner
+    // until they hard-reloaded. Refetch every 30 s so admin changes
+    // propagate. TanStack Query's structural sharing returns the same
+    // reference when the response is unchanged, so Mantine doesn't
+    // rebuild the theme on each tick.
+    staleTime: 30_000,
+    refetchInterval: 30_000,
     retry: false,
   });
 }


### PR DESCRIPTION
## Summary
- The public ``/app-config`` query had ``staleTime: Infinity`` and no refetch interval, so a regular user looking at the announcement banner — or stuck on the ``MaintenancePage`` — never picked up the admin's change without a hard reload (``invalidateQueries`` only fires in the admin's own browser).
- Drop ``staleTime`` to 30 s and add a 30 s ``refetchInterval`` in ``frontend/src/hooks/useAppConfig.ts``. The original anti-flicker concern is already covered by TanStack Query's structural sharing — identical responses keep the same data reference, so Mantine doesn't rebuild the theme on each tick.

## Test plan
- [ ] Set an announcement (or enable maintenance mode) as super_admin; in a separate non-super_admin browser, confirm the banner / maintenance page appears.
- [ ] Clear the announcement (or disable maintenance) in the admin browser; confirm the other browser drops the banner / leaves the maintenance page within ~30 s without a reload.
- [ ] Confirm the Mantine theme does not flicker on tab focus or on the 30 s refetch tick.