### PR TITLE
Fix: CI references stale booking-app-casa names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,21 +137,21 @@ jobs:
       - name: Run migrations
         run: make migrate
 
-      - name: Seed owners
-        # Pre-enroll TOTP on the main smoke owner + a second owner
+      - name: Seed admins
+        # Pre-enroll TOTP on the main smoke admin + a second admin
         # pre-enrolled with email OTP for the email-otp.spec. Calling
-        # seed_owner directly (not via ``make seed-owner``) because
+        # seed_admin directly (not via ``make seed-admin``) because
         # the Makefile wrapper doesn't thread --totp-secret /
         # --email-otp through.
         run: |
           docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.e2e.yml run --rm api \
-            python -m app.scripts.seed_owner \
+            python -m app.scripts.seed_admin \
               --email "$E2E_OWNER_EMAIL" \
               --password "$E2E_OWNER_PASSWORD" \
               --full-name 'E2E Owner' \
               --totp-secret "$E2E_OWNER_TOTP_SECRET"
           docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.e2e.yml run --rm api \
-            python -m app.scripts.seed_owner \
+            python -m app.scripts.seed_admin \
               --email "$E2E_EMAIL_OTP_EMAIL" \
               --password "$E2E_EMAIL_OTP_PASSWORD" \
               --full-name 'E2E Email-OTP Owner' \
@@ -211,7 +211,7 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           scan-type: image
-          image-ref: booking-app-casa-api
+          image-ref: atrium-api
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           exit-code: '1'
@@ -220,7 +220,7 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           scan-type: image
-          image-ref: booking-app-casa-web
+          image-ref: atrium-web
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           exit-code: '1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,14 +96,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [backend, frontend]
     env:
-      E2E_OWNER_EMAIL: owner@example.com
-      E2E_OWNER_PASSWORD: smoke-pw-12345
+      E2E_ADMIN_EMAIL: admin@example.com
+      E2E_ADMIN_PASSWORD: smoke-pw-12345
       # Fixed TOTP secret so Playwright can compute valid codes
-      # against the pre-enrolled smoke owner (mirrors Makefile).
-      E2E_OWNER_TOTP_SECRET: JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP
-      # Second owner pre-enrolled with email OTP for the
+      # against the pre-enrolled smoke admin (mirrors Makefile).
+      E2E_ADMIN_TOTP_SECRET: JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP
+      # Second admin pre-enrolled with email OTP for the
       # email-otp.spec.ts path.
-      E2E_EMAIL_OTP_EMAIL: email-otp-owner@example.com
+      E2E_EMAIL_OTP_EMAIL: email-otp-admin@example.com
       E2E_EMAIL_OTP_PASSWORD: email-otp-pw-12345
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -146,15 +146,16 @@ jobs:
         run: |
           docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.e2e.yml run --rm api \
             python -m app.scripts.seed_admin \
-              --email "$E2E_OWNER_EMAIL" \
-              --password "$E2E_OWNER_PASSWORD" \
-              --full-name 'E2E Owner' \
-              --totp-secret "$E2E_OWNER_TOTP_SECRET"
+              --email "$E2E_ADMIN_EMAIL" \
+              --password "$E2E_ADMIN_PASSWORD" \
+              --full-name 'Smoke Admin' \
+              --super-admin \
+              --totp-secret "$E2E_ADMIN_TOTP_SECRET"
           docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.e2e.yml run --rm api \
             python -m app.scripts.seed_admin \
               --email "$E2E_EMAIL_OTP_EMAIL" \
               --password "$E2E_EMAIL_OTP_PASSWORD" \
-              --full-name 'E2E Email-OTP Owner' \
+              --full-name 'Email-OTP Smoke Admin' \
               --email-otp
 
       - name: Wait for frontend


### PR DESCRIPTION
## Summary
- Rename `app.scripts.seed_owner` to `seed_admin` in the e2e Seed step (the only seed script atrium ships) so the e2e job stops failing with `No module named app.scripts.seed_owner`.
- Update Trivy image scans from `booking-app-casa-{api,web}` to `atrium-{api,web}` to match the actual compose project name on CI, so compose-build stops failing with "No such image".

## Test plan
- [ ] CI runs cleanly: `e2e` Seed step succeeds, `compose-build` Trivy image scans succeed.