### PR TITLE
UX: gate System-tab announcement behind a Switch

### DIFF
--- a/frontend/src/components/admin/SystemAdmin.tsx
+++ b/frontend/src/components/admin/SystemAdmin.tsx
@@ -100,30 +100,43 @@ export function SystemAdmin() {
       </Paper>
       <Paper withBorder p="md">
         <Stack>
-          <TextInput
-            label={t('system.announcement')}
-            description={t('system.announcementHelp')}
-            placeholder={t('system.announcementPlaceholder')}
-            value={draft.announcement ?? ''}
+          <Switch
+            label={t('system.announcementEnabled')}
+            description={t('system.announcementEnabledHelp')}
+            checked={draft.announcement !== null}
             onChange={(e) =>
               setDraft({
                 ...draft,
-                announcement:
-                  e.currentTarget.value === '' ? null : e.currentTarget.value,
+                announcement: e.currentTarget.checked ? '' : null,
               })
             }
-            maxLength={2000}
           />
-          <Select
-            label={t('system.announcementLevel')}
-            data={LEVEL_OPTIONS}
-            value={draft.announcement_level}
-            onChange={(v) =>
-              v &&
-              setDraft({ ...draft, announcement_level: v as AnnouncementLevel })
-            }
-            allowDeselect={false}
-          />
+          {draft.announcement !== null && (
+            <>
+              <TextInput
+                label={t('system.announcement')}
+                placeholder={t('system.announcementPlaceholder')}
+                value={draft.announcement}
+                onChange={(e) =>
+                  setDraft({ ...draft, announcement: e.currentTarget.value })
+                }
+                maxLength={2000}
+              />
+              <Select
+                label={t('system.announcementLevel')}
+                data={LEVEL_OPTIONS}
+                value={draft.announcement_level}
+                onChange={(v) =>
+                  v &&
+                  setDraft({
+                    ...draft,
+                    announcement_level: v as AnnouncementLevel,
+                  })
+                }
+                allowDeselect={false}
+              />
+            </>
+          )}
         </Stack>
       </Paper>
       <Group justify="flex-end">

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -197,8 +197,9 @@
     "maintenanceMessage": "Maintenance message",
     "maintenanceWarningTitle": "Heads up",
     "maintenanceWarning": "Only super_admins keep access while this is on. Make sure at least one super_admin can sign in before saving.",
+    "announcementEnabled": "Show announcement",
+    "announcementEnabledHelp": "Render a banner above the app shell for every signed-in user.",
     "announcement": "Announcement",
-    "announcementHelp": "Plain text shown above the app shell to every signed-in user. Leave empty to hide.",
     "announcementPlaceholder": "Scheduled maintenance Saturday 22:00-23:00 UTC.",
     "announcementLevel": "Severity",
     "saved": "System settings saved"


### PR DESCRIPTION
## Summary
The announcement field on the System admin tab was a bare text input, with the convention "empty = hidden" — visually indistinguishable from the maintenance message Textarea above it. An operator landed on the tab intending to flip Maintenance Mode and typed into the announcement field instead.

Now mirrors the maintenance pattern: a "Show announcement" Switch gates the text input + severity Select. Off saves `announcement: null`; on reveals the fields.

## Test plan
- [ ] System tab: toggle Show announcement on → text + severity appear; type something, save, banner appears.
- [ ] Toggle off → fields collapse, save, banner disappears.