### PR TITLE
Prune Playwright in CI: PRs run smoke project only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,13 @@ jobs:
 
       - name: Run Playwright smoke
         working-directory: frontend
-        run: pnpm playwright test
+        # ``--project=smoke`` runs only the four golden-path specs
+        # defined in playwright.config.ts. The rest live under
+        # ``--project=extended`` and are intentionally not gated on
+        # PRs — backend pytest already covers the same flows. Run
+        # them locally with ``make smoke-extended`` before risky
+        # frontend changes.
+        run: pnpm playwright test --project=smoke
 
       - name: Dump stack logs on failure
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,21 +90,22 @@ jobs:
         run: pnpm build
 
   e2e:
-    # Smoke-only: spin up the full stack with compose and run one Playwright
-    # test to prove the app boots end-to-end. Heavier flows stay at the API
-    # and unit-test layer.
+    # Smoke-only: spin up the full stack with compose and run the four
+    # golden-path Playwright specs (smoke project) to prove the app
+    # boots end-to-end. Heavier flows stay at the API and unit-test
+    # layer; the extended Playwright project runs locally only.
+    #
+    # Runs in parallel with backend / frontend / compose-build —
+    # nothing here consumes their artifacts. A red unit-test job
+    # surfaces alongside a red e2e instead of after it; net wall-clock
+    # win on green PRs is ~3 min.
     runs-on: ubuntu-latest
-    needs: [backend, frontend]
     env:
       E2E_ADMIN_EMAIL: admin@example.com
       E2E_ADMIN_PASSWORD: smoke-pw-12345
       # Fixed TOTP secret so Playwright can compute valid codes
       # against the pre-enrolled smoke admin (mirrors Makefile).
       E2E_ADMIN_TOTP_SECRET: JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP
-      # Second admin pre-enrolled with email OTP for the
-      # email-otp.spec.ts path.
-      E2E_EMAIL_OTP_EMAIL: email-otp-admin@example.com
-      E2E_EMAIL_OTP_PASSWORD: email-otp-pw-12345
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -137,26 +138,26 @@ jobs:
       - name: Run migrations
         run: make migrate
 
-      - name: Seed admins
-        # Pre-enroll TOTP on the main smoke admin + a second admin
-        # pre-enrolled with email OTP for the email-otp.spec. Calling
-        # seed_admin directly (not via ``make seed-admin``) because
-        # the Makefile wrapper doesn't thread --totp-secret /
-        # --email-otp through.
+      - name: Seed admin
+        # Pre-enroll TOTP on the smoke admin via ``exec`` (the api
+        # container is already running from "Start stack") rather
+        # than ``run --rm`` which cold-starts a fresh container per
+        # call. Calling seed_admin directly (not via the make
+        # wrapper) because the wrapper doesn't thread
+        # --totp-secret through.
+        #
+        # The email-OTP admin is no longer seeded on PR CI — the
+        # email-otp.spec lives in the extended Playwright project,
+        # which doesn't run here. ``make smoke-extended`` re-seeds
+        # it locally when needed.
         run: |
-          docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.e2e.yml run --rm api \
+          docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.e2e.yml exec -T api \
             python -m app.scripts.seed_admin \
               --email "$E2E_ADMIN_EMAIL" \
               --password "$E2E_ADMIN_PASSWORD" \
               --full-name 'Smoke Admin' \
               --super-admin \
               --totp-secret "$E2E_ADMIN_TOTP_SECRET"
-          docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.e2e.yml run --rm api \
-            python -m app.scripts.seed_admin \
-              --email "$E2E_EMAIL_OTP_EMAIL" \
-              --password "$E2E_EMAIL_OTP_PASSWORD" \
-              --full-name 'Email-OTP Smoke Admin' \
-              --email-otp
 
       - name: Wait for frontend
         run: |
@@ -171,9 +172,21 @@ jobs:
         working-directory: frontend
         run: pnpm install --frozen-lockfile
 
+      # Cache the Chromium binary by Playwright version. ``ubuntu-latest``
+      # already ships the system libs Chromium needs (libnss3, libgtk,
+      # fontconfig, etc.) so ``--with-deps`` is not required — dropping
+      # it skips the apt-get step that's the slower half of the install.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('frontend/pnpm-lock.yaml') }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: frontend
-        run: pnpm exec playwright install --with-deps chromium
+        run: pnpm exec playwright install chromium
 
       - name: Run Playwright smoke
         working-directory: frontend
@@ -190,8 +203,11 @@ jobs:
         run: docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.e2e.yml logs
 
   compose-build:
+    # Builds the prod images for trivy scanning. No dependency on
+    # backend / frontend test results — the scan is about CVEs in
+    # the resulting images, orthogonal to whether tests pass. Runs
+    # in parallel for faster overall CI.
     runs-on: ubuntu-latest
-    needs: [backend, frontend]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Build prod images

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 .PHONY: help up down logs ps build rebuild migrate migration \
         seed-admin seed-super-admin dev-bootstrap \
         shell-api shell-db test test-backend test-frontend lint format \
-        clean prod-build prod-up prod-down smoke smoke-dev smoke-up smoke-down \
+        clean prod-build prod-up prod-down \
+        smoke smoke-extended smoke-dev smoke-up smoke-down \
         web-install web-reinstall reset-test-state
 
 COMPOSE_DEV := docker compose -f docker-compose.yml -f docker-compose.dev.yml
@@ -45,10 +46,12 @@ help:
 	@echo "  make prod-up            Start prod stack"
 	@echo "  make prod-down          Stop prod stack"
 	@echo ""
-	@echo "  make smoke              Run Playwright against the e2e stack"
-	@echo "                          (prod web image; mirrors CI)"
-	@echo "  make smoke-dev          Run Playwright against the dev stack"
-	@echo "                          (vite dev server + --reload api; stack stays up)"
+	@echo "  make smoke              Run the Playwright smoke project (4 specs)"
+	@echo "                          against the e2e stack — mirrors CI"
+	@echo "  make smoke-extended     Run the full Playwright suite (smoke + extended)"
+	@echo "                          against the e2e stack"
+	@echo "  make smoke-dev          Run the full Playwright suite against the dev stack"
+	@echo "                          (vite + --reload api; stack stays up)"
 
 # --- Dev stack ---
 up:
@@ -242,6 +245,17 @@ smoke-down:
 	$(COMPOSE_E2E) down -v
 
 smoke: smoke-up
+	cd frontend && E2E_ADMIN_EMAIL=$(SMOKE_EMAIL) E2E_ADMIN_PASSWORD=$(SMOKE_PASSWORD) \
+		E2E_ADMIN_TOTP_SECRET=$(SMOKE_TOTP_SECRET) \
+		E2E_EMAIL_OTP_EMAIL=$(SMOKE_EMAIL_OTP_EMAIL) \
+		E2E_EMAIL_OTP_PASSWORD=$(SMOKE_EMAIL_OTP_PASSWORD) \
+		pnpm playwright test --project=smoke
+
+# Runs both the ``smoke`` and ``extended`` Playwright projects against
+# the e2e stack — the full pre-prune behaviour. Use before risky
+# frontend changes; the PR-gating ``make smoke`` only runs the four
+# golden-path specs.
+smoke-extended: smoke-up
 	cd frontend && E2E_ADMIN_EMAIL=$(SMOKE_EMAIL) E2E_ADMIN_PASSWORD=$(SMOKE_PASSWORD) \
 		E2E_ADMIN_TOTP_SECRET=$(SMOKE_TOTP_SECRET) \
 		E2E_EMAIL_OTP_EMAIL=$(SMOKE_EMAIL_OTP_EMAIL) \

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,12 +1,31 @@
 import { defineConfig } from '@playwright/test';
 
 /**
- * Smoke-only E2E. Expects the app to already be running at
- * http://localhost:5173 (backed by the dev compose stack).
+ * Two projects:
+ *   * ``smoke`` — four critical golden paths (login, invite, signup,
+ *     logout). Runs on every PR (~15 s) to prove the full stack
+ *     boots and the auth + browser plumbing works.
+ *   * ``extended`` — admin-config UI surfaces (branding, i18n,
+ *     captcha, email-templates, etc). Backend pytest already covers
+ *     the same flows; these specs exist as a UI regression net but
+ *     are too noisy to gate every PR on. Run via
+ *     ``pnpm playwright test --project=extended`` or
+ *     ``make smoke-extended`` before risky frontend changes.
  *
- * CI seeds an owner via the backend CLI before the tests run; see
- * .github/workflows/ci.yml.
+ * No ``--project`` flag = both projects = full suite (the previous
+ * default behaviour). CI uses ``--project=smoke`` explicitly.
+ *
+ * Expects the app to already be running at http://localhost:5173
+ * (backed by the dev compose stack). CI seeds the smoke admins via
+ * the backend CLI before the tests run; see .github/workflows/ci.yml.
  */
+const SMOKE_SPECS = [
+  '**/smoke.spec.ts',
+  '**/invite-flow.spec.ts',
+  '**/signup.spec.ts',
+  '**/logout.spec.ts',
+];
+
 export default defineConfig({
   testDir: './tests-e2e',
   fullyParallel: false,
@@ -21,8 +40,14 @@ export default defineConfig({
   },
   projects: [
     {
-      name: 'chromium',
+      name: 'smoke',
       use: { browserName: 'chromium' },
+      testMatch: SMOKE_SPECS,
+    },
+    {
+      name: 'extended',
+      use: { browserName: 'chromium' },
+      testIgnore: SMOKE_SPECS,
     },
   ],
 });


### PR DESCRIPTION
## Summary

Two layers of CI improvement on the e2e job, both small and reversible:

**Prune the suite (a00ff6d):**
- Split Playwright into two projects in `frontend/playwright.config.ts`: `smoke` (login, invite, signup, logout — 9 tests) and `extended` (admin-config UI surfaces — 33 tests). PRs run only `--project=smoke`.
- Backend pytest already mirrors every e2e flow; the extended specs duplicate that coverage at the UI layer. The four smoke paths preserve the "real browser proves the stack boots" signal.

**Speed up the job (7369048):**
- Drop `needs: [backend, frontend]` from `e2e` and `compose-build` so all four jobs run in parallel.
- Cache `~/.cache/ms-playwright` keyed on `pnpm-lock.yaml` hash. Chromium binary only downloads on Playwright version bump.
- Drop `--with-deps` from `playwright install` (ubuntu-latest already has the system libs).
- Use `compose exec` instead of `compose run --rm` for the admin seed — saves a cold-start. Also drop the email-OTP admin seed (the spec it backs lives in the extended project).
- Pin `actions/cache` to v4.3.0 SHA.

## Expected impact

Today's e2e job: ~7m36s. Expected on warm cache: ~3-4 min, limited mostly by `docker compose up --build`. That's the next optimisation target (BuildKit + GHA cache for the api/web/worker images), tracked for a follow-up.

## Test plan
- [x] `pnpm playwright test --project=smoke --list` shows 9 tests in 4 files
- [x] `pnpm playwright test --project=extended --list` shows 33 tests in 10 files
- [x] `make smoke` (dev stack) — 9 passed in 11.2s
- [ ] CI runs all four jobs in parallel
- [ ] First run after merge: cache miss on Playwright (expected); subsequent runs hit cache
- [ ] Wall-clock time on the e2e job drops noticeably