### PR TITLE
Add: host extension surface — backend bootstrap, perm seeder, frontend slots

### DIFF
--- a/backend/app/auth/rbac_seed.py
+++ b/backend/app/auth/rbac_seed.py
@@ -1,0 +1,133 @@
+"""Idempotent permission + role-grant seeding for atrium and host apps.
+
+Atrium seeds its own permissions in migration 0001. Host apps need the
+same pattern for their domain permissions, callable from two places:
+
+- A migration (alembic's ``op.get_bind()`` returns a sync connection).
+- The runtime ``init_app`` startup hook (an async session, see
+  ``ATRIUM_HOST_MODULE`` in ``app.main``).
+
+Both forms share the same SQL: INSERT IGNORE on ``permissions``,
+INSERT IGNORE on ``role_permissions`` for each named grant, plus an
+auto-grant to ``super_admin`` so a host adding a new permission doesn't
+have to remember to wire the omnipotent role manually. The auto-grant
+matches the seed pattern in migration 0001 (``super_admin`` cross-joins
+every permission).
+
+Unknown role codes in ``grants`` are skipped with a warning rather than
+raising — host apps may opt into a smaller role set than atrium ships,
+and a missing role shouldn't crash startup.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.logging import log
+
+
+_INSERT_PERM = (
+    "INSERT IGNORE INTO permissions (code, description) "
+    "VALUES (:code, :description)"
+)
+
+_GRANT_TO_ROLE = (
+    "INSERT IGNORE INTO role_permissions (role_id, permission_code) "
+    "SELECT r.id, :code FROM roles r WHERE r.code = :role_code"
+)
+
+_AUTO_GRANT_SUPER_ADMIN = (
+    "INSERT IGNORE INTO role_permissions (role_id, permission_code) "
+    "SELECT r.id, :code FROM roles r WHERE r.code = 'super_admin'"
+)
+
+_ROLE_EXISTS = "SELECT 1 FROM roles WHERE code = :role_code LIMIT 1"
+
+
+async def seed_permissions(
+    session: AsyncSession,
+    perms: Iterable[str],
+    *,
+    grants: Mapping[str, Iterable[str]] | None = None,
+) -> None:
+    """Idempotently insert ``perms`` into ``permissions`` and apply
+    ``grants`` (role code → permission codes) on ``role_permissions``.
+
+    Caller is responsible for ``session.commit()`` so the seed lands in
+    the same transaction as any surrounding work.
+    """
+    perms = list(perms)
+    for code in perms:
+        await session.execute(
+            text(_INSERT_PERM), {"code": code, "description": None}
+        )
+        # Auto-grant to super_admin to mirror atrium's own seeding
+        # convention; host operators expect "super_admin sees
+        # everything" without per-permission ceremony.
+        await session.execute(text(_AUTO_GRANT_SUPER_ADMIN), {"code": code})
+
+    for role_code, codes in (grants or {}).items():
+        if role_code == "super_admin":
+            # Already covered by the auto-grant above.
+            continue
+        exists = (
+            await session.execute(
+                text(_ROLE_EXISTS), {"role_code": role_code}
+            )
+        ).first()
+        if exists is None:
+            log.warning(
+                "rbac_seed.unknown_role",
+                role_code=role_code,
+                permissions=list(codes),
+            )
+            continue
+        for code in codes:
+            await session.execute(
+                text(_GRANT_TO_ROLE),
+                {"code": code, "role_code": role_code},
+            )
+
+
+def seed_permissions_sync(
+    connection: Connection,
+    perms: Iterable[str],
+    *,
+    grants: Mapping[str, Iterable[str]] | None = None,
+) -> None:
+    """Sync sibling for use inside alembic migrations.
+
+    ``op.get_bind()`` returns a sync ``Connection``; pass it straight
+    in. Same SQL as the async form, same idempotence contract.
+    """
+    perms = list(perms)
+    for code in perms:
+        connection.execute(
+            text(_INSERT_PERM), {"code": code, "description": None}
+        )
+        connection.execute(text(_AUTO_GRANT_SUPER_ADMIN), {"code": code})
+
+    for role_code, codes in (grants or {}).items():
+        if role_code == "super_admin":
+            continue
+        exists = connection.execute(
+            text(_ROLE_EXISTS), {"role_code": role_code}
+        ).first()
+        if exists is None:
+            log.warning(
+                "rbac_seed.unknown_role",
+                role_code=role_code,
+                permissions=list(codes),
+            )
+            continue
+        for code in codes:
+            connection.execute(
+                text(_GRANT_TO_ROLE),
+                {"code": code, "role_code": role_code},
+            )
+
+
+__all__ = ["seed_permissions", "seed_permissions_sync"]

--- a/backend/app/auth/rbac_seed.py
+++ b/backend/app/auth/rbac_seed.py
@@ -28,7 +28,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.logging import log
 
-
 _INSERT_PERM = (
     "INSERT IGNORE INTO permissions (code, description) "
     "VALUES (:code, :description)"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,5 @@
+import importlib
+import os
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request
@@ -151,6 +153,20 @@ def create_app() -> FastAPI:
     app.include_router(account_deletion_self_router)
     app.include_router(account_deletion_admin_router)
     app.include_router(signup_router)
+
+    host_module = os.environ.get("ATRIUM_HOST_MODULE")
+    if host_module:
+        # ImportError is intentionally loud — the operator opted in by
+        # setting the env var, so a typo or missing dep should fail
+        # startup rather than silently launch atrium without the host.
+        mod = importlib.import_module(host_module)
+        init = getattr(mod, "init_app", None)
+        if callable(init):
+            init(app)
+        else:
+            log.info(
+                "host.init_app.absent", module=host_module
+            )
 
     return app
 

--- a/backend/app/services/app_config.py
+++ b/backend/app/services/app_config.py
@@ -74,6 +74,13 @@ class SystemConfig(BaseModel):
     # textarea is expected to hold one or two short sentences.
     announcement: str | None = Field(default=None, max_length=2000)
     announcement_level: Literal["info", "warning", "critical"] = "info"
+    # URL of a host-supplied JS bundle dynamically imported on SPA
+    # boot. The bundle's import-time side-effects populate the host
+    # registries (home widgets, routes, nav items, admin tabs). The
+    # value is fetched and EXECUTED as JS by every browser, so only
+    # an ``app_setting.manage`` admin can set it — same gate as the
+    # rest of this namespace.
+    host_bundle_url: str | None = Field(default=None, max_length=2000)
 
 
 class AuthConfig(BaseModel):

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -12,6 +12,8 @@ LOCKED to claim exactly one row at a time.
 from __future__ import annotations
 
 import asyncio
+import importlib
+import os
 import signal
 from datetime import UTC, datetime
 
@@ -215,6 +217,16 @@ async def main() -> None:
         coalesce=True,
         max_instances=1,
     )
+
+    host_module = os.environ.get("ATRIUM_HOST_MODULE")
+    if host_module:
+        mod = importlib.import_module(host_module)
+        init = getattr(mod, "init_worker", None)
+        if callable(init):
+            init(scheduler)
+        else:
+            log.info("host.init_worker.absent", module=host_module)
+
     scheduler.start()
 
     # Kick once immediately so /health doesn't see a "worker: no heartbeat"

--- a/backend/tests/unit/test_host_bootstrap.py
+++ b/backend/tests/unit/test_host_bootstrap.py
@@ -1,0 +1,153 @@
+"""ATRIUM_HOST_MODULE bootstrap hook (main.py + worker.py).
+
+The hook lets a host project register routers, app-config namespaces,
+permissions, and APScheduler jobs from a single named module — see
+``docs/published-images.md`` and §2 of the extension-surface plan.
+
+Three contracts to verify:
+
+1. With the env var unset, ``create_app()`` works as it always has — the
+   hook is dormant when nobody opted in. (``conftest._reseed_rbac`` and
+   the rest of the suite already exercise this; the test below is the
+   explicit assertion.)
+2. With the env var pointing at a real module exposing ``init_app``,
+   the hook calls it with the FastAPI app — that's the contract the
+   docs promise.
+3. With a missing or unimportable module, the hook raises so the
+   operator sees the typo at startup rather than silently launching
+   atrium without their host extensions.
+
+The worker path mirrors the api path; we exercise the same shape by
+calling the inline import logic against a fake ``init_worker`` module.
+Spinning up the real ``worker.main()`` would start an APScheduler
+event loop, which isn't worth the test fixture cost.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import types
+
+import pytest
+from fastapi import FastAPI
+
+
+@pytest.fixture
+def _restore_env():
+    """Make sure ATRIUM_HOST_MODULE doesn't leak between tests — the
+    autouse session fixtures don't touch it."""
+    original = os.environ.get("ATRIUM_HOST_MODULE")
+    yield
+    if original is None:
+        os.environ.pop("ATRIUM_HOST_MODULE", None)
+    else:
+        os.environ["ATRIUM_HOST_MODULE"] = original
+
+
+def _install_fake_module(name: str, module: types.ModuleType) -> None:
+    sys.modules[name] = module
+
+
+def _uninstall_fake_module(name: str) -> None:
+    sys.modules.pop(name, None)
+
+
+def test_create_app_unset_is_noop(_restore_env, monkeypatch):
+    """Sanity: create_app() works without ATRIUM_HOST_MODULE."""
+    monkeypatch.delenv("ATRIUM_HOST_MODULE", raising=False)
+
+    from app.main import create_app
+
+    app = create_app()
+    assert isinstance(app, FastAPI)
+
+
+def test_create_app_calls_init_app(_restore_env, monkeypatch):
+    """A host module exposing ``init_app(app)`` is called with the app."""
+    captured: dict[str, FastAPI] = {}
+
+    fake = types.ModuleType("atrium_test_host_module_a")
+
+    def init_app(app: FastAPI) -> None:
+        captured["app"] = app
+
+    fake.init_app = init_app
+    _install_fake_module("atrium_test_host_module_a", fake)
+    monkeypatch.setenv("ATRIUM_HOST_MODULE", "atrium_test_host_module_a")
+
+    try:
+        from app.main import create_app
+
+        app = create_app()
+    finally:
+        _uninstall_fake_module("atrium_test_host_module_a")
+
+    assert captured.get("app") is app
+
+
+def test_create_app_missing_init_app_is_noop(_restore_env, monkeypatch):
+    """Side-effects-only host modules (no ``init_app`` defined) are
+    allowed — atrium logs and continues."""
+    fake = types.ModuleType("atrium_test_host_module_b")
+    # No init_app attribute.
+    _install_fake_module("atrium_test_host_module_b", fake)
+    monkeypatch.setenv("ATRIUM_HOST_MODULE", "atrium_test_host_module_b")
+
+    try:
+        from app.main import create_app
+
+        app = create_app()
+    finally:
+        _uninstall_fake_module("atrium_test_host_module_b")
+
+    assert isinstance(app, FastAPI)
+
+
+def test_create_app_unimportable_module_raises(_restore_env, monkeypatch):
+    """The operator opted in by setting the env var; a typo or missing
+    install must fail loud at startup rather than silently launching
+    atrium without the host extensions."""
+    monkeypatch.setenv(
+        "ATRIUM_HOST_MODULE", "definitely_not_a_real_module_xyz"
+    )
+
+    # Reload main so the env var is read fresh by create_app's body.
+    from app.main import create_app
+
+    with pytest.raises(ImportError):
+        create_app()
+
+
+def test_worker_bootstrap_calls_init_worker(_restore_env, monkeypatch):
+    """Mirror of the api hook: the worker reads ATRIUM_HOST_MODULE and
+    invokes ``init_worker(scheduler)`` if present.
+
+    We exercise the inline code shape rather than spinning up
+    ``worker.main()`` — that path starts an APScheduler event loop and
+    is significantly more expensive to fixture than the bootstrap
+    contract warrants.
+    """
+    captured: dict[str, object] = {}
+
+    fake = types.ModuleType("atrium_test_host_module_w")
+
+    def init_worker(scheduler: object) -> None:
+        captured["scheduler"] = scheduler
+
+    fake.init_worker = init_worker
+    _install_fake_module("atrium_test_host_module_w", fake)
+    monkeypatch.setenv("ATRIUM_HOST_MODULE", "atrium_test_host_module_w")
+
+    try:
+        host_module = os.environ.get("ATRIUM_HOST_MODULE")
+        scheduler_sentinel = object()
+        if host_module:
+            mod = importlib.import_module(host_module)
+            init = getattr(mod, "init_worker", None)
+            if callable(init):
+                init(scheduler_sentinel)
+    finally:
+        _uninstall_fake_module("atrium_test_host_module_w")
+
+    assert captured.get("scheduler") is scheduler_sentinel

--- a/backend/tests/unit/test_rbac_seed.py
+++ b/backend/tests/unit/test_rbac_seed.py
@@ -1,0 +1,214 @@
+"""Idempotent permission + role-grant seeding (rbac_seed module).
+
+Three contracts:
+
+1. Seeding twice is a no-op — the runtime form runs on every host
+   ``init_app`` startup, so repeated calls must not double-insert.
+2. ``super_admin`` auto-receives every newly seeded permission, mirror
+   of the migration-0001 seed pattern (host operators expect
+   "super_admin sees everything" without per-permission ceremony).
+3. Unknown role codes in ``grants`` are skipped with a log warning,
+   not raised — host apps may opt into a smaller role set than atrium
+   ships, and a missing role shouldn't crash startup.
+
+Also covered: the sync sibling (``seed_permissions_sync``) walks the
+same SQL paths via ``op.get_bind()``-style sync connections used inside
+alembic migrations.
+
+The ``permissions`` table is in the conftest truncate-skip list (it's
+seeded once by migration and assumed invariant), so each test cleans
+up the test-specific permission codes it wrote on teardown.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import create_engine, select, text
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.auth.rbac_seed import seed_permissions, seed_permissions_sync
+from app.models.rbac import Permission, Role, role_permissions
+
+_TEST_PERM_PREFIX = "test_rbac_seed."
+
+
+@pytest_asyncio.fixture
+async def _cleanup_test_perms(engine):
+    """Wipe any permission row whose code begins with the test prefix
+    on teardown, plus the role_permissions rows that referenced it."""
+    yield
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as s:
+        await s.execute(
+            text(
+                "DELETE FROM role_permissions "
+                "WHERE permission_code LIKE :prefix"
+            ),
+            {"prefix": f"{_TEST_PERM_PREFIX}%"},
+        )
+        await s.execute(
+            text("DELETE FROM permissions WHERE code LIKE :prefix"),
+            {"prefix": f"{_TEST_PERM_PREFIX}%"},
+        )
+        await s.commit()
+
+
+@pytest.mark.asyncio
+async def test_seed_inserts_permission_once(engine, _cleanup_test_perms):
+    code = f"{_TEST_PERM_PREFIX}toggle"
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as s:
+        await seed_permissions(s, [code])
+        await s.commit()
+
+    async with factory() as s:
+        rows = (
+            await s.execute(
+                select(Permission.code).where(Permission.code == code)
+            )
+        ).scalars().all()
+    assert rows == [code]
+
+
+@pytest.mark.asyncio
+async def test_seed_is_idempotent(engine, _cleanup_test_perms):
+    code = f"{_TEST_PERM_PREFIX}idempotent"
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as s:
+        await seed_permissions(s, [code], grants={"admin": [code]})
+        await s.commit()
+    async with factory() as s:
+        await seed_permissions(s, [code], grants={"admin": [code]})
+        await s.commit()
+
+    async with factory() as s:
+        perm_count = (
+            await s.execute(
+                select(Permission).where(Permission.code == code)
+            )
+        ).scalars().all()
+        admin_id = (
+            await s.execute(select(Role.id).where(Role.code == "admin"))
+        ).scalar_one()
+        grant_rows = (
+            await s.execute(
+                select(role_permissions).where(
+                    role_permissions.c.permission_code == code,
+                    role_permissions.c.role_id == admin_id,
+                )
+            )
+        ).all()
+
+    assert len(perm_count) == 1
+    assert len(grant_rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_super_admin_auto_grant(engine, _cleanup_test_perms):
+    """Every newly seeded permission lands on super_admin, even with
+    no explicit grant — mirrors the seed pattern in migration 0001."""
+    code = f"{_TEST_PERM_PREFIX}auto_super"
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as s:
+        await seed_permissions(s, [code])
+        await s.commit()
+
+    async with factory() as s:
+        super_id = (
+            await s.execute(
+                select(Role.id).where(Role.code == "super_admin")
+            )
+        ).scalar_one()
+        rows = (
+            await s.execute(
+                select(role_permissions).where(
+                    role_permissions.c.permission_code == code,
+                    role_permissions.c.role_id == super_id,
+                )
+            )
+        ).all()
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_unknown_role_is_skipped(engine, _cleanup_test_perms, caplog):
+    """A grant on a role that doesn't exist logs a warning and moves
+    on — host apps may opt into a smaller role set than atrium ships."""
+    code = f"{_TEST_PERM_PREFIX}unknown_role"
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as s:
+        await seed_permissions(
+            s,
+            [code],
+            grants={"definitely_not_a_real_role": [code]},
+        )
+        await s.commit()
+
+    async with factory() as s:
+        # The permission landed (and super_admin got it), but no
+        # role_permissions row references the bogus role.
+        bogus = (
+            await s.execute(
+                select(role_permissions).where(
+                    role_permissions.c.permission_code == code,
+                )
+            )
+        ).all()
+    # Only the super_admin auto-grant — the unknown role contributed
+    # nothing.
+    assert len(bogus) == 1
+
+
+def test_seed_permissions_sync(mysql_url, _cleanup_test_perms_sync):
+    """The sync sibling walks the same SQL inside an alembic migration.
+    Uses a short-lived sync engine matching the alembic ``op.get_bind()``
+    contract."""
+    code = f"{_TEST_PERM_PREFIX}sync"
+    sync_url = mysql_url.replace("mysql+aiomysql://", "mysql+pymysql://", 1)
+    sync_engine = create_engine(sync_url, pool_pre_ping=True)
+    try:
+        with sync_engine.begin() as conn:
+            seed_permissions_sync(conn, [code], grants={"admin": [code]})
+            seed_permissions_sync(conn, [code], grants={"admin": [code]})
+
+        with sync_engine.connect() as conn:
+            perm_rows = conn.execute(
+                text("SELECT code FROM permissions WHERE code = :c"),
+                {"c": code},
+            ).all()
+            grant_rows = conn.execute(
+                text(
+                    "SELECT 1 FROM role_permissions rp "
+                    "JOIN roles r ON r.id = rp.role_id "
+                    "WHERE rp.permission_code = :c"
+                ),
+                {"c": code},
+            ).all()
+    finally:
+        sync_engine.dispose()
+
+    # admin grant + super_admin auto-grant.
+    assert len(perm_rows) == 1
+    assert len(grant_rows) == 2
+
+
+@pytest.fixture
+def _cleanup_test_perms_sync(mysql_url):
+    yield
+    sync_url = mysql_url.replace("mysql+aiomysql://", "mysql+pymysql://", 1)
+    sync_engine = create_engine(sync_url, pool_pre_ping=True)
+    try:
+        with sync_engine.begin() as conn:
+            conn.execute(
+                text(
+                    "DELETE FROM role_permissions "
+                    "WHERE permission_code LIKE :prefix"
+                ),
+                {"prefix": f"{_TEST_PERM_PREFIX}%"},
+            )
+            conn.execute(
+                text("DELETE FROM permissions WHERE code LIKE :prefix"),
+                {"prefix": f"{_TEST_PERM_PREFIX}%"},
+            )
+    finally:
+        sync_engine.dispose()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { MaintenancePage } from './components/MaintenancePage';
 import { RequireAuth } from './components/RequireAuth';
 import { useAppConfig } from './hooks/useAppConfig';
 import { useMe } from './hooks/useAuth';
+import { getRoutes } from './host/registry';
 import { AcceptInvitePage } from './routes/AcceptInvitePage';
 import { AdminPage } from './routes/AdminPage';
 import { ForgotPasswordPage } from './routes/ForgotPasswordPage';
@@ -36,6 +37,20 @@ export default function App() {
       </Routes>
     );
   }
+  // Host bundles register additional routes via getRoutes(); split
+  // by ``layout``+``requireAuth`` so shell-routes nest inside the
+  // existing AppLayout/RequireAuth wrapper (whose <Outlet/> renders
+  // the matched child) and bare routes mount outside it.
+  const hostRoutes = getRoutes();
+  const shellAuthRoutes = hostRoutes.filter(
+    (r) => (r.layout ?? 'shell') === 'shell' && (r.requireAuth ?? true),
+  );
+  const bareAuthRoutes = hostRoutes.filter(
+    (r) => (r.layout ?? 'shell') === 'bare' && (r.requireAuth ?? true),
+  );
+  const publicHostRoutes = hostRoutes.filter(
+    (r) => (r.requireAuth ?? true) === false,
+  );
   return (
     <Routes>
       {/* Public auth routes (no layout) */}
@@ -49,6 +64,18 @@ export default function App() {
           RequireAuth (which only understands full sessions). */}
       <Route path="/2fa" element={<TwoFactorPage />} />
 
+      {publicHostRoutes.map((r) => (
+        <Route key={r.key} path={r.path} element={r.element} />
+      ))}
+
+      {bareAuthRoutes.map((r) => (
+        <Route
+          key={r.key}
+          path={r.path}
+          element={<RequireAuth>{r.element}</RequireAuth>}
+        />
+      ))}
+
       {/* Authenticated routes (inside app shell) */}
       <Route
         element={
@@ -61,6 +88,9 @@ export default function App() {
         <Route path="/admin" element={<AdminPage />} />
         <Route path="/profile" element={<ProfilePage />} />
         <Route path="/notifications" element={<NotificationsPage />} />
+        {shellAuthRoutes.map((r) => (
+          <Route key={r.key} path={r.path} element={r.element} />
+        ))}
         <Route path="*" element={<Navigate to="/" replace />} />
       </Route>
     </Routes>

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -24,6 +24,7 @@ import { useTranslation } from 'react-i18next';
 
 import { useAppConfig } from '@/hooks/useAppConfig';
 import { useMe, useLogout } from '@/hooks/useAuth';
+import { getNavItems } from '@/host/registry';
 
 import { AnnouncementBanner } from './AnnouncementBanner';
 import { ImpersonationBanner } from './ImpersonationBanner';
@@ -196,6 +197,24 @@ export function AppLayout() {
             onClick={close}
           />
         )}
+        {getNavItems()
+          .filter((item) =>
+            item.condition ? item.condition({ me: me ?? null }) : true,
+          )
+          .map((item) => (
+            <NavLink
+              key={item.key}
+              component={Link}
+              to={item.to}
+              label={item.label}
+              leftSection={item.icon}
+              active={
+                location.pathname === item.to ||
+                location.pathname.startsWith(`${item.to}/`)
+              }
+              onClick={close}
+            />
+          ))}
       </AppShell.Navbar>
 
       <AppShell.Main>

--- a/frontend/src/components/HostHomeWidgets.tsx
+++ b/frontend/src/components/HostHomeWidgets.tsx
@@ -1,0 +1,19 @@
+import { Fragment } from 'react';
+import { Stack } from '@mantine/core';
+
+import { getHomeWidgets } from '@/host/registry';
+
+/** Iterates the home-widget registry and renders each widget in a
+ *  vertical Mantine Stack above the atrium-shipped HomePage content.
+ *  Empty when no host bundle is loaded. */
+export function HostHomeWidgets() {
+  const widgets = getHomeWidgets();
+  if (widgets.length === 0) return null;
+  return (
+    <Stack gap="md">
+      {widgets.map((w) => (
+        <Fragment key={w.key}>{w.render()}</Fragment>
+      ))}
+    </Stack>
+  );
+}

--- a/frontend/src/hooks/useAppConfig.ts
+++ b/frontend/src/hooks/useAppConfig.ts
@@ -19,6 +19,11 @@ export interface SystemConfig {
   maintenance_message: string;
   announcement: string | null;
   announcement_level: AnnouncementLevel;
+  // URL of a host-supplied JS bundle dynamically imported on SPA boot.
+  // The bundle's import-time side-effects populate the host registries
+  // (home widgets, routes, nav items, admin tabs). Null when no host
+  // extension is loaded.
+  host_bundle_url?: string | null;
 }
 
 export interface I18nConfig {

--- a/frontend/src/host/registry.ts
+++ b/frontend/src/host/registry.ts
@@ -1,0 +1,168 @@
+/**
+ * Atrium host-extension registry.
+ *
+ * Atrium ships only the platform shell. Host applications inject their
+ * own UI fragments via four registries — home widgets, routes, nav
+ * items, and admin tabs — populated at SPA boot from a runtime-loaded
+ * host bundle (see ``main.tsx`` and ``system.host_bundle_url``).
+ *
+ * The registries are deliberately thin: each one is an array, ordered
+ * by registration call order, and the consumer components iterate
+ * them at first render. There is no mutation channel after boot —
+ * every host bundle's import-time side-effects must complete before
+ * React mounts, otherwise the consumer would render before the
+ * registration call lands.
+ *
+ * The same module exposes both:
+ *
+ *  - typed ``register*`` and ``get*`` functions, used by atrium's own
+ *    consumer components and by in-tree tests, and
+ *  - a ``window.__ATRIUM_REGISTRY__`` global pointing at the same
+ *    underlying state, so the runtime-loaded host bundle can call
+ *    ``register*`` without importing this file.
+ */
+import type { ReactElement } from 'react';
+
+import type { CurrentUser } from '@/lib/auth';
+
+export type HomeWidget = {
+  key: string;
+  render: () => ReactElement;
+};
+
+export type RouteEntry = {
+  key: string;
+  path: string;
+  element: ReactElement;
+  /** Default true. Set false for public routes (e.g. host-supplied
+   *  unauthenticated landing pages). */
+  requireAuth?: boolean;
+  /** Default 'shell'. Wraps the route in atrium's AppLayout (header +
+   *  sidebar). 'bare' renders the element with no chrome. */
+  layout?: 'shell' | 'bare';
+};
+
+export type NavItem = {
+  key: string;
+  label: string;
+  to: string;
+  icon?: ReactElement;
+  /** Optional visibility predicate. Default: always visible. The
+   *  predicate is called with the current ``me`` context (or null when
+   *  the SPA hasn't resolved auth yet). */
+  condition?: (ctx: { me: CurrentUser | null }) => boolean;
+};
+
+export type AdminTab = {
+  key: string;
+  label: string;
+  icon?: ReactElement;
+  /** Permission code; the tab is hidden for users who don't hold it.
+   *  Omit to show the tab to every admin viewer. */
+  perm?: string;
+  element: ReactElement;
+};
+
+const homeWidgets: HomeWidget[] = [];
+const routes: RouteEntry[] = [];
+const navItems: NavItem[] = [];
+const adminTabs: AdminTab[] = [];
+
+function registerHomeWidget(widget: HomeWidget): void {
+  if (homeWidgets.some((w) => w.key === widget.key)) {
+    console.warn(
+      `[atrium-registry] duplicate home widget key "${widget.key}"; ` +
+        `last registration wins`,
+    );
+    const idx = homeWidgets.findIndex((w) => w.key === widget.key);
+    homeWidgets.splice(idx, 1);
+  }
+  homeWidgets.push(widget);
+}
+
+function registerRoute(route: RouteEntry): void {
+  // Path collisions are last-write-wins so a host can deliberately
+  // override an atrium route, but we surface a console warning so the
+  // collision is visible during integration.
+  const collide = routes.find((r) => r.path === route.path);
+  if (collide) {
+    console.warn(
+      `[atrium-registry] route path "${route.path}" already registered ` +
+        `(key "${collide.key}"); replacing with "${route.key}"`,
+    );
+    const idx = routes.indexOf(collide);
+    routes.splice(idx, 1);
+  }
+  if (routes.some((r) => r.key === route.key)) {
+    const idx = routes.findIndex((r) => r.key === route.key);
+    routes.splice(idx, 1);
+  }
+  routes.push(route);
+}
+
+function registerNavItem(item: NavItem): void {
+  if (navItems.some((n) => n.key === item.key)) {
+    const idx = navItems.findIndex((n) => n.key === item.key);
+    navItems.splice(idx, 1);
+  }
+  navItems.push(item);
+}
+
+function registerAdminTab(tab: AdminTab): void {
+  if (adminTabs.some((t) => t.key === tab.key)) {
+    const idx = adminTabs.findIndex((t) => t.key === tab.key);
+    adminTabs.splice(idx, 1);
+  }
+  adminTabs.push(tab);
+}
+
+export const __ATRIUM_REGISTRY__ = {
+  registerHomeWidget,
+  registerRoute,
+  registerNavItem,
+  registerAdminTab,
+} as const;
+
+export type AtriumRegistry = typeof __ATRIUM_REGISTRY__;
+
+export function getHomeWidgets(): readonly HomeWidget[] {
+  return homeWidgets;
+}
+
+export function getRoutes(): readonly RouteEntry[] {
+  return routes;
+}
+
+export function getNavItems(): readonly NavItem[] {
+  return navItems;
+}
+
+export function getAdminTabs(): readonly AdminTab[] {
+  return adminTabs;
+}
+
+/** Test-only: drop every registration. Production code never calls
+ *  this — host bundles register once at boot and stay. */
+export function __resetRegistryForTests(): void {
+  homeWidgets.length = 0;
+  routes.length = 0;
+  navItems.length = 0;
+  adminTabs.length = 0;
+}
+
+declare global {
+  interface Window {
+    __ATRIUM_REGISTRY__?: AtriumRegistry;
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.__ATRIUM_REGISTRY__ = __ATRIUM_REGISTRY__;
+}
+
+export {
+  registerHomeWidget,
+  registerRoute,
+  registerNavItem,
+  registerAdminTab,
+};

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -18,6 +18,7 @@ export type { EmailTemplate } from '@/hooks/useEmailTemplates';
 export type {
   BrandConfig,
   PublicAppConfig,
+  SystemConfig,
   ThemePreset,
 } from '@/hooks/useAppConfig';
 export type { AuthSessionRead as AuthSession } from '@/hooks/useSessions';

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -17,20 +17,81 @@ import '@mantine/notifications/styles.css';
 import './styles/global.css';
 
 import App from './App';
+// Importing the registry module installs ``window.__ATRIUM_REGISTRY__``
+// as a side-effect; the host bundle reads from there. Must run before
+// the dynamic import below so the host bundle's import-time
+// registration calls find the global already populated.
+import './host/registry';
+import { api } from './lib/api';
 import { queryClient } from './lib/queryClient';
 import { ThemedApp } from './theme/ThemedApp';
 import './i18n';
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <ThemedApp>
-        <Notifications position="top-right" />
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
-        {DEVTOOLS_ENABLED && <ReactQueryDevtools initialIsOpen={false} />}
-      </ThemedApp>
-    </QueryClientProvider>
-  </React.StrictMode>,
-);
+// Host bundles externalise React + ReactDOM (per the Vite config in
+// docs/published-images.md) so their import-time code can call
+// ``React.createElement`` without doubling up on the React copy. We
+// expose the SPA's React instance on ``window`` for them to pick up;
+// without this, an externalised bundle would resolve to ``undefined``
+// at runtime.
+declare global {
+  interface Window {
+    React?: typeof React;
+  }
+}
+if (typeof window !== 'undefined') {
+  window.React = React;
+}
+
+interface BootSystemSlice {
+  host_bundle_url?: string | null;
+}
+
+interface BootAppConfig {
+  system?: BootSystemSlice;
+}
+
+async function loadHostBundle(): Promise<void> {
+  let url: string | null | undefined;
+  try {
+    const { data } = await api.get<BootAppConfig>('/app-config');
+    url = data?.system?.host_bundle_url ?? null;
+  } catch (err) {
+    // /app-config is the same call useAppConfig() makes once React
+    // mounts; if it's down here it'll surface there too. Don't block
+    // the app from rendering on a transient backend hiccup.
+    console.warn('[atrium] /app-config probe failed during boot', err);
+    return;
+  }
+  if (!url) return;
+  try {
+    // The host bundle's import-time side-effects call
+    // window.__ATRIUM_REGISTRY__.register*. By the time this await
+    // resolves every registration is in place, so the consumer
+    // components see a populated registry on first render.
+    await import(/* @vite-ignore */ url);
+  } catch (err) {
+    // Bundle-load failure is non-fatal: the SPA still renders, just
+    // without the host extensions. The error is logged so an admin
+    // who fat-fingered the URL can find it in the browser console.
+    console.error('[atrium] host bundle failed to load', url, err);
+  }
+}
+
+async function bootstrap(): Promise<void> {
+  await loadHostBundle();
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <QueryClientProvider client={queryClient}>
+        <ThemedApp>
+          <Notifications position="top-right" />
+          <BrowserRouter>
+            <App />
+          </BrowserRouter>
+          {DEVTOOLS_ENABLED && <ReactQueryDevtools initialIsOpen={false} />}
+        </ThemedApp>
+      </QueryClientProvider>
+    </React.StrictMode>,
+  );
+}
+
+void bootstrap();

--- a/frontend/src/routes/AdminPage.tsx
+++ b/frontend/src/routes/AdminPage.tsx
@@ -22,7 +22,8 @@ import { RolesAdmin } from '@/components/admin/RolesAdmin';
 import { SystemAdmin } from '@/components/admin/SystemAdmin';
 import { TranslationsAdmin } from '@/components/admin/TranslationsAdmin';
 import { UsersAdmin } from '@/components/admin/UsersAdmin';
-import { usePerm } from '@/hooks/useAuth';
+import { useMe, usePerm } from '@/hooks/useAuth';
+import { getAdminTabs } from '@/host/registry';
 
 const TABS = [
   'system',
@@ -35,20 +36,28 @@ const TABS = [
   'reminders',
   'audit',
 ] as const;
-type TabValue = (typeof TABS)[number];
 
 export function AdminPage() {
   const { t } = useTranslation();
+  const { data: me } = useMe();
   const canManageRoles = usePerm('role.manage');
   const canViewAudit = usePerm('audit.read');
   const canManageAppConfig = usePerm('app_setting.manage');
   const canManageEmailTemplates = usePerm('email_template.manage');
 
+  // Host-registered admin tabs; filtered by the perm code each tab
+  // declares (omitted ``perm`` means visible to every viewer of the
+  // admin page).
+  const userPerms = me?.permissions ?? [];
+  const visibleHostTabs = getAdminTabs().filter(
+    (tab) => !tab.perm || userPerms.includes(tab.perm),
+  );
+
   const [searchParams, setSearchParams] = useSearchParams();
-  const requested = searchParams.get('tab') as TabValue | null;
-  const isValid =
+  const requested = searchParams.get('tab');
+  const isBuiltinValid =
     requested !== null &&
-    TABS.includes(requested) &&
+    (TABS as readonly string[]).includes(requested) &&
     (requested !== 'audit' || canViewAudit) &&
     (requested !== 'roles' || canManageRoles) &&
     (requested !== 'branding' || canManageAppConfig) &&
@@ -56,7 +65,9 @@ export function AdminPage() {
     (requested !== 'auth' || canManageAppConfig) &&
     (requested !== 'translations' || canManageAppConfig) &&
     (requested !== 'emails' || canManageEmailTemplates);
-  const active: TabValue = isValid ? requested : 'users';
+  const isHostValid =
+    requested !== null && visibleHostTabs.some((t) => t.key === requested);
+  const active: string = isBuiltinValid || isHostValid ? requested! : 'users';
 
   const onTabChange = (v: string | null) => {
     if (!v) return;
@@ -112,6 +123,15 @@ export function AdminPage() {
               {t('audit.tab')}
             </Tabs.Tab>
           )}
+          {visibleHostTabs.map((tab) => (
+            <Tabs.Tab
+              key={tab.key}
+              value={tab.key}
+              leftSection={tab.icon}
+            >
+              {tab.label}
+            </Tabs.Tab>
+          ))}
         </Tabs.List>
         {canManageAppConfig && (
           <Tabs.Panel value="system" pt="md"><SystemAdmin /></Tabs.Panel>
@@ -138,6 +158,11 @@ export function AdminPage() {
         {canViewAudit && (
           <Tabs.Panel value="audit" pt="md"><AuditAdmin /></Tabs.Panel>
         )}
+        {visibleHostTabs.map((tab) => (
+          <Tabs.Panel key={tab.key} value={tab.key} pt="md">
+            {tab.element}
+          </Tabs.Panel>
+        ))}
       </Tabs>
     </Stack>
   );

--- a/frontend/src/routes/HomePage.tsx
+++ b/frontend/src/routes/HomePage.tsx
@@ -3,6 +3,7 @@ import { IconBell, IconSettings, IconUser } from '@tabler/icons-react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
+import { HostHomeWidgets } from '@/components/HostHomeWidgets';
 import { useMe } from '@/hooks/useAuth';
 
 /** Minimal landing page. Host apps replace this with whatever
@@ -15,6 +16,7 @@ export function HomePage() {
   return (
     <Container size={680}>
       <Stack gap="md">
+        <HostHomeWidgets />
         <Title order={2}>
           {me?.full_name
             ? t('home.welcomeNamed', { name: me.full_name })

--- a/frontend/src/test/host-registry.test.tsx
+++ b/frontend/src/test/host-registry.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Vitest coverage for the four host extension registries.
+ *
+ * The registries are module-level state, so each test resets via the
+ * exposed ``__resetRegistryForTests`` to avoid bleed between cases.
+ *
+ * Behaviour pinned down here:
+ *  - register* push entries that get* return in registration order.
+ *  - duplicate ``key`` for the same registry replaces the prior entry
+ *    rather than double-counting.
+ *  - ``registerRoute`` warns on path collisions (last-write-wins).
+ *  - the global ``window.__ATRIUM_REGISTRY__`` is bound to the same
+ *    underlying state as the typed ``register*`` exports — host
+ *    bundles loaded at runtime use the global, in-tree code uses the
+ *    typed exports, both populate the same arrays.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+  __ATRIUM_REGISTRY__,
+  __resetRegistryForTests,
+  getAdminTabs,
+  getHomeWidgets,
+  getNavItems,
+  getRoutes,
+  registerAdminTab,
+  registerHomeWidget,
+  registerNavItem,
+  registerRoute,
+} from '@/host/registry';
+
+describe('host registry', () => {
+  beforeEach(() => {
+    __resetRegistryForTests();
+  });
+
+  it('registerHomeWidget appends entries that getHomeWidgets returns', () => {
+    registerHomeWidget({ key: 'a', render: () => <span>A</span> });
+    registerHomeWidget({ key: 'b', render: () => <span>B</span> });
+    const widgets = getHomeWidgets();
+    expect(widgets.map((w) => w.key)).toEqual(['a', 'b']);
+  });
+
+  it('registerHomeWidget replaces on duplicate key', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      registerHomeWidget({ key: 'a', render: () => <span>first</span> });
+      registerHomeWidget({ key: 'a', render: () => <span>second</span> });
+      const widgets = getHomeWidgets();
+      expect(widgets).toHaveLength(1);
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('registerRoute warns on path collision and replaces', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      registerRoute({
+        key: 'first',
+        path: '/x',
+        element: <span>first</span>,
+      });
+      registerRoute({
+        key: 'second',
+        path: '/x',
+        element: <span>second</span>,
+      });
+      const routes = getRoutes();
+      expect(routes).toHaveLength(1);
+      expect(routes[0]?.key).toBe('second');
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('registerNavItem records condition predicates', () => {
+    const condition = vi.fn(() => true);
+    registerNavItem({ key: 'n', label: 'Nav', to: '/n', condition });
+    const items = getNavItems();
+    expect(items).toHaveLength(1);
+    expect(items[0]?.condition?.({ me: null })).toBe(true);
+    expect(condition).toHaveBeenCalled();
+  });
+
+  it('registerAdminTab carries perm code through', () => {
+    registerAdminTab({
+      key: 't',
+      label: 'Tab',
+      perm: 'thing.manage',
+      element: <span>tab</span>,
+    });
+    const tabs = getAdminTabs();
+    expect(tabs[0]?.perm).toBe('thing.manage');
+  });
+
+  it('window.__ATRIUM_REGISTRY__ writes through to the same state', () => {
+    // The runtime-loaded host bundle calls window.__ATRIUM_REGISTRY__
+    // rather than importing the typed exports — this test pins down
+    // that the two surfaces share state.
+    window.__ATRIUM_REGISTRY__?.registerHomeWidget({
+      key: 'global',
+      render: () => <span>global</span>,
+    });
+    const widgets = getHomeWidgets();
+    expect(widgets.map((w) => w.key)).toContain('global');
+    expect(__ATRIUM_REGISTRY__).toBe(window.__ATRIUM_REGISTRY__);
+  });
+
+  afterEach(() => {
+    __resetRegistryForTests();
+  });
+});

--- a/frontend/tests-e2e/host-bundle.spec.ts
+++ b/frontend/tests-e2e/host-bundle.spec.ts
@@ -1,0 +1,138 @@
+import type { APIRequestContext } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+
+import { API_URL, loginAsAdmin } from './helpers';
+
+/** Local helper — the shared ``setSystemConfig`` predates this branch
+ *  and types its patch tightly. We need to set ``host_bundle_url``,
+ *  which the shared signature doesn't accept yet, so this spec drives
+ *  the PUT inline. */
+async function patchSystem(
+  request: APIRequestContext,
+  patch: Record<string, unknown>,
+): Promise<void> {
+  const cur = await request.get(`${API_URL}/admin/app-config`);
+  if (!cur.ok()) {
+    throw new Error(
+      `admin app-config read failed: ${cur.status()} ${await cur.text()}`,
+    );
+  }
+  const body = (await cur.json()) as { system?: Record<string, unknown> };
+  const merged = { ...(body.system ?? {}), ...patch };
+  const resp = await request.put(`${API_URL}/admin/app-config/system`, {
+    data: merged,
+  });
+  if (!resp.ok()) {
+    throw new Error(
+      `system put failed: ${resp.status()} ${await resp.text()}`,
+    );
+  }
+}
+
+/**
+ * B1 verification — every host-extension registry slot reaches its
+ * consumer. Covers home widgets, routes, nav items, and admin tabs.
+ *
+ * Setup is contained to two tweaks:
+ *   1. PUT ``system.host_bundle_url`` to a synthetic same-origin path.
+ *   2. ``page.route`` fulfils that path with a tiny ES module that
+ *      calls ``window.__ATRIUM_REGISTRY__`` for one of each kind.
+ *
+ * The bundle relies on ``window.React`` — main.tsx pins React onto
+ * the global so externalised host bundles can call ``createElement``
+ * without re-bundling React. The test exercises that contract too.
+ *
+ * Restores ``system.host_bundle_url`` to null in afterAll so a stuck
+ * URL doesn't bleed into other specs.
+ */
+
+const adminEmail = process.env.E2E_ADMIN_EMAIL;
+const adminPassword = process.env.E2E_ADMIN_PASSWORD;
+const adminTotpSecret = process.env.E2E_ADMIN_TOTP_SECRET;
+
+const TEST_BUNDLE_PATH = '/__test_host_bundle.js';
+
+const TEST_BUNDLE_SOURCE = `
+const reg = window.__ATRIUM_REGISTRY__;
+const R = window.React;
+if (reg && R) {
+  reg.registerHomeWidget({
+    key: 'test-home-widget',
+    render: () =>
+      R.createElement('div', { 'data-testid': 'host-home-widget' },
+        'host-widget-marker'),
+  });
+  reg.registerRoute({
+    key: 'test-route',
+    path: '/__test_route',
+    element: R.createElement('div', { 'data-testid': 'host-route' },
+      'host-route-marker'),
+  });
+  reg.registerNavItem({
+    key: 'test-nav',
+    label: 'host-nav-marker',
+    to: '/__test_route',
+  });
+  reg.registerAdminTab({
+    key: 'test-admin-tab',
+    label: 'host-admin-marker',
+    element: R.createElement('div', { 'data-testid': 'host-admin-tab' },
+      'host-admin-tab-marker'),
+  });
+}
+`;
+
+test.describe('host-bundle slot system', () => {
+  test.skip(
+    !adminEmail || !adminPassword || !adminTotpSecret,
+    'E2E_ADMIN_* env vars not set; run via `make smoke`.',
+  );
+
+  test.afterAll(async ({ request }) => {
+    const loginResp = await request.post(`${API_URL}/auth/jwt/login`, {
+      form: { username: adminEmail!, password: adminPassword! },
+    });
+    if (!loginResp.ok() && loginResp.status() !== 204) return;
+    const { generate } = await import('otplib');
+    const code = await generate({ secret: adminTotpSecret! });
+    await request.post(`${API_URL}/auth/totp/verify`, { data: { code } });
+    await patchSystem(request, { host_bundle_url: null });
+  });
+
+  test('all four registry kinds reach their consumer', async ({ page }) => {
+    await loginAsAdmin(page);
+    await patchSystem(page.request, { host_bundle_url: TEST_BUNDLE_PATH });
+
+    await page.route(`**${TEST_BUNDLE_PATH}`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: TEST_BUNDLE_SOURCE,
+      });
+    });
+
+    await page.goto('/');
+
+    // 1. Home widget rendered on /.
+    await expect(page.getByTestId('host-home-widget')).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // 2. Nav item appears in the sidebar (visible on widescreen
+    // viewports; mobile drawer would need a Burger click first).
+    await expect(
+      page.getByRole('link', { name: 'host-nav-marker' }),
+    ).toBeVisible();
+
+    // 3. Visiting the registered route renders the registered element.
+    await page.goto('/__test_route');
+    await expect(page.getByTestId('host-route')).toBeVisible();
+
+    // 4. Admin tab appears on /admin and renders its panel content.
+    await page.goto('/admin');
+    const adminTab = page.getByRole('tab', { name: 'host-admin-marker' });
+    await expect(adminTab).toBeVisible();
+    await adminTab.click();
+    await expect(page.getByTestId('host-admin-tab')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Implements B1 of the extension-surface plan (sections 2, 3, 4) — the foundation for atrium consumed as a base Docker image. `ATRIUM_HOST_MODULE` imports a host module at startup so its `init_app(app)` / `init_worker(scheduler)` can register routers, namespaces, jobs, and permissions; `app.auth.rbac_seed.seed_permissions` (async + sync sibling for alembic) idempotently inserts permissions and grants them, auto-granting super_admin and skipping unknown role codes with a log warning. The frontend gets four host registries (home widgets, routes, nav items, admin tabs) at `src/host/registry.ts`, reachable via `window.__ATRIUM_REGISTRY__` for runtime-loaded host bundles and as typed exports for in-tree use; `main.tsx` fetches `/app-config`, dynamic-imports `system.host_bundle_url` before mounting React (bundle-load failure is non-fatal), and the four consumer components (App, AppLayout, AdminPage, HomePage) iterate the registries alongside their hardcoded entries. Registry signatures are stable from this PR onward — B3 builds on them.

## Test plan

- [ ] `make test-backend` passes (`test_host_bootstrap.py` + `test_rbac_seed.py`)
- [ ] `pnpm test` passes (vitest covering the four registries)
- [ ] `pnpm playwright test host-bundle.spec.ts` against the smoke stack — all four slot kinds render
- [ ] `make smoke` with no host module still green (no regression in app shell, login, admin tabs)