### PR TITLE
Add: GHCR publish workflow for atrium-backend + atrium-web on v* tags

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,119 @@
+name: Publish images
+
+# Strictly tag-driven publishing to GHCR. No `master` push trigger; no
+# `edge` or per-commit images. Tag from a green master — `ci.yml`
+# already covers PR validation, and gating publish on `needs:` would
+# mean re-running every PR check on the tagged commit (wasted work
+# when it already passed).
+#
+# `workflow_dispatch` lets a maintainer re-run an existing tag (eg.
+# registry outage recovery) without retagging.
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag to (re-)publish (e.g. v1.2.3)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/atrium-backend
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: backend
+          file: backend/Dockerfile
+          target: runtime
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # GHA cache so per-arch layers (especially the arm64
+          # emulated ones) are reused across runs.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/atrium-web
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: frontend
+          file: frontend/Dockerfile
+          target: runtime
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VITE_API_BASE_URL=/api
+            VITE_DEFAULT_LANGUAGE=en
+            VITE_CKEDITOR_LICENSE_KEY=GPL
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- New `.github/workflows/publish-images.yml` that builds and pushes `atrium-backend` and `atrium-web` to GHCR strictly on `v*` tag push (plus `workflow_dispatch` with a `ref` input for outage recovery).
- Two parallel jobs build `linux/amd64` + `linux/arm64` from each Dockerfile's `runtime` stage, with GHA layer cache so emulated arm64 layers are reused across runs.
- Tag set per push: `X.Y.Z`, `X.Y`, `X`, `latest` (no `edge`, no per-commit images). Web job passes `VITE_API_BASE_URL=/api`, `VITE_DEFAULT_LANGUAGE=en`, `VITE_CKEDITOR_LICENSE_KEY=GPL`.

Implements §5 of the base-image plan (branch B2). `ci.yml` is intentionally untouched — discipline is "tag from green master."

## Test plan
- [ ] After merge: tag a personal fork with `v0.0.1-test`, confirm both images land in GHCR for amd64 + arm64 with tag set `0.0.1-test`, `0.0`, `0`, `latest`.
- [ ] Pull the arm64 variant on Apple Silicon and confirm it boots.
- [ ] Delete the test tags.