### PR TITLE
Default /admin to System tab for app-config managers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -117,17 +117,6 @@ scratch; resist anything that's actually domain logic.
 
 ## UX polish (deferred from PR #6)
 
-- **Default `/admin` to the System tab for app-config managers.**
-  Tried in PR #6 but reverted: the System tab's `useAdminAppConfig`
-  fires its `GET /admin/app-config` fast enough that on the second
-  `goto('/admin')` after a logout, the 401 hard-redirects via
-  `window.location.replace('/login')` before Playwright's `page.goto`
-  resolves its `load` event — `ERR_ABORTED`. The master default of
-  `users` happens to lose this race. Real fix: change the api.ts 401
-  interceptor to skip the hard redirect during initial page load
-  (e.g. when `document.readyState !== 'complete'`) so RequireAuth can
-  bounce via SPA navigation. Would also harden any other admin
-  surface that fetches before `me` resolves.
 - **Strict password policy by default.** `password_require_mixed_case`
   / `_digit` / `_symbol` / `_check_breach` should ship `True` so a
   fresh instance has a safe baseline. Reverted in PR #6 because the

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -26,7 +26,15 @@ api.interceptors.response.use(
     const isPublic = url && PUBLIC_401_PATHS.some((p) => url.includes(p));
     if (status === 401 && !isPublic && typeof window !== 'undefined') {
       const path = window.location.pathname;
+      // While the document is still loading, an early 401 from a
+      // component that mounted before RequireAuth's /me probe resolved
+      // can race with the in-flight navigation: window.location.replace
+      // aborts the load (Playwright sees ERR_ABORTED). Skip the hard
+      // redirect — RequireAuth will SPA-Navigate to /login once the
+      // probe lands.
+      const isInitialLoad = document.readyState !== 'complete';
       if (
+        !isInitialLoad &&
         path !== '/login' &&
         !path.startsWith('/accept-invite') &&
         !path.startsWith('/register') &&

--- a/frontend/src/routes/AdminPage.tsx
+++ b/frontend/src/routes/AdminPage.tsx
@@ -67,7 +67,8 @@ export function AdminPage() {
     (requested !== 'emails' || canManageEmailTemplates);
   const isHostValid =
     requested !== null && visibleHostTabs.some((t) => t.key === requested);
-  const active: string = isBuiltinValid || isHostValid ? requested! : 'users';
+  const fallback: string = canManageAppConfig ? 'system' : 'users';
+  const active: string = isBuiltinValid || isHostValid ? requested! : fallback;
 
   const onTabChange = (v: string | null) => {
     if (!v) return;


### PR DESCRIPTION
## Summary
- Re-applies the AdminPage default-tab change reverted in PR #6: when the viewer holds `app_setting.manage`, `/admin` opens on **System**; everyone else still lands on **Users**.
- Pairs it with the underlying fix the PR #6 revert message called for: the api.ts 401 interceptor now skips the hard `window.location.replace('/login')` while `document.readyState !== 'complete'`. RequireAuth's `/me` probe still SPA-Navigates to `/login`, so the bounce is identical from the user's POV — but it no longer aborts an in-flight `page.goto` and trips Playwright's `ERR_ABORTED`.
- Removes the deferred-from-PR-#6 TODO entry now that it's done.

## Why the interceptor change is the right fix
The race in PR #6: after logout, `goto('/admin')` triggers SystemAdmin to fire `GET /admin/app-config` early in the page boot. That 401s, the interceptor calls `window.location.replace('/login')`, and the in-flight navigation aborts before its `load` event resolves. Master's `users` default sidesteps the race only because UsersAdmin happens not to fetch as eagerly on boot. The `users` default is a workaround, not a fix.

Suppressing the hard redirect during the initial document load is correct: while `readyState !== 'complete'` the document hasn't finished loading, so any `location.replace` necessarily aborts it. RequireAuth already covers this case via `<Navigate to="/login" />`. After `load` the original behaviour is unchanged (genuine session-expiry mid-app still hard-redirects).

## Test plan
- [ ] `make smoke` — branding / admin / logout specs all green (the previously regressing ones in PR #6)
- [ ] Manual: log in as super_admin, `/admin` opens on System; `?tab=users` still wins
- [ ] Manual: log in as a non-app-config admin (only `user.manage` + `audit.read`), `/admin` still opens on Users
- [ ] Manual: log out from `/admin`, then visit `/admin` directly — lands on `/login` via SPA navigation, no ERR_ABORTED in devtools network panel