### PR TITLE
Add BSD 2-Clause licence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 version: 2
 # Each ecosystem declares two groups:
 #   - *-version-updates   (applies-to: version-updates)  — the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 name: CI
 
 on:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 name: CodeQL
 
 # CodeQL analysis on every PR, a weekly scheduled scan, and on

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 name: Publish images
 
 # Strictly tag-driven publishing to GHCR. No `master` push trigger; no

--- a/.github/workflows/uv-lock-refresh.yml
+++ b/.github/workflows/uv-lock-refresh.yml
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 name: uv-lock-refresh
 
 # Dependabot reads ``backend/pyproject.toml`` and opens PRs bumping

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 # Python
 __pycache__/
 *.py[cod]

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,1 +1,4 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 # Trivy suppressions. Format: one finding ID per line. Comments allowed.

--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,0 +1,25 @@
+# BSD 2-Clause License
+
+Copyright (c) 2026, Brendan Bank
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 .PHONY: help up down logs ps build rebuild migrate migration \
         seed-admin seed-super-admin dev-bootstrap \
         shell-api shell-db test test-backend test-frontend lint format \

--- a/README.md
+++ b/README.md
@@ -413,7 +413,6 @@ The frontend pattern is the same: add hooks under `src/hooks/`,
 routes under `src/routes/`, mount them in `src/App.tsx`, gate with
 `usePerm("…")` or `<RequireAuth role="…">`.
 
-## License
+## Licence
 
-Pick your own. Atrium ships without one — fork it, vendor it, do
-whatever.
+BSD 2-Clause. See [`LICENCE.md`](LICENCE.md).

--- a/TODO.md
+++ b/TODO.md
@@ -141,4 +141,3 @@ scratch; resist anything that's actually domain logic.
   `system.maintenance_mode`", "what `audit.retention_days` means
   legally", etc. Today this is vibes + the comments in
   `app_config.py`.
-- add BSD-2 licence to all files.

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 __pycache__
 *.py[cod]
 .venv

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 # Multi-stage backend Dockerfile. Shared by api + worker containers.
 # - builder: installs deps into a virtualenv
 # - dev:     adds dev deps, bind-mounts source at runtime

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 [alembic]
 script_location = alembic
 prepend_sys_path = .

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Alembic environment. Supports async SQLAlchemy via asyncio.run_sync."""
 from __future__ import annotations
 

--- a/backend/alembic/script.py.mako
+++ b/backend/alembic/script.py.mako
@@ -1,3 +1,6 @@
+## Copyright (c) 2026 Brendan Bank
+## SPDX-License-Identifier: BSD-2-Clause
+
 """${message}
 
 Revision ID: ${up_revision}

--- a/backend/alembic/versions/2026_04_26_0001-0001_atrium_init.py
+++ b/backend/alembic/versions/2026_04_26_0001-0001_atrium_init.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Atrium initial schema.
 
 Revision ID: 0001_atrium_init

--- a/backend/alembic/versions/2026_04_26_0002-0002_email_outbox.py
+++ b/backend/alembic/versions/2026_04_26_0002-0002_email_outbox.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Email outbox queue.
 
 Revision ID: 0002_email_outbox

--- a/backend/alembic/versions/2026_04_26_0003-0003_user_soft_delete.py
+++ b/backend/alembic/versions/2026_04_26_0003-0003_user_soft_delete.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """User soft-delete columns + GDPR deletion email templates.
 
 Revision ID: 0003_user_soft_delete

--- a/backend/alembic/versions/2026_04_26_0004-0004_email_verifications.py
+++ b/backend/alembic/versions/2026_04_26_0004-0004_email_verifications.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Self-serve signup + email verification.
 
 Revision ID: 0004_email_verifications

--- a/backend/alembic/versions/2026_04_26_0005-0005_email_template_per_locale.py
+++ b/backend/alembic/versions/2026_04_26_0005-0005_email_template_per_locale.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Per-locale email templates + outbox locale column.
 
 Revision ID: 0005_email_template_per_locale

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause

--- a/backend/app/api/account_deletion.py
+++ b/backend/app/api/account_deletion.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Self-service + admin-driven account deletion.
 
 Two endpoints:

--- a/backend/app/api/admin_roles.py
+++ b/backend/app/api/admin_roles.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Role + permission administration (gated by ``role.manage``).
 
 Permissions are a fixed, code-defined catalogue seeded via migrations —

--- a/backend/app/api/admin_users.py
+++ b/backend/app/api/admin_users.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Owner-only user administration.
 
 fastapi-users ships a /users/{id} router but its authz is gated on

--- a/backend/app/api/app_config.py
+++ b/backend/app/api/app_config.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """App-config endpoints.
 
 Two surfaces:

--- a/backend/app/api/audit.py
+++ b/backend/app/api/audit.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Owner-only audit log view."""
 from __future__ import annotations
 

--- a/backend/app/api/email_otp.py
+++ b/backend/app/api/email_otp.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Email-OTP second-factor — parallel to authenticator-app TOTP.
 
 Flow mirrors ``/auth/totp/*``:

--- a/backend/app/api/email_templates.py
+++ b/backend/app/api/email_templates.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Admin API for email templates. Owner-only; agents have no reason
 to see template content.
 

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Service health probes.
 
 - ``/healthz``   — liveness. api process answers → 200.

--- a/backend/app/api/impersonate.py
+++ b/backend/app/api/impersonate.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """User impersonation — "log in as another user" for testing.
 
 Gated on the ``user.impersonate`` permission (carried by the

--- a/backend/app/api/invites.py
+++ b/backend/app/api/invites.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Invite flow: owners create invites; recipients accept with a token
 to set a password and activate their account.
 

--- a/backend/app/api/me_context.py
+++ b/backend/app/api/me_context.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Extended /users/me payload.
 
 fastapi-users' built-in /users/me returns a UserRead. This sibling

--- a/backend/app/api/notifications.py
+++ b/backend/app/api/notifications.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Notifications API for the bell icon in the header.
 
 Each user only sees their own notifications. Atrium ships the

--- a/backend/app/api/reminder_rules.py
+++ b/backend/app/api/reminder_rules.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Admin CRUD for reminder rules. Owner-only."""
 from __future__ import annotations
 

--- a/backend/app/api/sessions.py
+++ b/backend/app/api/sessions.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Session-management endpoints that live above fastapi-users.
 
 ``/auth/logout-all`` revokes every active session for the current

--- a/backend/app/api/signup.py
+++ b/backend/app/api/signup.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Self-serve signup + verify-email endpoints.
 
 The register route is rate-limited via ``AuthRateLimitMiddleware``

--- a/backend/app/api/totp.py
+++ b/backend/app/api/totp.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """TOTP enrollment + verification endpoints.
 
 Flow:

--- a/backend/app/api/webauthn.py
+++ b/backend/app/api/webauthn.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """WebAuthn / FIDO2 second-factor — alongside TOTP and email OTP.
 
 A user can register multiple authenticators at once (primary YubiKey

--- a/backend/app/auth/__init__.py
+++ b/backend/app/auth/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause

--- a/backend/app/auth/backend.py
+++ b/backend/app/auth/backend.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """JWT auth backend with httpOnly cookie transport, backed by a
 server-side ``auth_sessions`` row.
 

--- a/backend/app/auth/db.py
+++ b/backend/app/auth/db.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 from collections.abc import AsyncGenerator
 
 from fastapi import Depends

--- a/backend/app/auth/manager.py
+++ b/backend/app/auth/manager.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 from typing import Any
 
 from fastapi import Depends, Request

--- a/backend/app/auth/rbac.py
+++ b/backend/app/auth/rbac.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Permission resolver + FastAPI dependencies for RBAC checks.
 
 The effective permission set for a user is the union over every role

--- a/backend/app/auth/rbac_seed.py
+++ b/backend/app/auth/rbac_seed.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Idempotent permission + role-grant seeding for atrium and host apps.
 
 Atrium seeds its own permissions in migration 0001. Host apps need the

--- a/backend/app/auth/schemas.py
+++ b/backend/app/auth/schemas.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Pydantic schemas for users.
 
 Same shape as fastapi-users' ``schemas.BaseUser*`` minus ``is_superuser``

--- a/backend/app/auth/scope.py
+++ b/backend/app/auth/scope.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Scope abstraction.
 
 Atrium ships a no-op admin scope. Host apps that need row-level

--- a/backend/app/auth/two_factor.py
+++ b/backend/app/auth/two_factor.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Shared 2FA-gate helpers.
 
 ``write_token`` (in ``backend.py``) and ``current_user`` (in ``users.py``)

--- a/backend/app/auth/users.py
+++ b/backend/app/auth/users.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """FastAPIUsers singleton + dependency helpers.
 
 Two tiers of "authenticated":

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 from collections.abc import AsyncGenerator
 
 from sqlalchemy.ext.asyncio import (

--- a/backend/app/email/__init__.py
+++ b/backend/app/email/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 from app.email.backend import (
     ConsoleMailBackend,
     EmailMessage,

--- a/backend/app/email/backend.py
+++ b/backend/app/email/backend.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Pluggable mail backend.
 
 The active backend is chosen by the ``MAIL_BACKEND`` env var:

--- a/backend/app/email/sender.py
+++ b/backend/app/email/sender.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Render a DB-stored email template, send it via the configured
 backend, and write an email_log row.
 

--- a/backend/app/email/templates/__init__.py
+++ b/backend/app/email/templates/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause

--- a/backend/app/jobs/__init__.py
+++ b/backend/app/jobs/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause

--- a/backend/app/jobs/builtin_handlers.py
+++ b/backend/app/jobs/builtin_handlers.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Built-in scheduled-job handlers shipped with Atrium.
 
 Most platform-level work belongs in host apps (atrium ships the queue

--- a/backend/app/jobs/runner.py
+++ b/backend/app/jobs/runner.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Job runner — claims and dispatches a single ScheduledJob.
 
 Atrium ships no built-in job handlers. Host apps register them via

--- a/backend/app/jobs/schedule.py
+++ b/backend/app/jobs/schedule.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Queue helpers for the scheduled_jobs table.
 
 Atrium ships only the claim primitive (`next_due_job`). Host apps

--- a/backend/app/jobs/types.py
+++ b/backend/app/jobs/types.py
@@ -1,1 +1,4 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Job-type constants. Atrium ships none — host apps define their own."""

--- a/backend/app/logging.py
+++ b/backend/app/logging.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 import logging
 import sys
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 import importlib
 import os
 from contextlib import asynccontextmanager

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """SQLAlchemy models — import everything so Base.metadata is populated
 before Alembic autogenerate and before any query runs."""
 

--- a/backend/app/models/auth.py
+++ b/backend/app/models/auth.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 from datetime import datetime
 
 from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, String

--- a/backend/app/models/auth_session.py
+++ b/backend/app/models/auth_session.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Server-side session rows for DB-backed JWT auth.
 
 fastapi-users' default ``JWTStrategy`` is stateless — a stolen cookie

--- a/backend/app/models/email_otp.py
+++ b/backend/app/models/email_otp.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Email-OTP second-factor tables.
 
 ``UserEmailOTP`` mirrors ``UserTOTP``: one row per user who has opted

--- a/backend/app/models/email_outbox.py
+++ b/backend/app/models/email_outbox.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Outbox queue for outbound email.
 
 When ``MAIL_BACKEND=smtp`` and the relay is unavailable, ``send_and_log``

--- a/backend/app/models/email_template.py
+++ b/backend/app/models/email_template.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 from datetime import datetime
 
 from sqlalchemy import DateTime, String, Text, func

--- a/backend/app/models/email_verification.py
+++ b/backend/app/models/email_verification.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Email-verification token table for the self-serve signup flow.
 
 One row per outstanding verification challenge. The raw token is never

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 from enum import StrEnum
 
 

--- a/backend/app/models/mixins.py
+++ b/backend/app/models/mixins.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 from datetime import datetime
 
 from sqlalchemy import DateTime, func

--- a/backend/app/models/ops.py
+++ b/backend/app/models/ops.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Operational tables: notifications, scheduled jobs, email log, audit log,
 app settings. These are infrastructure, not core domain."""
 from datetime import datetime

--- a/backend/app/models/rbac.py
+++ b/backend/app/models/rbac.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """RBAC tables: roles, permissions, and their junctions.
 
 Shape:

--- a/backend/app/models/reminder_rule.py
+++ b/backend/app/models/reminder_rule.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 from sqlalchemy import Boolean, ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 

--- a/backend/app/models/user_totp.py
+++ b/backend/app/models/user_totp.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """TOTP enrollment row per user.
 
 Paired with ``app.services.totp`` for secret generation, provisioning

--- a/backend/app/models/webauthn.py
+++ b/backend/app/models/webauthn.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """WebAuthn / FIDO2 tables.
 
 ``WebAuthnCredential`` — one row per registered authenticator. A user

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause

--- a/backend/app/schemas/audit.py
+++ b/backend/app/schemas/audit.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 from datetime import datetime
 from typing import Any
 

--- a/backend/app/schemas/email_template.py
+++ b/backend/app/schemas/email_template.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 from datetime import datetime
 
 from pydantic import BaseModel, Field

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 from datetime import datetime
 from typing import Any
 

--- a/backend/app/schemas/reminder_rule.py
+++ b/backend/app/schemas/reminder_rule.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 from datetime import datetime
 from typing import Literal
 

--- a/backend/app/scripts/__init__.py
+++ b/backend/app/scripts/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause

--- a/backend/app/scripts/seed_admin.py
+++ b/backend/app/scripts/seed_admin.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Create or reset the bootstrap admin account.
 
 No public registration — this script is the only way to get the first

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause

--- a/backend/app/services/account_deletion.py
+++ b/backend/app/services/account_deletion.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """GDPR-aligned soft-delete for user accounts.
 
 The flow is three-stage:

--- a/backend/app/services/app_config.py
+++ b/backend/app/services/app_config.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Typed namespace-scoped reader/writer over the ``app_settings`` KV table.
 
 Each namespace owns one row whose ``value`` JSON column matches a Pydantic

--- a/backend/app/services/audit.py
+++ b/backend/app/services/audit.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Thin helper for writing audit_log rows.
 
 Callers don't commit — the audit entry travels in the same transaction

--- a/backend/app/services/audit_retention.py
+++ b/backend/app/services/audit_retention.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Audit-log retention pruning.
 
 Atrium keeps an unbounded ``audit_log`` by default. Operators that need

--- a/backend/app/services/captcha.py
+++ b/backend/app/services/captcha.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Pluggable CAPTCHA verification.
 
 Two providers — Cloudflare Turnstile and hCaptcha — share the same

--- a/backend/app/services/event_hub.py
+++ b/backend/app/services/event_hub.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """In-process pub/sub for server-sent notification events.
 
 One asyncio.Queue per connection, keyed by user id. Multiple open

--- a/backend/app/services/html_sanitise.py
+++ b/backend/app/services/html_sanitise.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Owner-authored HTML (email templates) → safe HTML.
 
 CKEditor writes reasonably clean output, but we shouldn't trust it —

--- a/backend/app/services/maintenance.py
+++ b/backend/app/services/maintenance.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Maintenance-mode gate.
 
 Reads the ``system`` namespace from ``app_settings``. When

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """In-app notification helper.
 
 Writes a `notifications` row and pokes the user's SSE channel via

--- a/backend/app/services/password_policy.py
+++ b/backend/app/services/password_policy.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Password-policy validation backed by ``AuthConfig``.
 
 A single entry point — :func:`validate_password_against_policy` — reads

--- a/backend/app/services/rate_limit.py
+++ b/backend/app/services/rate_limit.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Tiny in-memory sliding-window rate limiter.
 
 Sized for a single-worker deployment. The bucket is a per-key deque of

--- a/backend/app/services/signup.py
+++ b/backend/app/services/signup.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Self-serve signup + email verification.
 
 Two operations: ``register_user`` creates a fresh account (when the

--- a/backend/app/services/totp.py
+++ b/backend/app/services/totp.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """TOTP helpers — enrollment + verification.
 
 Thin wrapper over ``pyotp`` that hides the step/digits/algorithm choices

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 from functools import lru_cache
 from typing import Literal
 

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """APScheduler worker.
 
 One process, one container. Every ``POLL_INTERVAL_SECONDS`` it drains

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 [project]
 name = "atrium-backend"
 version = "0.1.0"

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause

--- a/backend/tests/api/__init__.py
+++ b/backend/tests/api/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause

--- a/backend/tests/api/test_account_deletion.py
+++ b/backend/tests/api/test_account_deletion.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Coverage for the GDPR-aligned account-deletion flow.
 
 What's pinned:

--- a/backend/tests/api/test_app_config.py
+++ b/backend/tests/api/test_app_config.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Tests for the app-config endpoints.
 
 Three surfaces to pin:

--- a/backend/tests/api/test_captcha.py
+++ b/backend/tests/api/test_captcha.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Coverage for the pluggable CAPTCHA gate (Phase 4).
 
 Pinned behaviours:

--- a/backend/tests/api/test_email_otp.py
+++ b/backend/tests/api/test_email_otp.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Email-OTP second-factor: setup / confirm / request / verify /
 disable flows, plus the updated ``/auth/totp/state`` and admin reset.
 

--- a/backend/tests/api/test_email_templates_per_locale.py
+++ b/backend/tests/api/test_email_templates_per_locale.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Per-locale email template coverage.
 
 What's pinned:

--- a/backend/tests/api/test_i18n_config.py
+++ b/backend/tests/api/test_i18n_config.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Tests for the ``i18n`` app-config namespace.
 
 Phase 9 ships locale enablement plus per-locale string overrides

--- a/backend/tests/api/test_impersonation.py
+++ b/backend/tests/api/test_impersonation.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Impersonation API — guardrails + round-trip.
 
 Verifies that /admin/users/{id}/impersonate + /admin/impersonate/stop

--- a/backend/tests/api/test_invite_flow.py
+++ b/backend/tests/api/test_invite_flow.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """End-to-end coverage for the invite flow.
 
 Verifies create/list/revoke/accept, multi-role assignment on accept,

--- a/backend/tests/api/test_maintenance.py
+++ b/backend/tests/api/test_maintenance.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Tests for the maintenance-mode middleware.
 
 Three things to pin:

--- a/backend/tests/api/test_notifications.py
+++ b/backend/tests/api/test_notifications.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """End-to-end coverage for the notification surface.
 
 Atrium ships:

--- a/backend/tests/api/test_password_policy.py
+++ b/backend/tests/api/test_password_policy.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Password-policy + 2FA-enforcement coverage (Phase 3).
 
 Driven through ``POST /auth/register`` because that's the realistic

--- a/backend/tests/api/test_rbac_admin.py
+++ b/backend/tests/api/test_rbac_admin.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Role admin CRUD + privilege-escalation guard on user role assignment.
 
 Two surfaces to pin down:

--- a/backend/tests/api/test_signup.py
+++ b/backend/tests/api/test_signup.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Coverage for the self-serve signup + email verification flow.
 
 Pinned behaviours:

--- a/backend/tests/api/test_totp.py
+++ b/backend/tests/api/test_totp.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """TOTP enrollment + challenge + admin reset.
 
 Covers the two-phase login contract:

--- a/backend/tests/api/test_webauthn.py
+++ b/backend/tests/api/test_webauthn.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """WebAuthn second-factor: register / authenticate / list / delete flows.
 
 The browser ceremony (``navigator.credentials.create`` / ``get``) can't

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Test fixtures — real MySQL via testcontainers.
 
 A single MySQL container is started for the whole session; tests get

--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Shared test helpers — user / role factories.
 
 Tests create users directly via SQLAlchemy (rather than via the invite

--- a/backend/tests/integration/__init__.py
+++ b/backend/tests/integration/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause

--- a/backend/tests/integration/test_audit_retention.py
+++ b/backend/tests/integration/test_audit_retention.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Audit-log retention pruning.
 
 Covers the service helper plus the ``audit_prune`` handler:

--- a/backend/tests/integration/test_email_outbox.py
+++ b/backend/tests/integration/test_email_outbox.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Email outbox queue — enqueue + handler retry behaviour.
 
 The outbox is the durable side of the email send path. ``enqueue_and_log``

--- a/backend/tests/test_healthz.py
+++ b/backend/tests/test_healthz.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 async def test_healthz_ok(client):
     r = await client.get("/healthz")
     assert r.status_code == 200

--- a/backend/tests/unit/__init__.py
+++ b/backend/tests/unit/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause

--- a/backend/tests/unit/test_host_bootstrap.py
+++ b/backend/tests/unit/test_host_bootstrap.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """ATRIUM_HOST_MODULE bootstrap hook (main.py + worker.py).
 
 The hook lets a host project register routers, app-config namespaces,

--- a/backend/tests/unit/test_mail_backend.py
+++ b/backend/tests/unit/test_mail_backend.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 from __future__ import annotations
 
 import pytest

--- a/backend/tests/unit/test_rbac_seed.py
+++ b/backend/tests/unit/test_rbac_seed.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Idempotent permission + role-grant seeding (rbac_seed module).
 
 Three contracts:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 # Dev overrides. Usage:
 #   docker compose -f docker-compose.yml -f docker-compose.dev.yml up
 #

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 # CI e2e override. Pairs with docker-compose.yml + docker-compose.dev.yml.
 #
 # The dev override runs the frontend as a vite dev server with a

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 # Production compose. See docker-compose.dev.yml for dev overrides.
 #
 # Services:

--- a/examples/hello-world/backend/.gitignore
+++ b/examples/hello-world/backend/.gitignore
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 __pycache__/
 *.pyc
 .venv/

--- a/examples/hello-world/backend/Dockerfile
+++ b/examples/hello-world/backend/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 # Host backend image — extends atrium-backend with the example package
 # pip-installed into atrium's virtualenv. The base image's CMD (uvicorn)
 # is unchanged; the host's behaviour is wired in by setting

--- a/examples/hello-world/backend/alembic.ini
+++ b/examples/hello-world/backend/alembic.ini
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 # Host-side alembic config for the Hello World example.
 #
 # Atrium owns its own chain in backend/alembic (version table:

--- a/examples/hello-world/backend/alembic/env.py
+++ b/examples/hello-world/backend/alembic/env.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Host-side alembic environment.
 
 Two things differ from atrium's ``backend/alembic/env.py``:

--- a/examples/hello-world/backend/alembic/versions/0001_hello_state.py
+++ b/examples/hello-world/backend/alembic/versions/0001_hello_state.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """hello_state table + permission seed
 
 Revision ID: 0001_hello_state

--- a/examples/hello-world/backend/pyproject.toml
+++ b/examples/hello-world/backend/pyproject.toml
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/examples/hello-world/backend/src/atrium_hello_world/__init__.py
+++ b/examples/hello-world/backend/src/atrium_hello_world/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause

--- a/examples/hello-world/backend/src/atrium_hello_world/bootstrap.py
+++ b/examples/hello-world/backend/src/atrium_hello_world/bootstrap.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Atrium host bootstrap entry points.
 
 The atrium image imports this module on startup when the operator sets

--- a/examples/hello-world/backend/src/atrium_hello_world/models.py
+++ b/examples/hello-world/backend/src/atrium_hello_world/models.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """Singleton state row for the Hello World demo.
 
 The host owns its own ``DeclarativeBase`` (and therefore its own

--- a/examples/hello-world/backend/src/atrium_hello_world/router.py
+++ b/examples/hello-world/backend/src/atrium_hello_world/router.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """HTTP surface for the Hello World demo.
 
 - ``GET /hello/state`` — read-only state. Auth required so the widget

--- a/examples/hello-world/backend/src/atrium_hello_world/schedule.py
+++ b/examples/hello-world/backend/src/atrium_hello_world/schedule.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """APScheduler tick that increments the counter when the demo is
 enabled.
 

--- a/examples/hello-world/backend/src/atrium_hello_world/scripts/__init__.py
+++ b/examples/hello-world/backend/src/atrium_hello_world/scripts/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause

--- a/examples/hello-world/backend/src/atrium_hello_world/scripts/seed_host_bundle.py
+++ b/examples/hello-world/backend/src/atrium_hello_world/scripts/seed_host_bundle.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 """One-shot CLI: write ``system.host_bundle_url`` so atrium picks up
 the host frontend bundle on the next page load.
 

--- a/examples/hello-world/compose.dev.yaml
+++ b/examples/hello-world/compose.dev.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 # Smoke-test overlay for the Hello World example against the dev stack.
 # Layered on top of compose.yaml; only override is HELLO_TICK_SECONDS=2
 # so the Playwright spec doesn't have to wait 30 seconds per assertion.

--- a/examples/hello-world/compose.e2e.yaml
+++ b/examples/hello-world/compose.e2e.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 # E2E overlay — runs the example against the prod images that
 # `make smoke` uses. Built from the repo root via the example's
 # Dockerfile (FROM atrium-backend + pip install ./backend) so the

--- a/examples/hello-world/compose.yaml
+++ b/examples/hello-world/compose.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 # Standalone Hello World demo overlay.
 #
 # Usage:

--- a/examples/hello-world/frontend/.gitignore
+++ b/examples/hello-world/frontend/.gitignore
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 node_modules/
 dist/
 playwright-report/

--- a/examples/hello-world/frontend/playwright.config.ts
+++ b/examples/hello-world/frontend/playwright.config.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 /**
  * Playwright config for the Hello World smoke spec.
  *

--- a/examples/hello-world/frontend/src/HelloAdminTab.tsx
+++ b/examples/hello-world/frontend/src/HelloAdminTab.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 /** Admin-tab rendering of the Hello World state.
  *
  * Registered with ``perm: 'hello.toggle'`` so atrium hides the tab

--- a/examples/hello-world/frontend/src/HelloPage.tsx
+++ b/examples/hello-world/frontend/src/HelloPage.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 /** Dedicated /hello route — same widget, plus a tiny detail line so
  *  the page is visibly different from the home card. Demonstrates the
  *  registerRoute slot. */

--- a/examples/hello-world/frontend/src/HelloWidget.tsx
+++ b/examples/hello-world/frontend/src/HelloWidget.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 /**
  * Home-widget rendering of the Hello World state.
  *

--- a/examples/hello-world/frontend/src/api.ts
+++ b/examples/hello-world/frontend/src/api.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 /** Thin fetch wrapper for the host's /hello/* endpoints + the
  *  atrium /users/me/context probe used to gate the toggle.
  *

--- a/examples/hello-world/frontend/src/main.tsx
+++ b/examples/hello-world/frontend/src/main.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 /** Hello World host bundle entry.
  *
  * Bundles its own React + ReactDOM + Mantine + TanStack Query. The

--- a/examples/hello-world/frontend/src/queryClient.ts
+++ b/examples/hello-world/frontend/src/queryClient.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { QueryClient } from '@tanstack/react-query';
 
 /** Single QueryClient shared across the home widget, the dedicated

--- a/examples/hello-world/frontend/tests-e2e/hello-world.spec.ts
+++ b/examples/hello-world/frontend/tests-e2e/hello-world.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 /**
  * Hello World end-to-end smoke. Exercises every B1 slot kind plus the
  * scheduler pipeline so the example doubles as the live contract for

--- a/examples/hello-world/frontend/tests-e2e/helpers.ts
+++ b/examples/hello-world/frontend/tests-e2e/helpers.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 /** Slim copy of the helpers atrium's frontend smoke uses, scoped to
  *  what the Hello World spec needs. Vendored rather than imported
  *  across project boundaries so Playwright's module resolver has all

--- a/examples/hello-world/frontend/vite.config.ts
+++ b/examples/hello-world/frontend/vite.config.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
 

--- a/examples/hello-world/host-bundle/nginx.conf
+++ b/examples/hello-world/host-bundle/nginx.conf
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 # nginx config for the host-bundle sidecar.
 #
 # Serves the prebuilt host bundle on its own origin so the SPA's

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 node_modules
 dist
 .vite

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 # Multi-stage frontend Dockerfile.
 # - dev:     pnpm dev server with HMR (used by docker-compose.dev.yml)
 # - builder: pnpm build → dist/

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import js from '@eslint/js';
 import globals from 'globals';
 import reactHooks from 'eslint-plugin-react-hooks';

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,3 +1,6 @@
+<!-- Copyright (c) 2026 Brendan Bank
+     SPDX-License-Identifier: BSD-2-Clause -->
+
 <!doctype html>
 <html lang="en">
   <head>

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 server {
     # Non-root nginx (nginxinc/nginx-unprivileged) can't bind <1024;
     # listen on 8080 and the proxy upstream points here.

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { defineConfig } from '@playwright/test';
 
 /**

--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 module.exports = {
   plugins: {
     'postcss-preset-mantine': {},

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { Routes, Route, Navigate } from 'react-router-dom';
 
 import { AppLayout } from './components/AppLayout';

--- a/frontend/src/components/AnnouncementBanner.tsx
+++ b/frontend/src/components/AnnouncementBanner.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { Alert } from '@mantine/core';
 import { IconInfoCircle, IconAlertTriangle, IconAlertOctagon } from '@tabler/icons-react';
 

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import {
   AppShell,
   Avatar,

--- a/frontend/src/components/CKEditorField.tsx
+++ b/frontend/src/components/CKEditorField.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useEffect, useRef } from 'react';
 
 /**

--- a/frontend/src/components/CaptchaWidget.tsx
+++ b/frontend/src/components/CaptchaWidget.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useEffect, useRef, useState } from 'react';
 
 import { useAppConfig } from '@/hooks/useAppConfig';

--- a/frontend/src/components/HostHomeWidgets.tsx
+++ b/frontend/src/components/HostHomeWidgets.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { Fragment } from 'react';
 import { Stack } from '@mantine/core';
 

--- a/frontend/src/components/ImpersonationBanner.tsx
+++ b/frontend/src/components/ImpersonationBanner.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { Button, Group, Text } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { useQueryClient } from '@tanstack/react-query';

--- a/frontend/src/components/InfoLabel.tsx
+++ b/frontend/src/components/InfoLabel.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { Group, Text, Tooltip } from '@mantine/core';
 import { IconInfoCircle } from '@tabler/icons-react';
 import type { ReactNode } from 'react';

--- a/frontend/src/components/MaintenancePage.tsx
+++ b/frontend/src/components/MaintenancePage.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { Center, Container, Stack, Text, Title } from '@mantine/core';
 import { IconTool } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';

--- a/frontend/src/components/NotificationsBell.tsx
+++ b/frontend/src/components/NotificationsBell.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useState } from 'react';
 import {
   ActionIcon,

--- a/frontend/src/components/RequireAuth.tsx
+++ b/frontend/src/components/RequireAuth.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { ReactNode } from 'react';
 import { Center, Loader } from '@mantine/core';
 import { Navigate, useLocation } from 'react-router-dom';

--- a/frontend/src/components/TwoFactorSetupModal.tsx
+++ b/frontend/src/components/TwoFactorSetupModal.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useEffect, useRef, useState } from 'react';
 import {
   Alert,

--- a/frontend/src/components/admin/AuditAdmin.tsx
+++ b/frontend/src/components/admin/AuditAdmin.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { Fragment, useState } from 'react';
 import {
   Badge,

--- a/frontend/src/components/admin/AuthAdmin.tsx
+++ b/frontend/src/components/admin/AuthAdmin.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useEffect, useMemo, useState } from 'react';
 import {
   Button,

--- a/frontend/src/components/admin/BrandingAdmin.tsx
+++ b/frontend/src/components/admin/BrandingAdmin.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useEffect, useMemo, useState } from 'react';
 import {
   Button,

--- a/frontend/src/components/admin/EmailTemplatesAdmin.tsx
+++ b/frontend/src/components/admin/EmailTemplatesAdmin.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useMemo, useState } from 'react';
 import {
   ActionIcon,

--- a/frontend/src/components/admin/RemindersAdmin.tsx
+++ b/frontend/src/components/admin/RemindersAdmin.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useEffect, useState } from 'react';
 import {
   ActionIcon,

--- a/frontend/src/components/admin/RolesAdmin.tsx
+++ b/frontend/src/components/admin/RolesAdmin.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useEffect, useMemo, useState } from 'react';
 import {
   ActionIcon,

--- a/frontend/src/components/admin/SystemAdmin.tsx
+++ b/frontend/src/components/admin/SystemAdmin.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useEffect, useState } from 'react';
 import {
   Alert,

--- a/frontend/src/components/admin/TranslationsAdmin.tsx
+++ b/frontend/src/components/admin/TranslationsAdmin.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useEffect, useMemo, useState } from 'react';
 import {
   Button,

--- a/frontend/src/components/admin/UsersAdmin.tsx
+++ b/frontend/src/components/admin/UsersAdmin.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useState } from 'react';
 import {
   ActionIcon,

--- a/frontend/src/hooks/useAccountDeletion.ts
+++ b/frontend/src/hooks/useAccountDeletion.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { api } from '@/lib/api';

--- a/frontend/src/hooks/useAppConfig.ts
+++ b/frontend/src/hooks/useAppConfig.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { api } from '@/lib/api';

--- a/frontend/src/hooks/useAudit.ts
+++ b/frontend/src/hooks/useAudit.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useQuery } from '@tanstack/react-query';
 
 import { api } from '@/lib/api';

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { fetchMe, logout as apiLogout, type CurrentUser } from '@/lib/auth';

--- a/frontend/src/hooks/useEmailTemplates.ts
+++ b/frontend/src/hooks/useEmailTemplates.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { api } from '@/lib/api';

--- a/frontend/src/hooks/useNotificationStream.ts
+++ b/frontend/src/hooks/useNotificationStream.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { api } from '@/lib/api';

--- a/frontend/src/hooks/useReminderRules.ts
+++ b/frontend/src/hooks/useReminderRules.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { api } from '@/lib/api';

--- a/frontend/src/hooks/useRolesAdmin.ts
+++ b/frontend/src/hooks/useRolesAdmin.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { api } from '@/lib/api';

--- a/frontend/src/hooks/useSessions.ts
+++ b/frontend/src/hooks/useSessions.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { api } from '@/lib/api';

--- a/frontend/src/hooks/useTOTP.ts
+++ b/frontend/src/hooks/useTOTP.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { api } from '@/lib/api';

--- a/frontend/src/hooks/useUsersAdmin.ts
+++ b/frontend/src/hooks/useUsersAdmin.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { api } from '@/lib/api';

--- a/frontend/src/hooks/useWebAuthn.ts
+++ b/frontend/src/hooks/useWebAuthn.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { api } from '@/lib/api';

--- a/frontend/src/host/registry.ts
+++ b/frontend/src/host/registry.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 /**
  * Atrium host-extension registry.
  *

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import i18n from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import axios from 'axios';
 
 const baseURL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000';

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { api } from './api';
 
 export type Language = 'en' | 'nl';

--- a/frontend/src/lib/money.test.ts
+++ b/frontend/src/lib/money.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { describe, expect, it } from 'vitest';
 
 import { formatMoney } from './money';

--- a/frontend/src/lib/money.ts
+++ b/frontend/src/lib/money.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 /**
  * Money formatting helpers.
  *

--- a/frontend/src/lib/notifications.ts
+++ b/frontend/src/lib/notifications.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import type { AppNotification } from '@/hooks/useNotifications';
 
 /** Atrium ships a kind-agnostic notification renderer. The backend

--- a/frontend/src/lib/queryClient.ts
+++ b/frontend/src/lib/queryClient.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { QueryClient } from '@tanstack/react-query';
 
 export const queryClient = new QueryClient({

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 // Shared frontend types. Most domain types live alongside the hooks
 // that fetch them (see hooks/useNotifications, useUsersAdmin, etc.);
 // this module re-exports the cross-cutting ones for convenience.

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { Notifications } from '@mantine/notifications';

--- a/frontend/src/routes/AcceptInvitePage.tsx
+++ b/frontend/src/routes/AcceptInvitePage.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useState } from 'react';
 import {
   Alert,

--- a/frontend/src/routes/AdminPage.tsx
+++ b/frontend/src/routes/AdminPage.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { Stack, Tabs, Title } from '@mantine/core';
 import {
   IconBrush,

--- a/frontend/src/routes/ForgotPasswordPage.tsx
+++ b/frontend/src/routes/ForgotPasswordPage.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useState } from 'react';
 import {
   Alert,

--- a/frontend/src/routes/HomePage.tsx
+++ b/frontend/src/routes/HomePage.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { Button, Container, Group, Stack, Text, Title } from '@mantine/core';
 import { IconBell, IconSettings, IconUser } from '@tabler/icons-react';
 import { Link } from 'react-router-dom';

--- a/frontend/src/routes/LoginPage.tsx
+++ b/frontend/src/routes/LoginPage.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useState } from 'react';
 import {
   Alert,

--- a/frontend/src/routes/NotificationsPage.tsx
+++ b/frontend/src/routes/NotificationsPage.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useState } from 'react';
 import {
   ActionIcon,

--- a/frontend/src/routes/ProfilePage.tsx
+++ b/frontend/src/routes/ProfilePage.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useEffect, useState } from 'react';
 import {
   Alert,

--- a/frontend/src/routes/RegisterPage.tsx
+++ b/frontend/src/routes/RegisterPage.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useState } from 'react';
 import {
   Alert,

--- a/frontend/src/routes/ResetPasswordPage.tsx
+++ b/frontend/src/routes/ResetPasswordPage.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useState } from 'react';
 import {
   Alert,

--- a/frontend/src/routes/TwoFactorPage.tsx
+++ b/frontend/src/routes/TwoFactorPage.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useEffect, useRef, useState } from 'react';
 import {
   Alert,
@@ -718,5 +721,4 @@ function WebAuthnSetupFlow({
     </Center>
   );
 }
-
 

--- a/frontend/src/routes/VerifyEmailPage.tsx
+++ b/frontend/src/routes/VerifyEmailPage.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useEffect, useRef, useState } from 'react';
 import {
   Alert,

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,3 +1,7 @@
+/* Copyright (c) 2026 Brendan Bank
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
 /* iOS Safari auto-zooms on *editable* inputs whose computed font-size
  * is below 16px. Readonly inputs (e.g. Mantine's MonthPickerInput)
  * don't trigger the zoom, so leave those at their design size to

--- a/frontend/src/test/host-registry.test.tsx
+++ b/frontend/src/test/host-registry.test.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 /**
  * Vitest coverage for the four host extension registries.
  *

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,1 +1,4 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import '@testing-library/jest-dom/vitest';

--- a/frontend/src/test/smoke.test.tsx
+++ b/frontend/src/test/smoke.test.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { describe, it, expect } from 'vitest';
 
 import i18n from '@/i18n';

--- a/frontend/src/theme/ThemedApp.tsx
+++ b/frontend/src/theme/ThemedApp.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { useMemo } from 'react';
 import { MantineProvider } from '@mantine/core';
 

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { createTheme, type MantineColorScheme, type MantineThemeOverride } from '@mantine/core';
 
 import type { BrandConfig, ThemePreset } from '@/hooks/useAppConfig';

--- a/frontend/src/theme/presets/classic.ts
+++ b/frontend/src/theme/presets/classic.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import type { MantineThemeOverride } from '@mantine/core';
 
 const SERIF_DISPLAY_STACK =

--- a/frontend/src/theme/presets/dark-glass.ts
+++ b/frontend/src/theme/presets/dark-glass.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import type { MantineThemeOverride } from '@mantine/core';
 
 const DISPLAY_FONT_STACK =

--- a/frontend/src/theme/presets/default.ts
+++ b/frontend/src/theme/presets/default.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import type { MantineThemeOverride } from '@mantine/core';
 
 const SYSTEM_FONT_STACK =

--- a/frontend/tests-e2e/account-deletion.spec.ts
+++ b/frontend/tests-e2e/account-deletion.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { expect, test } from '@playwright/test';
 
 import {
@@ -253,4 +256,3 @@ test('attempting to delete a super_admin from the admin UI is refused', async ({
     await userContext.close();
   }
 });
-

--- a/frontend/tests-e2e/branding.spec.ts
+++ b/frontend/tests-e2e/branding.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { expect, test } from '@playwright/test';
 
 import {

--- a/frontend/tests-e2e/captcha.spec.ts
+++ b/frontend/tests-e2e/captcha.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { expect, test } from '@playwright/test';
 import type { APIRequestContext } from '@playwright/test';
 

--- a/frontend/tests-e2e/email-otp.spec.ts
+++ b/frontend/tests-e2e/email-otp.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { expect, test } from '@playwright/test';
 
 import { loginAndPassEmailOTP } from './helpers';

--- a/frontend/tests-e2e/email-templates-i18n.spec.ts
+++ b/frontend/tests-e2e/email-templates-i18n.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { execSync } from 'child_process';
 
 import { expect, test } from '@playwright/test';

--- a/frontend/tests-e2e/helpers.ts
+++ b/frontend/tests-e2e/helpers.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { execSync } from 'child_process';
 
 import type { APIRequestContext, Page } from '@playwright/test';

--- a/frontend/tests-e2e/host-bundle.spec.ts
+++ b/frontend/tests-e2e/host-bundle.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import type { APIRequestContext } from '@playwright/test';
 import { expect, test } from '@playwright/test';
 

--- a/frontend/tests-e2e/i18n.spec.ts
+++ b/frontend/tests-e2e/i18n.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { expect, test } from '@playwright/test';
 
 import {

--- a/frontend/tests-e2e/invite-flow.spec.ts
+++ b/frontend/tests-e2e/invite-flow.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { expect, test } from '@playwright/test';
 
 import { loginAndPassTOTP } from './helpers';

--- a/frontend/tests-e2e/logout.spec.ts
+++ b/frontend/tests-e2e/logout.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { expect, test } from '@playwright/test';
 
 import { loginAndPassTOTP } from './helpers';

--- a/frontend/tests-e2e/maintenance.spec.ts
+++ b/frontend/tests-e2e/maintenance.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { expect, test } from '@playwright/test';
 
 import {

--- a/frontend/tests-e2e/password-policy.spec.ts
+++ b/frontend/tests-e2e/password-policy.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { expect, test } from '@playwright/test';
 import type { APIRequestContext } from '@playwright/test';
 import { generate as generateTOTP } from 'otplib';

--- a/frontend/tests-e2e/profile-language.spec.ts
+++ b/frontend/tests-e2e/profile-language.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { expect, test } from '@playwright/test';
 
 import {

--- a/frontend/tests-e2e/signup.spec.ts
+++ b/frontend/tests-e2e/signup.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { execSync } from 'child_process';
 
 import { expect, test } from '@playwright/test';

--- a/frontend/tests-e2e/smoke.spec.ts
+++ b/frontend/tests-e2e/smoke.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { test, expect } from '@playwright/test';
 
 import { loginAndPassTOTP } from './helpers';

--- a/frontend/tests-e2e/webauthn.spec.ts
+++ b/frontend/tests-e2e/webauthn.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { expect, test } from '@playwright/test';
 
 import { loginAndPassTOTP } from './helpers';

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'node:path';

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import path from 'node:path';

--- a/infra/mysql/my.cnf
+++ b/infra/mysql/my.cnf
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 [mysqld]
 character-set-server = utf8mb4
 collation-server = utf8mb4_unicode_ci

--- a/infra/proxy/gen-cert.sh
+++ b/infra/proxy/gen-cert.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 # Generate a self-signed cert on first boot. The cert lives in a named
 # volume so it's stable across container restarts (same fingerprint to
 # pin against from the edge Caddy). Delete the volume to rotate.

--- a/infra/proxy/nginx.conf
+++ b/infra/proxy/nginx.conf
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 # TLS termination for the edge Caddy on the firewall.
 #
 # Caddy terminates the public TLS and then reverse-proxies over the

--- a/scripts/db-dump.sh
+++ b/scripts/db-dump.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
 # Stream a full mysqldump of the running MySQL container to stdout.
 #
 # Usage:


### PR DESCRIPTION
## Summary
- Add `LICENCE.md` at the repo root with the BSD 2-Clause text (Copyright (c) 2026, Brendan Bank).
- Prepend a two-line SPDX header (`Copyright (c) 2026 Brendan Bank` / `SPDX-License-Identifier: BSD-2-Clause`) to every tracked source file (Python, TS/TSX/JS/CJS, CSS, HTML, shell, YAML, TOML, INI, conf, Dockerfile, Makefile, mako). Comment syntax matches the host language; shebangs are preserved.
- Skipped: `*.json`, `*.md`, `*.svg`, `*.lock`, `pnpm-lock.yaml`, `.env.example` (no comment support / not source).
- Update the README licence section to reference `LICENCE.md` and remove the matching `TODO.md` entry.

## Test plan
- [x] Every `*.py` file still parses (`ast.parse` sweep).
- [x] Every `*.yml`/`*.yaml`/`*.toml` file still parses.
- [x] `app.main` and `app.worker` still import cleanly.
- [x] Re-running the inserter is idempotent (`touched=0 already=248`).
- [ ] CI green.