### PR TITLE
Add registerProfileItem host extension

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -619,6 +619,15 @@ System tab) and the `audit_prune` job will DELETE older rows daily.
 - CKEditor 5 is loaded from the CDN (see `index.html`); the
   `VITE_CKEDITOR_LICENSE_KEY` is injected via Vite HTML
   `%VITE_*%` substitution. Set it to `GPL` to use the free tier.
+- Host bundles inject UI fragments via the registry in
+  `src/host/registry.ts`: `registerHomeWidget`, `registerRoute`,
+  `registerNavItem`, `registerAdminTab`, `registerProfileItem`. All
+  five must be called at import-time before React mounts (see
+  `loadHostBundle` in `src/main.tsx`). `registerProfileItem` takes an
+  optional `slot` (`after-profile` / `after-password` / `after-2fa` /
+  `after-roles` (default) / `after-sessions` / `before-delete`) and an
+  optional `condition({ me })` predicate; the host owns the card
+  chrome (no auto-wrapping in a `Paper`).
 
 ## Testing
 

--- a/examples/hello-world/frontend/src/HelloProfileItem.tsx
+++ b/examples/hello-world/frontend/src/HelloProfileItem.tsx
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+/**
+ * Profile-page item registered by the Hello World host bundle.
+ *
+ * Demonstrates the ``registerProfileItem`` extension point: the host
+ * owns the card chrome (Paper / title / content) and renders inside
+ * its own MantineProvider + QueryClientProvider, isolated from
+ * atrium's React tree by the wrapper div in main.tsx.
+ *
+ * The item appears after the Roles summary on /profile (the default
+ * slot for ``registerProfileItem``).
+ */
+import {
+  MantineProvider,
+  Paper,
+  Stack,
+  Switch,
+  Text,
+  Title,
+} from '@mantine/core';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  QueryClientProvider,
+} from '@tanstack/react-query';
+
+import {
+  getHelloState,
+  getMeContext,
+  postHelloToggle,
+  type HelloState,
+} from './api';
+import { queryClient } from './queryClient';
+
+const STATE_KEY = ['hello', 'state'] as const;
+const ME_KEY = ['hello', 'me-context'] as const;
+
+function HelloProfileItemInner() {
+  const qc = useQueryClient();
+  const { data } = useQuery({ queryKey: STATE_KEY, queryFn: getHelloState });
+  const { data: me } = useQuery({ queryKey: ME_KEY, queryFn: getMeContext });
+  const canToggle = me?.permissions.includes('hello.toggle') ?? false;
+  const toggleMutation = useMutation({
+    mutationFn: (enabled: boolean) => postHelloToggle(enabled),
+    onSuccess: (next: HelloState) => qc.setQueryData(STATE_KEY, next),
+  });
+
+  return (
+    <Paper withBorder p="sm" radius="md" data-testid="hello-profile-item">
+      <Title order={5} mb={4}>
+        Hello World preferences
+      </Title>
+      <Stack gap={6}>
+        <Text size="sm" c="dimmed">
+          Toggle the demo Hello World counter from your profile.
+        </Text>
+        <Switch
+          checked={data?.enabled ?? false}
+          disabled={!canToggle || toggleMutation.isPending}
+          onChange={(e) => toggleMutation.mutate(e.currentTarget.checked)}
+          label={canToggle ? 'Hello World enabled' : 'Hello World (admin only)'}
+          data-testid="hello-profile-toggle"
+        />
+      </Stack>
+    </Paper>
+  );
+}
+
+export function HelloProfileItem() {
+  return (
+    <MantineProvider>
+      <QueryClientProvider client={queryClient}>
+        <HelloProfileItemInner />
+      </QueryClientProvider>
+    </MantineProvider>
+  );
+}

--- a/examples/hello-world/frontend/src/main.tsx
+++ b/examples/hello-world/frontend/src/main.tsx
@@ -21,6 +21,7 @@ import { IconHandStop } from '@tabler/icons-react';
 
 import { HelloAdminTab } from './HelloAdminTab';
 import { HelloPage } from './HelloPage';
+import { HelloProfileItem } from './HelloProfileItem';
 import { HelloWidget } from './HelloWidget';
 
 interface AtriumRegistry {
@@ -44,6 +45,17 @@ interface AtriumRegistry {
     icon?: unknown;
     perm?: string;
     element: unknown;
+  }) => void;
+  registerProfileItem: (p: {
+    key: string;
+    slot?:
+      | 'after-profile'
+      | 'after-password'
+      | 'after-2fa'
+      | 'after-roles'
+      | 'after-sessions'
+      | 'before-delete';
+    render: () => unknown;
   }) => void;
 }
 
@@ -112,5 +124,10 @@ if (!reg) {
     icon: AtriumReact.createElement(IconHandStop, { size: 14 }),
     perm: 'hello.toggle',
     element: makeWrapperElement(<HelloAdminTab />),
+  });
+  reg.registerProfileItem({
+    key: 'hello-profile',
+    slot: 'after-roles',
+    render: () => makeWrapperElement(<HelloProfileItem />),
   });
 }

--- a/frontend/src/host/registry.ts
+++ b/frontend/src/host/registry.ts
@@ -5,9 +5,10 @@
  * Atrium host-extension registry.
  *
  * Atrium ships only the platform shell. Host applications inject their
- * own UI fragments via four registries — home widgets, routes, nav
- * items, and admin tabs — populated at SPA boot from a runtime-loaded
- * host bundle (see ``main.tsx`` and ``system.host_bundle_url``).
+ * own UI fragments via five registries — home widgets, routes, nav
+ * items, admin tabs, and profile items — populated at SPA boot from a
+ * runtime-loaded host bundle (see ``main.tsx`` and
+ * ``system.host_bundle_url``).
  *
  * The registries are deliberately thin: each one is an array, ordered
  * by registration call order, and the consumer components iterate
@@ -66,10 +67,33 @@ export type AdminTab = {
   element: ReactElement;
 };
 
+/** Slot inside ``ProfilePage``'s vertical card stack where a host
+ *  item is inserted. Default ``after-roles`` — the natural place for
+ *  extra preferences. */
+export type ProfileSlot =
+  | 'after-profile'
+  | 'after-password'
+  | 'after-2fa'
+  | 'after-roles'
+  | 'after-sessions'
+  | 'before-delete';
+
+export type ProfileItem = {
+  key: string;
+  /** Insertion slot. Default ``after-roles``. */
+  slot?: ProfileSlot;
+  /** Optional visibility predicate, mirrors ``NavItem``. The profile
+   *  page early-returns on a missing user, so ``me`` is never null
+   *  when this fires. */
+  condition?: (ctx: { me: CurrentUser }) => boolean;
+  render: () => ReactElement;
+};
+
 const homeWidgets: HomeWidget[] = [];
 const routes: RouteEntry[] = [];
 const navItems: NavItem[] = [];
 const adminTabs: AdminTab[] = [];
+const profileItems: ProfileItem[] = [];
 
 function registerHomeWidget(widget: HomeWidget): void {
   if (homeWidgets.some((w) => w.key === widget.key)) {
@@ -119,11 +143,24 @@ function registerAdminTab(tab: AdminTab): void {
   adminTabs.push(tab);
 }
 
+function registerProfileItem(item: ProfileItem): void {
+  if (profileItems.some((p) => p.key === item.key)) {
+    console.warn(
+      `[atrium-registry] duplicate profile item key "${item.key}"; ` +
+        `last registration wins`,
+    );
+    const idx = profileItems.findIndex((p) => p.key === item.key);
+    profileItems.splice(idx, 1);
+  }
+  profileItems.push(item);
+}
+
 export const __ATRIUM_REGISTRY__ = {
   registerHomeWidget,
   registerRoute,
   registerNavItem,
   registerAdminTab,
+  registerProfileItem,
 } as const;
 
 export type AtriumRegistry = typeof __ATRIUM_REGISTRY__;
@@ -144,6 +181,10 @@ export function getAdminTabs(): readonly AdminTab[] {
   return adminTabs;
 }
 
+export function getProfileItems(): readonly ProfileItem[] {
+  return profileItems;
+}
+
 /** Test-only: drop every registration. Production code never calls
  *  this — host bundles register once at boot and stay. */
 export function __resetRegistryForTests(): void {
@@ -151,6 +192,7 @@ export function __resetRegistryForTests(): void {
   routes.length = 0;
   navItems.length = 0;
   adminTabs.length = 0;
+  profileItems.length = 0;
 }
 
 declare global {
@@ -168,4 +210,5 @@ export {
   registerRoute,
   registerNavItem,
   registerAdminTab,
+  registerProfileItem,
 };

--- a/frontend/src/routes/ProfilePage.tsx
+++ b/frontend/src/routes/ProfilePage.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Brendan Bank
 // SPDX-License-Identifier: BSD-2-Clause
 
-import { useEffect, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import {
   Alert,
   Badge,
@@ -27,6 +27,7 @@ import { useNavigate } from 'react-router-dom';
 import { TwoFactorSetupModal } from '@/components/TwoFactorSetupModal';
 import { useSelfDelete } from '@/hooks/useAccountDeletion';
 import { ME_QUERY_KEY, useMe } from '@/hooks/useAuth';
+import { getProfileItems, type ProfileSlot } from '@/host/registry';
 import { useLogoutAll, useSessions } from '@/hooks/useSessions';
 import {
   useEmailOTPDisable,
@@ -158,6 +159,27 @@ export function ProfilePage() {
   if (isLoading) return <Loader />;
   if (!me) return <Alert color="red">{t('profile.notLoggedIn')}</Alert>;
 
+  // Items registered by host bundles via ``registerProfileItem``. We
+  // resolve them once per render and bucket by slot so each slot
+  // marker below is just an array lookup. ``condition`` is evaluated
+  // here so a host can hide an item based on roles / permissions.
+  const slottedItems: Record<ProfileSlot, ReturnType<typeof getProfileItems>[number][]> = {
+    'after-profile': [],
+    'after-password': [],
+    'after-2fa': [],
+    'after-roles': [],
+    'after-sessions': [],
+    'before-delete': [],
+  };
+  for (const item of getProfileItems()) {
+    if (item.condition && !item.condition({ me })) continue;
+    slottedItems[item.slot ?? 'after-roles'].push(item);
+  }
+  const renderSlot = (slot: ProfileSlot) =>
+    slottedItems[slot].map((item) => (
+      <Fragment key={item.key}>{item.render()}</Fragment>
+    ));
+
   return (
     <Stack maw={820} gap={6}>
       <Title order={2}>{t('profile.title')}</Title>
@@ -204,6 +226,8 @@ export function ProfilePage() {
         </form>
       </Paper>
 
+      {renderSlot('after-profile')}
+
       <Paper withBorder p="sm" radius="md">
         <Title order={5} mb={4}>
           {t('profile.changePassword')}
@@ -232,6 +256,8 @@ export function ProfilePage() {
           </Stack>
         </form>
       </Paper>
+
+      {renderSlot('after-password')}
 
       <Paper withBorder p="sm" radius="md">
         <Title order={5} mb={4}>
@@ -411,7 +437,11 @@ export function ProfilePage() {
         onEnrolled={() => refetchTotpState()}
       />
 
+      {renderSlot('after-2fa')}
+
       <RolesSummary roles={me.roles} />
+
+      {renderSlot('after-roles')}
 
       <Paper withBorder p="sm" radius="md">
         <Title order={5} mb={4}>
@@ -486,6 +516,10 @@ export function ProfilePage() {
           </Button>
         </Group>
       </Paper>
+
+      {renderSlot('after-sessions')}
+
+      {renderSlot('before-delete')}
 
       <Paper withBorder p="sm" radius="md">
         <Title order={5} mb={4}>

--- a/frontend/src/test/host-registry.test.tsx
+++ b/frontend/src/test/host-registry.test.tsx
@@ -25,10 +25,12 @@ import {
   getAdminTabs,
   getHomeWidgets,
   getNavItems,
+  getProfileItems,
   getRoutes,
   registerAdminTab,
   registerHomeWidget,
   registerNavItem,
+  registerProfileItem,
   registerRoute,
 } from '@/host/registry';
 
@@ -97,6 +99,36 @@ describe('host registry', () => {
     });
     const tabs = getAdminTabs();
     expect(tabs[0]?.perm).toBe('thing.manage');
+  });
+
+  it('registerProfileItem appends in registration order', () => {
+    registerProfileItem({
+      key: 'a',
+      slot: 'after-roles',
+      render: () => <span>A</span>,
+    });
+    registerProfileItem({
+      key: 'b',
+      slot: 'before-delete',
+      render: () => <span>B</span>,
+    });
+    const items = getProfileItems();
+    expect(items.map((i) => i.key)).toEqual(['a', 'b']);
+    expect(items[0]?.slot).toBe('after-roles');
+    expect(items[1]?.slot).toBe('before-delete');
+  });
+
+  it('registerProfileItem replaces on duplicate key with a warning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      registerProfileItem({ key: 'p', render: () => <span>first</span> });
+      registerProfileItem({ key: 'p', render: () => <span>second</span> });
+      const items = getProfileItems();
+      expect(items).toHaveLength(1);
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it('window.__ATRIUM_REGISTRY__ writes through to the same state', () => {


### PR DESCRIPTION
## Summary

- Adds a fifth host extension registry, `registerProfileItem`, alongside the existing `registerHomeWidget` / `registerRoute` / `registerNavItem` / `registerAdminTab`. Host bundles can now inject configuration cards into `/profile` without forking `ProfilePage.tsx`.
- `ProfileItem` carries a `key`, an optional `slot` (`after-profile` / `after-password` / `after-2fa` / `after-roles` (default) / `after-sessions` / `before-delete`), an optional `condition({ me })` predicate, and a `render()` returning a ReactElement. The host owns the card chrome — no auto-`Paper` wrapping — matching the `HomeWidget` convention.
- The Hello World example registers a small "Hello World preferences" toggle at `after-roles` to exercise the API end-to-end.

## Test plan

- [x] `pnpm test` — 17/17 vitest tests pass (includes 2 new cases for register order + duplicate-key replace)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (1 pre-existing warning unrelated to this change)
- [x] `pnpm build` — clean
- [x] `uv run ruff check .` — clean
- [x] `uv run pytest` — 177/177 backend tests pass
- [ ] `make smoke-hello-dev` — log in and confirm the new Hello World preferences card appears below the Roles summary on `/profile`