### PR TITLE
Smooth the host-extension surface for newer host bundles

### DIFF
--- a/backend/app/auth/rbac.py
+++ b/backend/app/auth/rbac.py
@@ -38,6 +38,10 @@ async def get_user_permissions(
 
     One query, joined through user_roles → role_permissions. Empty set
     if the user has no roles (which shouldn't happen in practice).
+
+    Prefer ``current_user_permissions`` from a route — it resolves once
+    per request via FastAPI's dep cache, so multiple ``require_perm``
+    gates on the same endpoint don't re-query.
     """
     result = await session.execute(
         select(role_permissions.c.permission_code)
@@ -49,14 +53,29 @@ async def get_user_permissions(
     return {row[0] for row in result.all()}
 
 
+async def current_user_permissions(
+    user: User = Depends(current_user),
+    session: AsyncSession = Depends(get_session),
+) -> set[str]:
+    """Effective permission set for the current user, cached per request.
+
+    FastAPI memoises a ``Depends`` by callable identity within a single
+    request, so any number of ``require_perm("...")`` gates on one
+    endpoint resolve to a single ``get_user_permissions`` call. Host
+    code that needs the full set (e.g. to render a UI gate server-side
+    or branch on a non-fatal capability) should depend on this rather
+    than calling ``get_user_permissions`` directly.
+    """
+    return await get_user_permissions(session, user.id)
+
+
 def require_perm(code: str):
     """Dependency factory: 403 unless the current user has ``code``."""
 
     async def _dep(
         user: User = Depends(current_user),
-        session: AsyncSession = Depends(get_session),
+        perms: set[str] = Depends(current_user_permissions),
     ) -> User:
-        perms = await get_user_permissions(session, user.id)
         if code not in perms:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,

--- a/docs/new-project/README.md
+++ b/docs/new-project/README.md
@@ -521,7 +521,8 @@ out of the host subtree.
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "typescript": "^6.0.3",
-    "vite": "^8.0.10"
+    "vite": "^8.0.10",
+    "vite-plugin-css-injected-by-js": "^3.5.2"
   }
 }
 ```
@@ -531,6 +532,7 @@ out of the host subtree.
 ```ts
 import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
+import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js';
 
 export default defineConfig({
   define: {
@@ -540,6 +542,16 @@ export default defineConfig({
     'process.env.NODE_ENV': JSON.stringify('production'),
     'process.env': '{}',
   },
+  // Vite's lib build extracts every imported `.css` to a sibling
+  // file. atrium dynamic-imports `main.js` only, so a sibling
+  // `<bundle-name>.css` would sit there orphaned and the bundle would
+  // render unstyled. The plugin rewrites those imports to inject the
+  // CSS via a runtime `<style>` tag — a single `main.js` carries
+  // everything. Keep the plugin in even when the bundle has no CSS
+  // imports today: the failure mode (silently unstyled widgets the
+  // first time you `import 'fullcalendar/main.css'`) is unpleasant
+  // to diagnose.
+  plugins: [cssInjectedByJsPlugin()],
   build: {
     target: 'es2022',
     lib: {
@@ -924,6 +936,54 @@ Permission gating on the API: `Depends(require_perm("your_thing.read"))`.
 Permission gating on the SPA: pass `perm:` to `registerAdminTab`, or
 read `me.permissions` directly in your component (your bundle can fetch
 `/users/me/context` itself).
+
+### Running backend tests in-container
+
+The published atrium image is a runtime image — `pytest`, `pytest-asyncio`,
+and `httpx` are not installed. Two paths:
+
+**Inline install + run** (good for one-off runs, no Dockerfile churn):
+
+```bash
+docker compose exec -u root api /opt/venv/bin/python -m pip install \
+    --no-cache-dir pytest pytest-asyncio httpx
+docker compose exec api /opt/venv/bin/python -m pytest /opt/host_app/tests
+```
+
+The `-u root` is needed because `/opt/venv` is owned by root in the
+runtime image; the host package itself was installed at image build
+time when the Dockerfile dropped to `USER root` for that step.
+
+**Make target** (recommended once you have more than one test invocation
+to remember):
+
+```makefile
+.PHONY: test-backend
+test-backend:
+	docker compose exec -u root -T api /opt/venv/bin/python -m pip install \
+	    --quiet --no-cache-dir pytest pytest-asyncio httpx
+	docker compose exec -T api /opt/venv/bin/python -m pytest /opt/host_app/tests
+```
+
+The pip install is idempotent — it's a no-op once the deps are present
+in the running container's venv. (A container restart wipes them; the
+next `make test-backend` reinstalls.)
+
+**Bake a `dev` image** (cleanest for active development, costs one
+extra Docker layer and a `--target dev` flag in compose). Add a stage
+to your Dockerfile after the `runtime` stage:
+
+```dockerfile
+FROM runtime AS dev
+USER root
+RUN /opt/venv/bin/python -m pip install --no-cache-dir \
+    pytest pytest-asyncio httpx
+USER app
+```
+
+…and pin the dev compose file to `target: dev`. The runtime image
+stays slim; the dev image carries the test deps so `pytest` is on
+PATH the moment the container boots.
 
 ## Retrofitting an existing app
 

--- a/docs/new-project/SKILL.md
+++ b/docs/new-project/SKILL.md
@@ -17,6 +17,16 @@ canonical worked example is [`../../examples/hello-world/`](../../examples/hello
 This SKILL.md is the procedure to follow when an agent is doing the
 bootstrap.
 
+> **Example version-pinning.** `examples/hello-world/` tracks `master`
+> and exercises whatever extension surface ships at HEAD. If the user
+> pins their atrium image to an older `X.Y` tag (sensible for prod),
+> read the example **at the matching git tag** — `git checkout vX.Y.Z
+> -- examples/hello-world/` — before copying snippets. The host
+> registry tolerates calls to slots that don't exist in the running
+> image (logs a console warning, the rest of the bundle continues
+> registering), so a newer-than-image bundle degrades gracefully
+> rather than catastrophically — but the slot still won't render.
+
 ## Up-front decisions to confirm with the user
 
 Before writing files, confirm:
@@ -96,10 +106,19 @@ host subtree.
 
 - `frontend/package.json` — react/react-dom 19, mantine 9, tanstack
   query 5, vite 8, typescript 6, tabler icons 3. Single script: `vite
-  build`.
+  build`. **Add `vite-plugin-css-injected-by-js` as a devDependency** —
+  see vite.config.ts below.
 - `frontend/vite.config.ts` — library mode (`build.lib`), single
   output `main.js`, define `process.env.NODE_ENV` and `process.env`
-  so React/TanStack don't throw on a missing process shim.
+  so React/TanStack don't throw on a missing process shim. **Plug
+  `vite-plugin-css-injected-by-js` into `plugins`**: Vite's lib build
+  extracts every `import 'pkg/styles.css'` into a sibling
+  `<bundle-name>.css`, but atrium dynamic-imports `main.js` only —
+  the sibling never loads and the page renders unstyled. The plugin
+  rewrites those imports to inject CSS via a runtime `<style>` tag,
+  so a single `main.js` carries everything. Add it preemptively even
+  if the bundle has no CSS imports today: the failure mode (silently
+  unstyled widgets) is annoying to diagnose later.
 - `frontend/src/main.tsx` — the entry. Reads `window.React` and
   `window.__ATRIUM_REGISTRY__` (both set by atrium's main.tsx before
   the dynamic import). Calls `reg.register{HomeWidget,Route,NavItem,AdminTab,ProfileItem}`.
@@ -221,6 +240,14 @@ docker compose exec api python -m <your_pkg>.scripts.seed_host_bundle /host/main
 
 Or do it inline with the Python snippet in [`README.md`](README.md)
 section *Step 8*.
+
+### 9b. Backend tests in-container (optional)
+
+The runtime image strips `pytest`, `pytest-asyncio`, and `httpx`. If the
+host wants to run backend tests in the api container, install them on
+demand or bake a `dev` Dockerfile stage. See [`README.md`](README.md)
+section *Running backend tests in-container* for both patterns and a
+Make target.
 
 ### 10. Verify
 

--- a/docs/published-images.md
+++ b/docs/published-images.md
@@ -289,7 +289,15 @@ required, ~250 KB gzipped.
 
 ```ts
 // vite.config.ts
+import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js';
+
 export default defineConfig({
+  // Vite's lib build extracts every `import 'pkg/styles.css'` into a
+  // sibling `main.css`. atrium dynamic-imports `main.js` only — that
+  // sibling is never fetched and the bundle ships unstyled. The
+  // plugin inlines those imports as a runtime `<style>` tag so a
+  // single `main.js` carries everything.
+  plugins: [cssInjectedByJsPlugin()],
   build: {
     lib: { entry: 'src/main.tsx', formats: ['es'], fileName: () => 'main.js' },
   },
@@ -344,9 +352,20 @@ serves. Until then, self-contained is the path of least resistance.
 
 The [`examples/hello-world/`](../examples/hello-world/) directory ships a
 host bundle that registers one of every slot kind (home widget, route, nav
-item, admin tab) plus the backend half (`init_app` + `init_worker`,
-permission seeding, scheduler pipeline). It doubles as the smoke-test for
-the slot system itself — `make smoke-hello` runs the full end-to-end spec.
+item, admin tab, profile item) plus the backend half (`init_app` +
+`init_worker`, permission seeding, scheduler pipeline). It doubles as the
+smoke-test for the slot system itself — `make smoke-hello` runs the full
+end-to-end spec.
+
+The example tracks `master`. If you pin your atrium image to an older
+`X.Y` tag, read the example **at the matching git tag** (`git checkout
+vX.Y.Z -- examples/hello-world/`) before copying patterns wholesale —
+slots added in later releases (e.g. `registerProfileItem` in `v0.11`)
+will be present at HEAD but missing from older images. The frontend
+registry catches calls to unknown methods and logs a console warning
+instead of throwing, so a bundle built against a newer atrium degrades
+gracefully (the rest of its registrations still land); the unknown slot
+just doesn't render.
 
 ---
 

--- a/examples/hello-world/frontend/package.json
+++ b/examples/hello-world/frontend/package.json
@@ -23,6 +23,7 @@
     "@types/react-dom": "^19.0.0",
     "otplib": "^13.4.0",
     "typescript": "^6.0.3",
-    "vite": "^8.0.10"
+    "vite": "^8.0.10",
+    "vite-plugin-css-injected-by-js": "^3.5.2"
   }
 }

--- a/examples/hello-world/frontend/pnpm-lock.yaml
+++ b/examples/hello-world/frontend/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       vite:
         specifier: ^8.0.10
         version: 8.0.10
+      vite-plugin-css-injected-by-js:
+        specifier: ^3.5.2
+        version: 3.5.2(vite@8.0.10)
 
 packages:
 
@@ -494,6 +497,11 @@ packages:
       '@types/react':
         optional: true
 
+  vite-plugin-css-injected-by-js@3.5.2:
+    resolution: {integrity: sha512-2MpU/Y+SCZyWUB6ua3HbJCrgnF0KACAsmzOQt1UvRVJCGF6S8xdA3ZUhWcWdM9ivG4I5az8PnQmwwrkC2CAQrQ==}
+    peerDependencies:
+      vite: '>2.0.0-0'
+
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -912,6 +920,10 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
+
+  vite-plugin-css-injected-by-js@3.5.2(vite@8.0.10):
+    dependencies:
+      vite: 8.0.10
 
   vite@8.0.10:
     dependencies:

--- a/examples/hello-world/frontend/vite.config.ts
+++ b/examples/hello-world/frontend/vite.config.ts
@@ -3,6 +3,7 @@
 
 import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
+import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js';
 
 // Library build that emits a single ES module loaded by atrium via
 // dynamic import (`system.host_bundle_url` → `await import(url)`).
@@ -30,6 +31,16 @@ export default defineConfig({
     'process.env.NODE_ENV': JSON.stringify('production'),
     'process.env': '{}',
   },
+  // Vite's library build extracts every imported ``.css`` to a sibling
+  // file (``main.css``) by default. Atrium dynamic-imports
+  // ``main.js`` only — sibling CSS is never fetched, leaving widgets
+  // unstyled. ``vite-plugin-css-injected-by-js`` rewrites those
+  // imports to inject the CSS via a runtime ``<style>`` tag so a
+  // single ``main.js`` is sufficient. This example doesn't import any
+  // CSS today, but the plugin stays here so the very first ``import
+  // 'pkg/styles.css'`` you add (FullCalendar, react-big-calendar,
+  // any rich-text editor) doesn't quietly ship without styles.
+  plugins: [cssInjectedByJsPlugin()],
   build: {
     target: 'es2022',
     lib: {

--- a/frontend/src/components/HostHomeWidgets.tsx
+++ b/frontend/src/components/HostHomeWidgets.tsx
@@ -1,22 +1,50 @@
 // Copyright (c) 2026 Brendan Bank
 // SPDX-License-Identifier: BSD-2-Clause
 
-import { Fragment } from 'react';
-import { Stack } from '@mantine/core';
+import { Fragment, type ReactElement } from 'react';
+import { Container, Stack } from '@mantine/core';
 
-import { getHomeWidgets } from '@/host/registry';
+import { getHomeWidgets, type HomeWidgetWidth } from '@/host/registry';
 
-/** Iterates the home-widget registry and renders each widget in a
- *  vertical Mantine Stack above the atrium-shipped HomePage content.
- *  Empty when no host bundle is loaded. */
+/** Wrap a widget element in the Container that matches its declared
+ *  width. ``full`` renders without a Container so the widget owns the
+ *  panel (handy for FullCalendar, large tables, anything that needs
+ *  horizontal real estate). ``narrow`` (the default) keeps the 680px
+ *  column atrium uses for its own welcome content so widgets that
+ *  predate the ``width`` prop look exactly as they did. */
+function widthContainer(
+  child: ReactElement,
+  width: HomeWidgetWidth | undefined,
+  key: string,
+): ReactElement {
+  switch (width ?? 'narrow') {
+    case 'full':
+      return <Fragment key={key}>{child}</Fragment>;
+    case 'wide':
+      return (
+        <Container key={key} size="lg">
+          {child}
+        </Container>
+      );
+    case 'narrow':
+    default:
+      return (
+        <Container key={key} size={680}>
+          {child}
+        </Container>
+      );
+  }
+}
+
+/** Iterates the home-widget registry and renders each widget at its
+ *  declared width above the atrium-shipped HomePage content. Empty
+ *  when no host bundle is loaded. */
 export function HostHomeWidgets() {
   const widgets = getHomeWidgets();
   if (widgets.length === 0) return null;
   return (
     <Stack gap="md">
-      {widgets.map((w) => (
-        <Fragment key={w.key}>{w.render()}</Fragment>
-      ))}
+      {widgets.map((w) => widthContainer(w.render(), w.width, w.key))}
     </Stack>
   );
 }

--- a/frontend/src/host/registry.ts
+++ b/frontend/src/host/registry.ts
@@ -29,9 +29,17 @@ import type { ReactElement } from 'react';
 
 import type { CurrentUser } from '@/lib/auth';
 
+/** Layout width for a home-page widget. ``narrow`` matches the default
+ *  680px column atrium ships for the welcome content; ``wide`` extends
+ *  out to a comfortable dashboard column; ``full`` lets the widget own
+ *  the full panel (still inside ``AppShell.Main``'s padding). Default
+ *  is ``narrow`` so existing widgets keep their current layout. */
+export type HomeWidgetWidth = 'narrow' | 'wide' | 'full';
+
 export type HomeWidget = {
   key: string;
   render: () => ReactElement;
+  width?: HomeWidgetWidth;
 };
 
 export type RouteEntry = {
@@ -155,7 +163,7 @@ function registerProfileItem(item: ProfileItem): void {
   profileItems.push(item);
 }
 
-export const __ATRIUM_REGISTRY__ = {
+const baseRegistry = {
   registerHomeWidget,
   registerRoute,
   registerNavItem,
@@ -163,7 +171,35 @@ export const __ATRIUM_REGISTRY__ = {
   registerProfileItem,
 } as const;
 
-export type AtriumRegistry = typeof __ATRIUM_REGISTRY__;
+export type AtriumRegistry = typeof baseRegistry;
+
+/** Wrap the registry in a Proxy so a host bundle that targets a newer
+ *  atrium build (e.g. it calls ``registerSettingsTab`` against an
+ *  image that hasn't shipped that slot yet) gets a clear console
+ *  warning instead of a ``TypeError: ... is not a function`` that
+ *  unwinds mid-bundle and loses every prior registration. The typed
+ *  exports above stay the source of truth for what should exist; the
+ *  Proxy is purely a runtime safety net. */
+const registryProxy = new Proxy(baseRegistry, {
+  get(target, prop, receiver) {
+    if (typeof prop === 'symbol' || prop in target) {
+      return Reflect.get(target, prop, receiver);
+    }
+    const propStr = String(prop);
+    return (...args: unknown[]): void => {
+      const arg = args[0] as { key?: unknown } | undefined;
+      const key = typeof arg?.key === 'string' ? arg.key : '<unknown>';
+      console.warn(
+        `[atrium-registry] host bundle called __ATRIUM_REGISTRY__.${propStr}(...) ` +
+          `but that method is not available in this atrium build ` +
+          `(key="${key}"). Registration ignored — upgrade the atrium ` +
+          `image or remove the call from the host bundle.`,
+      );
+    };
+  },
+}) as AtriumRegistry;
+
+export const __ATRIUM_REGISTRY__: AtriumRegistry = registryProxy;
 
 export function getHomeWidgets(): readonly HomeWidget[] {
   return homeWidgets;

--- a/frontend/src/routes/HomePage.tsx
+++ b/frontend/src/routes/HomePage.tsx
@@ -10,51 +10,58 @@ import { HostHomeWidgets } from '@/components/HostHomeWidgets';
 import { useMe } from '@/hooks/useAuth';
 
 /** Minimal landing page. Host apps replace this with whatever
- *  dashboard makes sense for them; Atrium ships only the shell. */
+ *  dashboard makes sense for them; Atrium ships only the shell.
+ *
+ *  ``HostHomeWidgets`` is rendered outside the welcome Container so
+ *  widgets that opt into ``width: 'wide'`` or ``'full'`` can break
+ *  out of the 680px column. The atrium-shipped welcome content stays
+ *  in the narrow column. */
 export function HomePage() {
   const { t } = useTranslation();
   const { data: me } = useMe();
   const isAdmin = me?.roles.includes('admin') ?? false;
 
   return (
-    <Container size={680}>
-      <Stack gap="md">
-        <HostHomeWidgets />
-        <Title order={2}>
-          {me?.full_name
-            ? t('home.welcomeNamed', { name: me.full_name })
-            : t('home.welcome')}
-        </Title>
-        <Text c="dimmed">{t('home.intro')}</Text>
-        <Group>
-          <Button
-            component={Link}
-            to="/profile"
-            variant="light"
-            leftSection={<IconUser size={16} />}
-          >
-            {t('nav.profile')}
-          </Button>
-          <Button
-            component={Link}
-            to="/notifications"
-            variant="light"
-            leftSection={<IconBell size={16} />}
-          >
-            {t('nav.notifications')}
-          </Button>
-          {isAdmin && (
+    <Stack gap="md">
+      <HostHomeWidgets />
+      <Container size={680}>
+        <Stack gap="md">
+          <Title order={2}>
+            {me?.full_name
+              ? t('home.welcomeNamed', { name: me.full_name })
+              : t('home.welcome')}
+          </Title>
+          <Text c="dimmed">{t('home.intro')}</Text>
+          <Group>
             <Button
               component={Link}
-              to="/admin"
+              to="/profile"
               variant="light"
-              leftSection={<IconSettings size={16} />}
+              leftSection={<IconUser size={16} />}
             >
-              {t('nav.admin')}
+              {t('nav.profile')}
             </Button>
-          )}
-        </Group>
-      </Stack>
-    </Container>
+            <Button
+              component={Link}
+              to="/notifications"
+              variant="light"
+              leftSection={<IconBell size={16} />}
+            >
+              {t('nav.notifications')}
+            </Button>
+            {isAdmin && (
+              <Button
+                component={Link}
+                to="/admin"
+                variant="light"
+                leftSection={<IconSettings size={16} />}
+              >
+                {t('nav.admin')}
+              </Button>
+            )}
+          </Group>
+        </Stack>
+      </Container>
+    </Stack>
   );
 }

--- a/frontend/src/test/host-registry.test.tsx
+++ b/frontend/src/test/host-registry.test.tsx
@@ -46,6 +46,27 @@ describe('host registry', () => {
     expect(widgets.map((w) => w.key)).toEqual(['a', 'b']);
   });
 
+  it('registerHomeWidget carries the optional width prop through', () => {
+    registerHomeWidget({
+      key: 'narrow-default',
+      render: () => <span>n</span>,
+    });
+    registerHomeWidget({
+      key: 'wide',
+      render: () => <span>w</span>,
+      width: 'wide',
+    });
+    registerHomeWidget({
+      key: 'full',
+      render: () => <span>f</span>,
+      width: 'full',
+    });
+    const widgets = getHomeWidgets();
+    expect(widgets.find((w) => w.key === 'narrow-default')?.width).toBeUndefined();
+    expect(widgets.find((w) => w.key === 'wide')?.width).toBe('wide');
+    expect(widgets.find((w) => w.key === 'full')?.width).toBe('full');
+  });
+
   it('registerHomeWidget replaces on duplicate key', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     try {
@@ -126,6 +147,36 @@ describe('host registry', () => {
       const items = getProfileItems();
       expect(items).toHaveLength(1);
       expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('__ATRIUM_REGISTRY__ logs a warning for unknown register* methods without throwing', () => {
+    // A host bundle built against a newer atrium that registers a
+    // slot this build doesn't ship must not crash mid-import: the
+    // earlier registrations would be lost. The Proxy returns a
+    // logging shim instead of letting `undefined()` throw.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const reg = window.__ATRIUM_REGISTRY__ as unknown as Record<
+        string,
+        (arg: unknown) => void
+      >;
+      expect(typeof reg.registerSomethingFromTheFuture).toBe('function');
+      reg.registerSomethingFromTheFuture({ key: 'futurey' });
+      expect(warn).toHaveBeenCalledOnce();
+      const message = String(warn.mock.calls[0]?.[0] ?? '');
+      expect(message).toContain('registerSomethingFromTheFuture');
+      expect(message).toContain('futurey');
+      // The bundle's later calls still land — that's the whole point.
+      registerHomeWidget({
+        key: 'after-future-call',
+        render: () => <span>ok</span>,
+      });
+      expect(getHomeWidgets().map((w) => w.key)).toContain(
+        'after-future-call',
+      );
     } finally {
       warn.mockRestore();
     }


### PR DESCRIPTION
## Summary
Six papercuts surfaced while building a real host bundle on top of a published atrium image. The biggest fix is a Proxy-wrapped registry: a host bundle that calls a `register*` method missing in the running atrium build now logs a warning and continues instead of throwing TypeError mid-init and losing every prior registration.

## Changes
- **Registry** (`frontend/src/host/registry.ts`): Proxy wraps `__ATRIUM_REGISTRY__` so unknown methods log a clear warning and don't crash the bundle. `HomeWidget` gains optional `width: 'narrow' | 'wide' | 'full'` so widgets like FullCalendar can break out of the 680px column; `HostHomeWidgets` + `HomePage` route the welcome content to a narrow Container while letting wide/full widgets own the panel.
- **RBAC** (`backend/app/auth/rbac.py`): new `current_user_permissions` Depends-able resolver. Multiple `require_perm` gates on one endpoint now share a single DB roundtrip per request via FastAPI's dep cache.
- **Docs**: new-project README/SKILL/published-images cover the `vite-plugin-css-injected-by-js` requirement (orphaned sibling CSS is the silent failure mode), version-pin guidance for `examples/hello-world/`, and three patterns for running pytest in the test-stripped runtime image.
- **Example**: hello-world bundle adopts the CSS-injection plugin preemptively so the first `.css` import doesn't ship unstyled.

## Test plan
- [x] Backend: `pytest tests/api/{test_rbac_admin,test_impersonation,test_invite_flow,test_app_config,test_account_deletion,test_email_templates_per_locale}.py` — 57 tests pass
- [x] Frontend: vitest registry suite (10 tests, including 2 new), `pnpm typecheck`, `pnpm lint`, hello-world bundle build
- [ ] `make smoke-hello` against the rebuilt bundle (recommended before merge)