### PR TITLE
Add weekly security pipeline and split publish-images per-arch

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,29 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Repo-local CodeQL config — referenced from .github/workflows/codeql.yml
+# via `config-file`. Keeps the rule set on `security-and-quality` (wider
+# than security-only — worth it for a small codebase) and trims two
+# sources of pure noise that drown the real findings.
+
+name: atrium
+
+queries:
+  - uses: security-and-quality
+
+paths-ignore:
+  # Alembic migrations are run-once scripts; the patterns CodeQL flags
+  # in them (unused locals, broad excepts) are idiomatic for migration
+  # code and not meaningful for runtime risk.
+  - backend/alembic/versions/**
+  # Test fixtures + scaffolding — out of scope for product security
+  # review; their findings rarely correspond to real risk.
+  - backend/tests/**
+
+query-filters:
+  - exclude:
+      # Alembic owns `revision`, `down_revision`, `branch_labels`, and
+      # `depends_on` in every migration file via reflection. The parser
+      # sees them as unused module globals; without this filter the
+      # Security tab fills with one alert per migration.
+      id: py/unused-global-variable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,24 +228,21 @@ jobs:
             frontend/pnpm-lock.yaml
             examples/hello-world/frontend/pnpm-lock.yaml
 
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
-
       - name: Build atrium runtime image
         # Local atrium build instead of pulling from GHCR so PRs don't
         # depend on a published artifact for the branch under test.
-        # ``cache-from``/``cache-to`` reuse the same GHA cache scope as
-        # ``compose-build`` and ``publish-images``: a layer built once
-        # is reused across all three jobs (and across re-runs on the
-        # same PR).
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
-        with:
-          context: .
-          file: Dockerfile
-          target: runtime
-          load: true
-          tags: atrium-local:source
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+        # Stays on raw ``docker build`` (not buildx/build-push-action)
+        # because the next step is ``docker compose up --build`` which
+        # references this image as ``FROM ${ATRIUM_IMAGE}`` in the
+        # example's Dockerfile. Compose's active buildx builder must
+        # be able to resolve that FROM against the docker daemon's
+        # image store — a docker-container builder (what
+        # ``setup-buildx-action`` activates by default) can't see
+        # daemon-local tags and falls back to pulling from docker.io,
+        # which fails with ``pull access denied``. The cache savings
+        # would have been parallel to ``backend`` (not on the
+        # critical path) so the trade isn't worth the breakage.
+        run: docker build -t atrium-local:source --target runtime .
 
       - name: Prepare smoke .env
         # The example compose reads .env from examples/hello-world/.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,10 +228,24 @@ jobs:
             frontend/pnpm-lock.yaml
             examples/hello-world/frontend/pnpm-lock.yaml
 
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+
       - name: Build atrium runtime image
         # Local atrium build instead of pulling from GHCR so PRs don't
         # depend on a published artifact for the branch under test.
-        run: docker build -t atrium-local:source --target runtime .
+        # ``cache-from``/``cache-to`` reuse the same GHA cache scope as
+        # ``compose-build`` and ``publish-images``: a layer built once
+        # is reused across all three jobs (and across re-runs on the
+        # same PR).
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: .
+          file: Dockerfile
+          target: runtime
+          load: true
+          tags: atrium-local:source
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Prepare smoke .env
         # The example compose reads .env from examples/hello-world/.
@@ -334,40 +348,3 @@ jobs:
             examples/hello-world/frontend/playwright-report
             examples/hello-world/frontend/test-results
           if-no-files-found: ignore
-
-  compose-build:
-    # Builds the unified atrium image for trivy scanning. No dependency
-    # on backend / frontend test results — the scan is about CVEs in
-    # the resulting image, orthogonal to whether tests pass.
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-
-      - name: Build unified atrium image
-        run: docker build -t atrium:scan --target runtime .
-
-      # Trivy: filesystem scan catches dep CVEs (uv.lock, pnpm-lock.yaml),
-      # Dockerfile / IaC misconfig, and committed secrets. --ignore-unfixed
-      # avoids blocking on CVEs that have no upstream patch yet.
-      - name: Trivy filesystem scan
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
-        with:
-          scan-type: fs
-          scan-ref: .
-          scanners: vuln,misconfig,secret
-          severity: HIGH,CRITICAL
-          ignore-unfixed: true
-          exit-code: '1'
-          skip-dirs: frontend/node_modules,backend/.venv
-
-      # OS-package CVEs in the python:3.14-slim base + the Vite-built
-      # SPA's bundled deps. api + worker share this image, so one scan
-      # covers both runtime roles.
-      - name: Trivy image scan
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
-        with:
-          scan-type: image
-          image-ref: atrium:scan
-          severity: HIGH,CRITICAL
-          ignore-unfixed: true
-          exit-code: '1'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,7 +9,7 @@ name: CodeQL
 
 on:
   pull_request:
-    branches: [main]
+    branches: [master]
   schedule:
     - cron: "0 6 * * 1"
   workflow_dispatch:
@@ -40,9 +40,11 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
-          # security-and-quality widens the rule set beyond
-          # security-only; worth it for a small codebase.
-          queries: security-and-quality
+          # The query set (security-and-quality), the paths-ignore for
+          # alembic + tests, and the py/unused-global-variable filter
+          # all live in the repo-local config so this workflow stays
+          # focused on driving the matrix.
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -11,6 +11,17 @@ name: Publish image
 #
 # `workflow_dispatch` lets a maintainer re-run an existing tag (eg.
 # registry outage recovery) without retagging.
+#
+# Per-arch parallel builds: amd64 on ubuntu-24.04, arm64 on
+# ubuntu-24.04-arm. Each matrix job pushes its image by digest only
+# (no tags); the merge job assembles the multi-arch manifest list
+# under the canonical semver tags. This replaces the previous
+# unified single-runner build that emulated arm64 via qemu — the
+# emulation was the dominant cost (8 min for a typical release).
+# Native arm64 runners are free for private repos on the Team plan;
+# if the runner ever becomes unavailable, swap matrix.runner.arm64
+# back to ubuntu-24.04 and re-add docker/setup-qemu-action to fall
+# back to emulation.
 on:
   push:
     tags:
@@ -30,15 +41,86 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/atrium
+
 jobs:
-  image:
-    runs-on: ubuntu-latest
+  build:
+    name: Build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
+      - name: Resolve platform pair
+        # buildx artifact names can't contain slashes; turn linux/amd64
+        # into linux-amd64 for the digest artifact name + cache scope.
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
 
-      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: .
+          file: Dockerfile
+          target: runtime
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            VITE_API_BASE_URL=
+            VITE_DEFAULT_LANGUAGE=en
+            VITE_CKEDITOR_LICENSE_KEY=GPL
+          # No tags here — push-by-digest is what lets the merge job
+          # below assemble the multi-arch manifest list under the
+          # real semver tags.
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=runtime-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,scope=runtime-${{ env.PLATFORM_PAIR }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4.6.2
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge manifest
+    needs: build
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
 
@@ -53,30 +135,25 @@ jobs:
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
         with:
-          images: ghcr.io/${{ github.repository_owner }}/atrium
+          images: ${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=latest
 
-      - name: Build and push
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
-        with:
-          # Repo root — the unified Dockerfile needs to reach both
-          # backend/ and frontend/ in one COPY tree.
-          context: .
-          file: Dockerfile
-          target: runtime
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VITE_API_BASE_URL=
-            VITE_DEFAULT_LANGUAGE=en
-            VITE_CKEDITOR_LICENSE_KEY=GPL
-          # GHA cache so per-arch layers (especially the arm64
-          # emulated ones) are reused across runs.
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        # `imagetools create` accepts repeated -t flags for tags and
+        # one or more @sha256:... source refs; jq pulls the tag list
+        # straight out of metadata-action's JSON output. Word
+        # splitting on the two $(...) substitutions is intentional —
+        # each tag and each digest must arrive as its own argv slot.
+        run: |
+          # shellcheck disable=SC2046
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf "${IMAGE_NAME}@sha256:%s " *)
+
+      - name: Inspect image
+        run: docker buildx imagetools inspect "${IMAGE_NAME}:${{ steps.meta.outputs.version }}"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,167 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: Security
+
+# Three supply-chain scans on a single workflow:
+#   - Trivy fs + image scan of the runtime image (SARIF -> Security tab)
+#   - pip-audit of the backend deps (informational)
+#   - pnpm audit of the SPA deps (informational)
+#
+# Triggered on PRs and pushes to master, plus a weekly cron so a fresh
+# CVE on an unchanged repo still surfaces within seven days.
+#
+# `actions: read` is non-obvious but required: codeql-action/upload-sarif
+# reads workflow-run metadata to attach SARIF to the right run, and
+# without it the upload fails silently with
+# "Resource not accessible by integration - workflow-runs".
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+  packages: read
+  actions: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  trivy:
+    name: Trivy (runtime image)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+
+      # Required because the published runtime image is private. If
+      # the package is later flipped to public, this step becomes a
+      # no-op but still works.
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build runtime image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: .
+          file: Dockerfile
+          target: runtime
+          load: true
+          tags: atrium:scan
+          build-args: |
+            VITE_API_BASE_URL=
+            VITE_DEFAULT_LANGUAGE=en
+            VITE_CKEDITOR_LICENSE_KEY=GPL
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Filesystem scan catches dep CVEs (uv.lock, pnpm-lock.yaml),
+      # Dockerfile / IaC misconfig, and committed secrets. Skipping
+      # node_modules and the python venv keeps the scan focused on
+      # the lockfiles + sources rather than the materialised deps.
+      - name: Trivy filesystem scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln,misconfig,secret
+          format: sarif
+          output: trivy-fs.sarif
+          ignore-unfixed: true
+          severity: HIGH,CRITICAL
+          skip-dirs: frontend/node_modules,backend/.venv
+
+      - name: Upload Trivy fs SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2
+        with:
+          sarif_file: trivy-fs.sarif
+          category: trivy-fs
+
+      # OS-package CVEs in the python:3.14-slim base + the Vite-built
+      # SPA's bundled deps. api + worker share this image, so one
+      # scan covers both runtime roles.
+      - name: Trivy image scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+        with:
+          scan-type: image
+          image-ref: atrium:scan
+          format: sarif
+          output: trivy-image.sarif
+          ignore-unfixed: true
+          severity: HIGH,CRITICAL
+
+      - name: Upload Trivy image SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2
+        with:
+          sarif_file: trivy-image.sarif
+          category: trivy-image
+
+  pip-audit:
+    name: pip-audit (backend deps)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+
+      - name: Install system deps
+        run: sudo apt-get update && sudo apt-get install -y default-libmysqlclient-dev pkg-config
+
+      - name: Sync deps
+        run: uv sync
+
+      # Non-blocking: Dependabot already proposes the fix, the audit
+      # is informational. Reports surface in the job log; SARIF
+      # upload would need a separate format conversion, not worth it
+      # while pip-audit is run as a backstop to Dependabot.
+      - name: Run pip-audit
+        run: uv run --with pip-audit pip-audit --strict --progress-spinner off || true
+
+  pnpm-audit:
+    name: pnpm audit (SPA deps)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e  # v6.0.3
+        with:
+          version: 10.33.1
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      # Non-blocking, see pip-audit comment above.
+      - name: Run pnpm audit
+        run: pnpm audit --audit-level high || true


### PR DESCRIPTION
## Summary

- Adds `security.yml`: Trivy fs + image (SARIF), pip-audit, pnpm audit on PRs and a Monday 06:00 UTC cron, plus a repo-local CodeQL config that ignores alembic migrations + tests and silences the `py/unused-global-variable` false-positive Alembic globals trigger.
- Consolidates Trivy: drops the duplicate fail-fast job in `ci.yml`; gating now flows through the auto-generated CodeQL summary check on open Code Scanning alerts.
- Splits `publish-images.yml` into a per-arch matrix on native `ubuntu-24.04` + `ubuntu-24.04-arm` runners with a manifest-merge job, replacing the qemu-emulated arm64 build that drove the ~8-min release time.
- Adds GHA build-cache to the `hello-world-e2e` runtime image build so PR re-runs reuse layers.

## Pre-flight before merge

- Confirm Code Security is enabled on the repo so SARIF uploads land as Code Scanning alerts:

  ```
  gh api -X PATCH repos/Brendan-Bank/atrium \
    -f 'security_and_analysis[code_security][status]=enabled'
  ```

## Test plan

- [ ] PR run: `Trivy (runtime image)` job uploads two SARIF categories (`trivy-fs`, `trivy-image`) visible in the Security tab.
- [ ] PR run: `pip-audit` and `pnpm audit` jobs complete (non-blocking by design).
- [ ] PR run: `Analyze (python)` and `Analyze (javascript)` jobs use the repo-local config (no flood of `py/unused-global-variable` from `backend/alembic/versions/**`).
- [ ] PR run: `compose-build` is gone; the auto-generated `CodeQL` summary check is the gate on open alerts.
- [ ] After merge + tag: `Publish image` runs `Build (linux/amd64)` on `ubuntu-24.04` and `Build (linux/arm64)` on `ubuntu-24.04-arm`; `Merge manifest` produces the multi-arch tag list. Compare wall-clock to the prior ~8 min.