### PR TITLE
Add registerNotificationKind host extension for the bell + inbox

### DIFF
--- a/docs/new-project/README.md
+++ b/docs/new-project/README.md
@@ -601,6 +601,15 @@ interface AtriumRegistry {
       | 'after-roles' | 'after-sessions' | 'before-delete';
     render: () => unknown;
   }) => void;
+  registerNotificationKind: (r: {
+    kind: string;
+    render: (n: {
+      id: number; kind: string; payload: Record<string, unknown>;
+      read_at: string | null; created_at: string;
+    }) => unknown;
+    title?: (n: { kind: string; payload: Record<string, unknown> }) => string;
+    href?: (n: { kind: string; payload: Record<string, unknown> }) => string;
+  }) => void;
 }
 
 const AtriumReact = (
@@ -930,6 +939,7 @@ Adding an endpoint, a job, a UI fragment — the standard moves:
 | Sidebar link                  | A label + path                                           | `reg.registerNavItem({ key, label, to, icon?, condition? })`               |
 | Admin tab                     | A component, gated by a permission                       | `reg.registerAdminTab({ key, label, icon?, perm, element })`               |
 | Profile-page card             | A component                                              | `reg.registerProfileItem({ key, slot?, render, condition? })`              |
+| Bell / inbox per-kind UI      | Title + (optional) detail-modal element                  | `reg.registerNotificationKind({ kind, render, title?, href? })`            |
 
 Permission gating on the API: `Depends(require_perm("your_thing.read"))`.
 

--- a/docs/new-project/SKILL.md
+++ b/docs/new-project/SKILL.md
@@ -332,6 +332,7 @@ registerRoute({ key, path, element, requireAuth?, layout? })
 registerNavItem({ key, label, to, icon?, condition? })
 registerAdminTab({ key, label, icon?, perm?, element })
 registerProfileItem({ key, slot?, render, condition? })
+registerNotificationKind({ kind, render, title?, href? })
 ```
 
 ## Hard rules

--- a/docs/published-images.md
+++ b/docs/published-images.md
@@ -228,7 +228,7 @@ and matches the schema-shaped nature of permissions.
 
 ## Frontend extension contract
 
-Atrium exposes four registries for the SPA. The host populates them at
+Atrium exposes six registries for the SPA. The host populates them at
 runtime by serving a JS bundle that atrium dynamically imports on boot.
 
 ### How the loader works
@@ -254,7 +254,7 @@ container serves it at `/host/...` (same origin as the SPA, so no CORS).
 ### The registries
 
 ```ts
-// All four exposed on window.__ATRIUM_REGISTRY__:
+// All six exposed on window.__ATRIUM_REGISTRY__:
 registerHomeWidget({ key, render })           // Card on the home page.
 registerRoute({ key, path, element,           // Adds a <Route> in the
                 requireAuth?, layout? })       //   app router.
@@ -262,6 +262,10 @@ registerNavItem({ key, label, to, icon?,      // Sidebar link.
                   condition? })
 registerAdminTab({ key, label, icon?,         // Adds a tab to /admin.
                    perm?, element })
+registerProfileItem({ key, slot?,             // Card on /profile.
+                      condition?, render })
+registerNotificationKind({ kind, render,      // Per-kind rendering for
+                           title?, href? })   //   the bell + inbox.
 ```
 
 - `registerRoute`'s `requireAuth` defaults to `true`; `layout` defaults to
@@ -272,9 +276,21 @@ registerAdminTab({ key, label, icon?,         // Adds a tab to /admin.
   permission).
 - `registerAdminTab`'s `perm` filters the tab on `me.permissions` — users
   who lack the code never see the tab in the markup.
+- `registerProfileItem`'s `slot` (default `'after-roles'`) picks where the
+  card lands in the `/profile` stack; the host owns the chrome — atrium
+  drops the rendered element straight in without wrapping.
+- `registerNotificationKind` is keyed on the notification `kind` string
+  (not a `key`). `render(n)` is invoked for the detail-modal body;
+  `title(n)` is the compact summary atrium uses for the bell list /
+  inbox row line and the modal title; `href(n)` deep-links the row
+  click into the host's UI (atrium hands the string to react-router
+  `navigate`, so keep it relative to the SPA root). `render` is the
+  only required field — atrium falls back to the kind code +
+  `JSON.stringify(payload)` when no renderer is registered, so kinds
+  without renderers keep working.
 
-Same key registered twice → last write wins, with a `console.warn`
-collision notice.
+Same key (or `kind`) registered twice → last write wins, with a
+`console.warn` collision notice.
 
 ### Building the host bundle
 
@@ -360,8 +376,9 @@ end-to-end spec.
 The example tracks `master`. If you pin your atrium image to an older
 `X.Y` tag, read the example **at the matching git tag** (`git checkout
 vX.Y.Z -- examples/hello-world/`) before copying patterns wholesale —
-slots added in later releases (e.g. `registerProfileItem` in `v0.11`)
-will be present at HEAD but missing from older images. The frontend
+slots added in later releases (e.g. `registerProfileItem` in `v0.11`,
+`registerNotificationKind` in `v0.12`) will be present at HEAD but
+missing from older images. The frontend
 registry catches calls to unknown methods and logs a console warning
 instead of throwing, so a bundle built against a newer atrium degrades
 gracefully (the rest of its registrations still land); the unknown slot

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -18,6 +18,9 @@ is lying.
 | `registerRoute`                | Dedicated `/hello` page                              |
 | `registerNavItem`              | Sidebar link                                         |
 | `registerAdminTab`             | Admin tab gated by `hello.toggle`                    |
+| `registerProfileItem`          | Toggle card on `/profile`                            |
+| `registerNotificationKind`     | Bell + inbox renderer for `hello.toggled`            |
+| `notify_user`                  | Backend writes a `hello.toggled` notification on toggle |
 
 ## Layout
 

--- a/examples/hello-world/backend/src/atrium_hello_world/router.py
+++ b/examples/hello-world/backend/src/atrium_hello_world/router.py
@@ -20,6 +20,7 @@ from app.auth.users import current_user
 from app.db import get_session
 from app.models.auth import User
 from app.services.audit import record as record_audit
+from app.services.notifications import notify_user
 
 from .models import HelloState
 
@@ -79,6 +80,18 @@ async def toggle(
         entity_id=state.id,
         action="toggle",
         diff={"enabled": {"before": before, "after": body.enabled}},
+    )
+    # Demonstrates the registerNotificationKind extension slot — the
+    # host bundle's HelloNotification renderer picks this up.
+    notify_user(
+        session,
+        user_id=user.id,
+        kind="hello.toggled",
+        payload={
+            "enabled": body.enabled,
+            "counter": state.counter,
+            "actor_user_id": user.id,
+        },
     )
     await session.commit()
     return StateOut(

--- a/examples/hello-world/frontend/src/HelloNotification.tsx
+++ b/examples/hello-world/frontend/src/HelloNotification.tsx
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+/**
+ * Per-kind notification renderer registered by the Hello World host
+ * bundle.
+ *
+ * Demonstrates the ``registerNotificationKind`` extension point.
+ * Atrium emits ``{kind, payload}`` rows but ships no built-in
+ * formatting; the host names the kinds it cares about and decides
+ * what each one looks like in the bell + inbox.
+ *
+ * The bundle registers a renderer for ``hello.toggled`` (the kind
+ * the backend writes when the Hello World counter is flipped).
+ * Atrium calls:
+ *
+ *   - ``title(n)``     → the row line + modal title
+ *   - ``render(n)``    → the detail-modal body
+ *   - ``href(n)``      → omitted here; clicking the row opens the
+ *                        modal so visitors can see the rich render
+ *
+ * Atrium is unchanged for any kind we don't claim — the fallback
+ * raw-payload modal still renders for unregistered kinds.
+ */
+import {
+  Badge,
+  Group,
+  MantineProvider,
+  Paper,
+  Stack,
+  Text,
+} from '@mantine/core';
+
+interface HelloToggledPayload {
+  enabled?: boolean;
+  counter?: number;
+  actor_user_id?: number;
+}
+
+export function helloToggledTitle(n: { payload: Record<string, unknown> }): string {
+  const payload = n.payload as HelloToggledPayload;
+  const verb = payload.enabled ? 'enabled' : 'disabled';
+  return `Hello World ${verb} (counter: ${payload.counter ?? '?'})`;
+}
+
+function HelloToggledNotificationInner({
+  payload,
+  createdAt,
+}: {
+  payload: HelloToggledPayload;
+  createdAt: string;
+}) {
+  return (
+    <Paper withBorder p="md" radius="md" data-testid="hello-notification">
+      <Stack gap="xs">
+        <Group justify="space-between" align="center">
+          <Text fw={500}>Hello World counter</Text>
+          <Badge color={payload.enabled ? 'teal' : 'gray'} variant="light">
+            {payload.enabled ? 'enabled' : 'disabled'}
+          </Badge>
+        </Group>
+        <Text size="sm">
+          Counter is now <strong>{payload.counter ?? '?'}</strong>.
+        </Text>
+        <Text size="xs" c="dimmed">
+          Toggled by user #{payload.actor_user_id ?? '?'} ·{' '}
+          {new Date(
+            createdAt + (createdAt.endsWith('Z') ? '' : 'Z'),
+          ).toLocaleString()}
+        </Text>
+      </Stack>
+    </Paper>
+  );
+}
+
+export function HelloToggledNotification({
+  payload,
+  createdAt,
+}: {
+  payload: HelloToggledPayload;
+  createdAt: string;
+}) {
+  return (
+    <MantineProvider>
+      <HelloToggledNotificationInner payload={payload} createdAt={createdAt} />
+    </MantineProvider>
+  );
+}

--- a/examples/hello-world/frontend/src/main.tsx
+++ b/examples/hello-world/frontend/src/main.tsx
@@ -23,6 +23,18 @@ import { HelloAdminTab } from './HelloAdminTab';
 import { HelloPage } from './HelloPage';
 import { HelloProfileItem } from './HelloProfileItem';
 import { HelloWidget } from './HelloWidget';
+import {
+  HelloToggledNotification,
+  helloToggledTitle,
+} from './HelloNotification';
+
+interface HostNotification {
+  id: number;
+  kind: string;
+  payload: Record<string, unknown>;
+  read_at: string | null;
+  created_at: string;
+}
 
 interface AtriumRegistry {
   registerHomeWidget: (w: { key: string; render: () => unknown }) => void;
@@ -56,6 +68,12 @@ interface AtriumRegistry {
       | 'after-sessions'
       | 'before-delete';
     render: () => unknown;
+  }) => void;
+  registerNotificationKind: (r: {
+    kind: string;
+    render: (n: HostNotification) => unknown;
+    title?: (n: HostNotification) => string;
+    href?: (n: HostNotification) => string;
   }) => void;
 }
 
@@ -129,5 +147,16 @@ if (!reg) {
     key: 'hello-profile',
     slot: 'after-roles',
     render: () => makeWrapperElement(<HelloProfileItem />),
+  });
+  reg.registerNotificationKind({
+    kind: 'hello.toggled',
+    title: helloToggledTitle,
+    render: (n) =>
+      makeWrapperElement(
+        <HelloToggledNotification
+          payload={n.payload}
+          createdAt={n.created_at}
+        />,
+      ),
   });
 }

--- a/frontend/src/components/NotificationsBell.tsx
+++ b/frontend/src/components/NotificationsBell.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Brendan Bank
 // SPDX-License-Identifier: BSD-2-Clause
 
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import {
   ActionIcon,
   Badge,
@@ -19,7 +19,9 @@ import {
 } from '@mantine/core';
 import { IconBell, IconCheck, IconX } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 
+import { lookupNotificationRenderer } from '@/host/registry';
 import { useMe } from '@/hooks/useAuth';
 import {
   useDeleteNotification,
@@ -54,13 +56,33 @@ export function NotificationsBell() {
   const markRead = useMarkRead();
   const markAllRead = useMarkAllRead();
   const delNotif = useDeleteNotification();
+  const navigate = useNavigate();
   const [opened, setOpened] = useState(false);
   const [payloadOpen, setPayloadOpen] = useState<AppNotification | null>(null);
 
   const handleNotifClick = (n: AppNotification) => {
     if (n.read_at === null) markRead.mutate(n.id);
-    setPayloadOpen(n);
     setOpened(false);
+    // A registered href short-circuits the modal: the host wants the
+    // click to deep-link into their own UI, not show the raw payload.
+    const renderer = lookupNotificationRenderer(n.kind);
+    let href: string | undefined;
+    if (renderer?.href) {
+      try {
+        href = renderer.href(n);
+      } catch (err) {
+        console.warn(
+          `[atrium] notification href() for kind "${n.kind}" threw; ` +
+            `opening detail modal instead`,
+          err,
+        );
+      }
+    }
+    if (href) {
+      navigate(href);
+    } else {
+      setPayloadOpen(n);
+    }
   };
 
   // Subscribe to the SSE stream while the user is logged in; EventSource
@@ -198,14 +220,37 @@ export function NotificationPayloadModal({
   onClose: () => void;
 }) {
   const { t } = useTranslation();
-  return (
-    <Modal
-      opened={notif !== null}
-      onClose={onClose}
-      title={notif?.kind ?? ''}
-      size="lg"
-    >
-      {notif && (
+  const renderer = notif ? lookupNotificationRenderer(notif.kind) : undefined;
+
+  let title = notif?.kind ?? '';
+  if (notif && renderer?.title) {
+    try {
+      title = renderer.title(notif);
+    } catch (err) {
+      console.warn(
+        `[atrium] notification title() for kind "${notif.kind}" threw; ` +
+          `falling back to kind code`,
+        err,
+      );
+    }
+  }
+
+  let body: ReactNode = null;
+  if (notif) {
+    if (renderer) {
+      try {
+        body = renderer.render(notif);
+      } catch (err) {
+        console.warn(
+          `[atrium] notification render() for kind "${notif.kind}" threw; ` +
+            `falling back to raw payload`,
+          err,
+        );
+        body = null;
+      }
+    }
+    if (body === null) {
+      body = (
         <Stack>
           <Text size="xs" c="dimmed">
             {t('notifs.payloadHint')}
@@ -222,7 +267,13 @@ export function NotificationPayloadModal({
             {JSON.stringify(notif.payload, null, 2)}
           </Code>
         </Stack>
-      )}
+      );
+    }
+  }
+
+  return (
+    <Modal opened={notif !== null} onClose={onClose} title={title} size="lg">
+      {body}
     </Modal>
   );
 }

--- a/frontend/src/host/registry.ts
+++ b/frontend/src/host/registry.ts
@@ -5,10 +5,10 @@
  * Atrium host-extension registry.
  *
  * Atrium ships only the platform shell. Host applications inject their
- * own UI fragments via five registries — home widgets, routes, nav
- * items, admin tabs, and profile items — populated at SPA boot from a
- * runtime-loaded host bundle (see ``main.tsx`` and
- * ``system.host_bundle_url``).
+ * own UI fragments via six registries — home widgets, routes, nav
+ * items, admin tabs, profile items, and notification renderers —
+ * populated at SPA boot from a runtime-loaded host bundle (see
+ * ``main.tsx`` and ``system.host_bundle_url``).
  *
  * The registries are deliberately thin: each one is an array, ordered
  * by registration call order, and the consumer components iterate
@@ -28,6 +28,7 @@
 import type { ReactElement } from 'react';
 
 import type { CurrentUser } from '@/lib/auth';
+import type { AppNotification } from '@/hooks/useNotifications';
 
 /** Layout width for a home-page widget. ``narrow`` matches the default
  *  680px column atrium ships for the welcome content; ``wide`` extends
@@ -97,11 +98,52 @@ export type ProfileItem = {
   render: () => ReactElement;
 };
 
+/** Per-kind renderer for a notification row. Atrium emits
+ *  ``{kind, payload}`` rows but ships no built-in formatting — each
+ *  host app registers a renderer for the kinds it cares about. The
+ *  bell + inbox fall back to ``kind`` + raw-JSON payload for any kind
+ *  with no registered renderer.
+ *
+ *  Atrium calls the helpers in three places:
+ *
+ *  - bell list line / inbox row body → ``title(n)`` if provided,
+ *    otherwise ``n.kind``. ``render`` is *not* invoked per row;
+ *    list rendering is intentionally a string lookup so a long inbox
+ *    isn't a per-row React tree.
+ *  - row click / "View" → ``href(n)`` if provided is passed to
+ *    react-router ``navigate``; otherwise atrium opens the detail
+ *    modal.
+ *  - detail modal body → ``render(n)`` element if provided,
+ *    otherwise the fallback ``<pre>`` of ``JSON.stringify(payload)``.
+ *
+ *  The ``render`` element follows the same wrapper-element contract
+ *  as ``HomeWidget.render`` / ``RouteEntry.element``: it's an
+ *  atrium-React element, typically a ``<div>`` whose ``ref`` mounts
+ *  the host's React tree inside.
+ */
+export type NotificationKindRenderer = {
+  /** Notification ``kind`` string this renderer handles. Match is
+   *  exact; no glob / prefix matching. Duplicate registrations for
+   *  the same kind warn and last-write-wins. */
+  kind: string;
+  /** Detail-modal body. Receives the full notification row. */
+  render: (n: AppNotification) => ReactElement;
+  /** Compact summary for the bell + inbox row (and the modal title).
+   *  Plain string so the list iterates cheaply. */
+  title?: (n: AppNotification) => string;
+  /** App-internal href for the row click. Passed to react-router
+   *  ``navigate`` — keep it relative to the SPA root (e.g.
+   *  ``/calendar?focus=block:1``). When set, the row click navigates
+   *  instead of opening the detail modal. */
+  href?: (n: AppNotification) => string;
+};
+
 const homeWidgets: HomeWidget[] = [];
 const routes: RouteEntry[] = [];
 const navItems: NavItem[] = [];
 const adminTabs: AdminTab[] = [];
 const profileItems: ProfileItem[] = [];
+const notificationRenderers: NotificationKindRenderer[] = [];
 
 function registerHomeWidget(widget: HomeWidget): void {
   if (homeWidgets.some((w) => w.key === widget.key)) {
@@ -163,12 +205,27 @@ function registerProfileItem(item: ProfileItem): void {
   profileItems.push(item);
 }
 
+function registerNotificationKind(renderer: NotificationKindRenderer): void {
+  if (notificationRenderers.some((r) => r.kind === renderer.kind)) {
+    console.warn(
+      `[atrium-registry] duplicate notification renderer kind "${renderer.kind}"; ` +
+        `last registration wins`,
+    );
+    const idx = notificationRenderers.findIndex(
+      (r) => r.kind === renderer.kind,
+    );
+    notificationRenderers.splice(idx, 1);
+  }
+  notificationRenderers.push(renderer);
+}
+
 const baseRegistry = {
   registerHomeWidget,
   registerRoute,
   registerNavItem,
   registerAdminTab,
   registerProfileItem,
+  registerNotificationKind,
 } as const;
 
 export type AtriumRegistry = typeof baseRegistry;
@@ -221,6 +278,19 @@ export function getProfileItems(): readonly ProfileItem[] {
   return profileItems;
 }
 
+export function getNotificationRenderers(): readonly NotificationKindRenderer[] {
+  return notificationRenderers;
+}
+
+/** Look up the renderer for a single notification kind. Returns
+ *  ``undefined`` when no host has registered for it; callers fall
+ *  back to atrium's generic kind+JSON rendering. */
+export function lookupNotificationRenderer(
+  kind: string,
+): NotificationKindRenderer | undefined {
+  return notificationRenderers.find((r) => r.kind === kind);
+}
+
 /** Test-only: drop every registration. Production code never calls
  *  this — host bundles register once at boot and stay. */
 export function __resetRegistryForTests(): void {
@@ -229,6 +299,7 @@ export function __resetRegistryForTests(): void {
   navItems.length = 0;
   adminTabs.length = 0;
   profileItems.length = 0;
+  notificationRenderers.length = 0;
 }
 
 declare global {
@@ -247,4 +318,5 @@ export {
   registerNavItem,
   registerAdminTab,
   registerProfileItem,
+  registerNotificationKind,
 };

--- a/frontend/src/lib/notifications.ts
+++ b/frontend/src/lib/notifications.ts
@@ -1,13 +1,31 @@
 // Copyright (c) 2026 Brendan Bank
 // SPDX-License-Identifier: BSD-2-Clause
 
+import { lookupNotificationRenderer } from '@/host/registry';
 import type { AppNotification } from '@/hooks/useNotifications';
 
-/** Atrium ships a kind-agnostic notification renderer. The backend
- *  emits `{kind, payload}` rows; host apps pick which kinds to show
- *  prettily, and everything else falls through to this generic
- *  rendering of the kind code plus a "View" affordance for the raw
- *  payload. Override by re-exporting your own version from this path. */
+/** Compact summary string for the bell list / inbox row.
+ *
+ *  Atrium ships a kind-agnostic fallback: each row shows the raw
+ *  ``kind`` code. Host apps swap in friendlier per-kind text by
+ *  registering ``__ATRIUM_REGISTRY__.registerNotificationKind({ kind,
+ *  title, ... })`` — when a renderer is registered with a ``title``
+ *  helper, atrium calls it here. The detail-modal body uses
+ *  ``render`` (a full React element); this row helper deliberately
+ *  stays string-only so the inbox iterates cheaply. */
 export function renderNotificationBody(n: AppNotification): string {
+  const title = lookupNotificationRenderer(n.kind)?.title;
+  if (title) {
+    try {
+      return title(n);
+    } catch (err) {
+      // A bad host renderer must not poison the whole bell list.
+      console.warn(
+        `[atrium] notification title() for kind "${n.kind}" threw; ` +
+          `falling back to kind code`,
+        err,
+      );
+    }
+  }
   return n.kind;
 }

--- a/frontend/src/routes/NotificationsPage.tsx
+++ b/frontend/src/routes/NotificationsPage.tsx
@@ -17,8 +17,10 @@ import {
 } from '@mantine/core';
 import { IconCheck, IconTrash } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 
 import { NotificationPayloadModal } from '@/components/NotificationsBell';
+import { lookupNotificationRenderer } from '@/host/registry';
 import { renderNotificationBody } from '@/lib/notifications';
 import {
   useDeleteNotification,
@@ -44,13 +46,31 @@ export function NotificationsPage() {
   const markRead = useMarkRead();
   const markAllRead = useMarkAllRead();
   const delNotif = useDeleteNotification();
+  const navigate = useNavigate();
   const [payloadOpen, setPayloadOpen] = useState<AppNotification | null>(null);
 
   const unreadCount = list.filter((n) => n.read_at === null).length;
 
   const view = (n: AppNotification) => {
     if (n.read_at === null) markRead.mutate(n.id);
-    setPayloadOpen(n);
+    const renderer = lookupNotificationRenderer(n.kind);
+    let href: string | undefined;
+    if (renderer?.href) {
+      try {
+        href = renderer.href(n);
+      } catch (err) {
+        console.warn(
+          `[atrium] notification href() for kind "${n.kind}" threw; ` +
+            `opening detail modal instead`,
+          err,
+        );
+      }
+    }
+    if (href) {
+      navigate(href);
+    } else {
+      setPayloadOpen(n);
+    }
   };
 
   if (isLoading) {

--- a/frontend/src/test/host-registry.test.tsx
+++ b/frontend/src/test/host-registry.test.tsx
@@ -2,16 +2,18 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 /**
- * Vitest coverage for the four host extension registries.
+ * Vitest coverage for the host extension registries.
  *
  * The registries are module-level state, so each test resets via the
  * exposed ``__resetRegistryForTests`` to avoid bleed between cases.
  *
  * Behaviour pinned down here:
  *  - register* push entries that get* return in registration order.
- *  - duplicate ``key`` for the same registry replaces the prior entry
- *    rather than double-counting.
+ *  - duplicate ``key`` (or ``kind`` for notifications) replaces the
+ *    prior entry rather than double-counting.
  *  - ``registerRoute`` warns on path collisions (last-write-wins).
+ *  - ``lookupNotificationRenderer`` returns the registered entry for
+ *    a kind, ``undefined`` otherwise.
  *  - the global ``window.__ATRIUM_REGISTRY__`` is bound to the same
  *    underlying state as the typed ``register*`` exports — host
  *    bundles loaded at runtime use the global, in-tree code uses the
@@ -25,14 +27,29 @@ import {
   getAdminTabs,
   getHomeWidgets,
   getNavItems,
+  getNotificationRenderers,
   getProfileItems,
   getRoutes,
+  lookupNotificationRenderer,
   registerAdminTab,
   registerHomeWidget,
   registerNavItem,
+  registerNotificationKind,
   registerProfileItem,
   registerRoute,
 } from '@/host/registry';
+import type { AppNotification } from '@/hooks/useNotifications';
+
+const sampleNotification = (
+  overrides: Partial<AppNotification> = {},
+): AppNotification => ({
+  id: 1,
+  kind: 'sample.kind',
+  payload: {},
+  read_at: null,
+  created_at: '2026-01-01T00:00:00Z',
+  ...overrides,
+});
 
 describe('host registry', () => {
   beforeEach(() => {
@@ -150,6 +167,78 @@ describe('host registry', () => {
     } finally {
       warn.mockRestore();
     }
+  });
+
+  it('registerNotificationKind appends entries that getNotificationRenderers returns', () => {
+    registerNotificationKind({
+      kind: 'block.updated',
+      render: () => <span>block</span>,
+    });
+    registerNotificationKind({
+      kind: 'booking.created',
+      render: () => <span>booking</span>,
+    });
+    const entries = getNotificationRenderers();
+    expect(entries.map((r) => r.kind)).toEqual([
+      'block.updated',
+      'booking.created',
+    ]);
+  });
+
+  it('registerNotificationKind carries optional title and href through', () => {
+    registerNotificationKind({
+      kind: 'block.updated',
+      render: () => <span>block</span>,
+      title: (n) => `Block ${(n.payload.block_id as number) ?? '?'} updated`,
+      href: (n) => `/calendar?focus=block:${n.payload.block_id ?? ''}`,
+    });
+    registerNotificationKind({
+      kind: 'minimal.kind',
+      render: () => <span>minimal</span>,
+    });
+    const block = lookupNotificationRenderer('block.updated');
+    expect(
+      block?.title?.(sampleNotification({ payload: { block_id: 7 } })),
+    ).toBe('Block 7 updated');
+    expect(
+      block?.href?.(sampleNotification({ payload: { block_id: 7 } })),
+    ).toBe('/calendar?focus=block:7');
+    const minimal = lookupNotificationRenderer('minimal.kind');
+    expect(minimal?.title).toBeUndefined();
+    expect(minimal?.href).toBeUndefined();
+  });
+
+  it('registerNotificationKind replaces on duplicate kind with a warning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      registerNotificationKind({
+        kind: 'block.updated',
+        render: () => <span>first</span>,
+      });
+      registerNotificationKind({
+        kind: 'block.updated',
+        render: () => <span>second</span>,
+      });
+      const entries = getNotificationRenderers();
+      expect(entries).toHaveLength(1);
+      // The whole point of last-write-wins is that the second renderer
+      // is the live one — exercise it via the lookup.
+      const found = lookupNotificationRenderer('block.updated');
+      const element = found?.render(sampleNotification());
+      const props = element?.props as { children?: string };
+      expect(props?.children).toBe('second');
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('lookupNotificationRenderer returns undefined for an unregistered kind', () => {
+    registerNotificationKind({
+      kind: 'block.updated',
+      render: () => <span>block</span>,
+    });
+    expect(lookupNotificationRenderer('not.a.kind')).toBeUndefined();
   });
 
   it('__ATRIUM_REGISTRY__ logs a warning for unknown register* methods without throwing', () => {


### PR DESCRIPTION
## Summary

- Adds a sixth host-extension registry — `registerNotificationKind({ kind, render, title?, href? })` — so host bundles can pretty-print bell/inbox rows for kinds they care about. `title(n)` drives the row line + modal title, `render(n)` replaces the JSON-dump modal body, `href(n)` deep-links the row click via react-router. Unregistered kinds keep the existing fallback so older bundles see no regression.
- Wires the lookup into `NotificationsBell` + `NotificationsPage` (with try/catch around each host call so a faulty renderer can't poison the bell), updates `docs/published-images.md` + the `new-project` walkthrough, and exercises the slot end-to-end in Hello World — `HelloNotification.tsx` registers `hello.toggled`, and the backend toggle endpoint now writes a matching `notify_user` row.

## Test plan

- [x] `pnpm typecheck` (atrium frontend + hello-world bundle)
- [x] `pnpm test` — 23 vitest cases pass, including four new ones for the registry (append, optional title/href passthrough, duplicate-kind warn-and-replace, lookup helper)
- [x] `pnpm build` of the hello-world host bundle
- [ ] Manual smoke: load the hello-world bundle, flip the toggle, confirm the bell shows "Hello World enabled (counter: N)" and the modal renders the Mantine card