### PR TITLE
Lowercase IMAGE_NAME in publish-images so GHCR accepts the ref

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -41,8 +41,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
-env:
-  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/atrium
+# IMAGE_NAME is computed per-job from ``github.repository_owner``
+# lowercased. The owner login can contain uppercase characters
+# (e.g. ``Brendan-Bank``) but GHCR refs are case-sensitive and reject
+# anything that isn't all-lowercase. ``docker/metadata-action`` is
+# tolerant — it normalises internally — but the per-arch refactor
+# also feeds the name straight into ``build-push-action``'s
+# ``outputs:`` ref and the merge step's ``printf``, neither of which
+# normalise. Computing once into ``$GITHUB_ENV`` keeps every later
+# reference consistent and avoids stamping a mixed-case ref into the
+# push.
 
 jobs:
   build:
@@ -57,10 +65,13 @@ jobs:
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
     steps:
-      - name: Resolve platform pair
+      - name: Resolve image name + platform pair
         # buildx artifact names can't contain slashes; turn linux/amd64
         # into linux-amd64 for the digest artifact name + cache scope.
+        # ``${var,,}`` is bash's lowercase parameter expansion.
         run: |
+          owner="${{ github.repository_owner }}"
+          echo "IMAGE_NAME=ghcr.io/${owner,,}/atrium" >> "$GITHUB_ENV"
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
 
@@ -115,6 +126,11 @@ jobs:
     needs: build
     runs-on: ubuntu-24.04
     steps:
+      - name: Resolve image name
+        run: |
+          owner="${{ github.repository_owner }}"
+          echo "IMAGE_NAME=ghcr.io/${owner,,}/atrium" >> "$GITHUB_ENV"
+
       - name: Download digests
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary

- The per-arch refactor in #24 fed `IMAGE_NAME` into `build-push-action`'s `outputs:` ref and the merge step's `printf`, both of which pass the ref straight to Docker buildx. `github.repository_owner` is `Brendan-Bank` (mixed case) and GHCR rejects non-lowercase refs, so the v0.11.2 publish failed with `invalid reference format … must be lowercase`. v0.11.0 / v0.11.1 worked because the single-job workflow only used the name through `docker/metadata-action`, which normalises case internally.
- Computes `IMAGE_NAME` at the top of each job via bash's `${var,,}` lowercase expansion so every later reference sees the same all-lowercase ref.

## Test plan

- [x] Diff inspected — both `build` and `merge` jobs now resolve `IMAGE_NAME` from `${owner,,}` before any step that uses it.
- [ ] On merge, re-run publish-images on the v0.11.2 tag via `gh workflow run publish-images.yml -f ref=v0.11.2` to confirm the manifest lands at `ghcr.io/brendan-bank/atrium:0.11.2` (and `0.11`, `0`, `latest`).