### PR TITLE
Typed SSE events + auto-hide HomePage intro on host widgets

### DIFF
--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -4,8 +4,9 @@
 """In-app notification helper.
 
 Writes a `notifications` row and pokes the user's SSE channel via
-`event_hub` so the bell refetches. Caller controls the transaction —
-this just `session.add`s.
+`event_hub` so the bell refetches and host bundles can route the
+typed event to selective React Query cache invalidations. Caller
+controls the transaction — this just `session.add`s.
 """
 from __future__ import annotations
 
@@ -24,9 +25,12 @@ def notify_user(
     kind: str,
     payload: dict[str, Any],
 ) -> None:
-    """Add a notification row and publish a refresh event.
+    """Add a notification row and publish the matching SSE event.
 
-    `kind` is a free-form string; the UI maps it to a presentation.
+    The published event mirrors the row: ``{"kind": kind, "payload":
+    payload}``. The bell refetches on every event regardless of kind;
+    host bundles use the kind to invalidate only their own affected
+    query keys instead of fanning out a broad refresh.
     """
     session.add(Notification(user_id=user_id, kind=kind, payload=payload))
-    hub.publish(user_id, {"kind": "refresh"})
+    hub.publish(user_id, {"kind": kind, "payload": payload})

--- a/backend/tests/api/test_notifications.py
+++ b/backend/tests/api/test_notifications.py
@@ -6,14 +6,15 @@
 Atrium ships:
 
 - ``services.notifications.notify_user`` — slim helper: add a row,
-  publish a refresh event on the SSE pub/sub.
+  publish the matching ``{kind, payload}`` event on the SSE pub/sub.
 - ``/notifications`` — list, unread count, mark-read, mark-all-read,
   delete, SSE stream.
 
 Tests verify the helper writes through the active session, that
 endpoints are scoped to the calling user (no cross-user leakage), and
-that the helper publishes to the in-process ``event_hub`` so the SSE
-bell refetches.
+that the helper publishes the typed event on the in-process
+``event_hub`` so the SSE bell refetches and host bundles can route on
+the kind.
 """
 from __future__ import annotations
 
@@ -57,9 +58,11 @@ async def test_notify_user_writes_row_and_publishes_event(client, engine):
             assert row.payload == {"hello": "there"}
             assert row.read_at is None
 
-        # The helper also pokes event_hub so the SSE bell refetches.
+        # The helper also pokes event_hub so the SSE bell refetches and
+        # host bundles can route the typed event to selective query
+        # invalidations. The published payload mirrors the row.
         event = await queue.get()
-        assert event == {"kind": "refresh"}
+        assert event == {"kind": "welcome", "payload": {"hello": "there"}}
     finally:
         hub.unsubscribe(admin.id, queue)
 

--- a/docs/new-project/README.md
+++ b/docs/new-project/README.md
@@ -610,6 +610,10 @@ interface AtriumRegistry {
     title?: (n: { kind: string; payload: Record<string, unknown> }) => string;
     href?: (n: { kind: string; payload: Record<string, unknown> }) => string;
   }) => void;
+  subscribeEvent: (
+    kind: string,
+    handler: (event: { kind: string; payload: Record<string, unknown> }) => void,
+  ) => () => void;
 }
 
 const AtriumReact = (
@@ -940,6 +944,7 @@ Adding an endpoint, a job, a UI fragment — the standard moves:
 | Admin tab                     | A component, gated by a permission                       | `reg.registerAdminTab({ key, label, icon?, perm, element })`               |
 | Profile-page card             | A component                                              | `reg.registerProfileItem({ key, slot?, render, condition? })`              |
 | Bell / inbox per-kind UI      | Title + (optional) detail-modal element                  | `reg.registerNotificationKind({ kind, render, title?, href? })`            |
+| Selective React Query refresh | Handler that invalidates the host's affected query keys  | `reg.subscribeEvent('your.kind', (evt) => qc.invalidateQueries({...}))`    |
 
 Permission gating on the API: `Depends(require_perm("your_thing.read"))`.
 

--- a/docs/new-project/SKILL.md
+++ b/docs/new-project/SKILL.md
@@ -333,6 +333,7 @@ registerNavItem({ key, label, to, icon?, condition? })
 registerAdminTab({ key, label, icon?, perm?, element })
 registerProfileItem({ key, slot?, render, condition? })
 registerNotificationKind({ kind, render, title?, href? })
+subscribeEvent(kind, (evt) => { /* qc.invalidateQueries(...) */ })
 ```
 
 ## Hard rules

--- a/docs/published-images.md
+++ b/docs/published-images.md
@@ -254,7 +254,8 @@ container serves it at `/host/...` (same origin as the SPA, so no CORS).
 ### The registries
 
 ```ts
-// All six exposed on window.__ATRIUM_REGISTRY__:
+// All six render-time registries plus the SSE event tap, exposed
+// on window.__ATRIUM_REGISTRY__:
 registerHomeWidget({ key, render })           // Card on the home page.
 registerRoute({ key, path, element,           // Adds a <Route> in the
                 requireAuth?, layout? })       //   app router.
@@ -266,6 +267,9 @@ registerProfileItem({ key, slot?,             // Card on /profile.
                       condition?, render })
 registerNotificationKind({ kind, render,      // Per-kind rendering for
                            title?, href? })   //   the bell + inbox.
+subscribeEvent(kind, handler)                 // Tap into atrium's
+                                              //   SSE stream; handler
+                                              //   receives {kind,payload}.
 ```
 
 - `registerRoute`'s `requireAuth` defaults to `true`; `layout` defaults to
@@ -288,9 +292,31 @@ registerNotificationKind({ kind, render,      // Per-kind rendering for
   only required field — atrium falls back to the kind code +
   `JSON.stringify(payload)` when no renderer is registered, so kinds
   without renderers keep working.
+- `subscribeEvent(kind, handler)` taps atrium's single
+  `EventSource('/notifications/stream')`. The handler fires whenever a
+  matching notification lands and receives `{ kind, payload }` —
+  exactly the row's typed body, the same shape `registerNotificationKind`'s
+  renderer sees. Returns an `unsubscribe` function; host bundles
+  usually subscribe once at import time and never unsubscribe (the
+  connection stays open while the user is logged in). The typical
+  use is host-side React Query invalidation:
+  ```ts
+  reg.subscribeEvent('booking.created', () => {
+    queryClient.invalidateQueries({ queryKey: ['bookings'] });
+    queryClient.invalidateQueries({ queryKey: ['calendar'] });
+  });
+  ```
+  One connection per tab is shared between atrium's bell and every
+  host subscriber — there is no second `EventSource` to manage. The
+  bell still refetches on every event regardless of kind, so the
+  helper is purely for **selective** host invalidation; subscribing
+  is optional.
 
 Same key (or `kind`) registered twice → last write wins, with a
-`console.warn` collision notice.
+`console.warn` collision notice. `subscribeEvent` is a different
+shape (no key, returns an unsubscribe handle) and follows
+register-once-then-stay semantics — a duplicate subscription with
+the same handler reference is a silent no-op.
 
 ### Building the host bundle
 

--- a/examples/hello-world/frontend/src/main.tsx
+++ b/examples/hello-world/frontend/src/main.tsx
@@ -27,6 +27,7 @@ import {
   HelloToggledNotification,
   helloToggledTitle,
 } from './HelloNotification';
+import { queryClient } from './queryClient';
 
 interface HostNotification {
   id: number;
@@ -34,6 +35,11 @@ interface HostNotification {
   payload: Record<string, unknown>;
   read_at: string | null;
   created_at: string;
+}
+
+interface AtriumEvent {
+  kind: string;
+  payload: Record<string, unknown>;
 }
 
 interface AtriumRegistry {
@@ -75,6 +81,10 @@ interface AtriumRegistry {
     title?: (n: HostNotification) => string;
     href?: (n: HostNotification) => string;
   }) => void;
+  subscribeEvent: (
+    kind: string,
+    handler: (event: AtriumEvent) => void,
+  ) => () => void;
 }
 
 /** atrium's React, exposed at ``window.React`` by atrium's main.tsx
@@ -158,5 +168,14 @@ if (!reg) {
           createdAt={n.created_at}
         />,
       ),
+  });
+  // Subscribe to the typed SSE event so the widget refreshes the
+  // moment another tab (or another user) flips the toggle, instead
+  // of waiting for the 5s polling interval. The QueryClient here is
+  // the host bundle's own — atrium's bell uses its own client and
+  // refetches independently. See ``queryClient.ts``: ``refetchInterval``
+  // is now off, the SSE stream owns freshness.
+  reg.subscribeEvent('hello.toggled', () => {
+    queryClient.invalidateQueries({ queryKey: ['hello', 'state'] });
   });
 }

--- a/examples/hello-world/frontend/src/queryClient.ts
+++ b/examples/hello-world/frontend/src/queryClient.ts
@@ -6,12 +6,17 @@ import { QueryClient } from '@tanstack/react-query';
 /** Single QueryClient shared across the home widget, the dedicated
  *  page, and the admin tab. Each one wraps its element in a
  *  QueryClientProvider that points at this client so they share the
- *  cache for ``['hello', 'state']``. */
+ *  cache for ``['hello', 'state']``.
+ *
+ *  Freshness is driven by the SSE event bus, not a polling interval —
+ *  ``main.tsx`` calls ``subscribeEvent('hello.toggled', ...)`` which
+ *  invalidates this client the moment a toggle lands. ``staleTime``
+ *  bounds how long a fresh fetch is reused for sibling components
+ *  mounting back-to-back. */
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 2_000,
-      refetchInterval: 5_000,
       retry: 1,
     },
   },

--- a/examples/hello-world/frontend/tests-e2e/hello-world.spec.ts
+++ b/examples/hello-world/frontend/tests-e2e/hello-world.spec.ts
@@ -92,6 +92,23 @@ test.describe('hello-world example', () => {
     await expect(card.getByTestId('hello-toggle')).toBeVisible();
   });
 
+  test('starter intro is hidden when a host home widget is registered', async ({
+    page,
+  }) => {
+    // The integrator-onboarding line ("This is the Atrium starter
+    // shell...") is noise once a host has shipped its own home widget.
+    // The intro should not render on a page where the hello-world
+    // widget mounts.
+    await loginAsSuperAdmin(page);
+    await page.goto('/');
+    await expect(page.getByTestId('hello-card')).toBeVisible();
+    await expect(
+      page.getByText(
+        'This is the Atrium starter shell. Hook your domain pages onto the routes from here.',
+      ),
+    ).toHaveCount(0);
+  });
+
   test('nav item appears in the sidebar', async ({ page }) => {
     await loginAsSuperAdmin(page);
     await page.goto('/');

--- a/frontend/src/hooks/useNotificationStream.ts
+++ b/frontend/src/hooks/useNotificationStream.ts
@@ -4,15 +4,28 @@
 import { useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 
+import { dispatchAtriumEvent, parseAtriumEvent } from '@/host/events';
 import { NOTIFS_LIST_KEY, NOTIFS_UNREAD_KEY } from './useNotifications';
 
 /**
- * Subscribe to the notifications SSE stream and invalidate the bell's
- * React Query caches whenever a push arrives. EventSource handles
- * auto-reconnect on network blips — no manual retry needed.
+ * Subscribe to the notifications SSE stream.
  *
- * The stream reuses the JWT httpOnly cookie for auth because
- * `EventSource` sends credentials same-origin automatically.
+ * Atrium owns one ``EventSource('/notifications/stream')`` per tab —
+ * this hook is the owner. Two responsibilities, one connection:
+ *
+ *  - Refresh the bell. The bell unconditionally invalidates its list
+ *    + unread-count queries on every push, regardless of kind. The
+ *    presence of an event is the signal; the row content is fetched
+ *    out of band.
+ *  - Fan the typed event out to host subscribers via the event bus
+ *    in ``host/events.ts``. Hosts call ``subscribeEvent(kind, fn)``
+ *    on the host-extension registry (or directly from in-tree code)
+ *    and route the kind to selective React Query invalidations.
+ *
+ * EventSource handles auto-reconnect on network blips — no manual
+ * retry needed. The stream reuses the JWT httpOnly cookie for auth
+ * because ``EventSource`` sends credentials same-origin
+ * automatically.
  */
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '';
@@ -26,23 +39,26 @@ export function useNotificationStream(enabled: boolean) {
     const url = `${BASE_URL}/notifications/stream`;
     const es = new EventSource(url, { withCredentials: true });
 
-    const onPush = () => {
+    const onPush = (e: MessageEvent) => {
       qc.invalidateQueries({ queryKey: NOTIFS_LIST_KEY });
       qc.invalidateQueries({ queryKey: NOTIFS_UNREAD_KEY });
+      const evt = parseAtriumEvent(e.data);
+      if (evt) dispatchAtriumEvent(evt);
     };
 
-    es.addEventListener('notification', onPush);
+    es.addEventListener('notification', onPush as EventListener);
 
     // `error` fires on disconnect; EventSource will retry automatically
-    // (default 3s). If the user has logged out, the server will 401 on
-    // reconnect — we close the stream explicitly when `enabled` flips
-    // false (the effect cleanup below does that).
+    // (default 3s; backend sends `retry: 2000` to override). If the
+    // user has logged out, the server will 401 on reconnect — we close
+    // the stream explicitly when `enabled` flips false (the effect
+    // cleanup below does that).
     es.addEventListener('error', () => {
       // Intentionally no-op: let the browser's built-in retry handle it.
     });
 
     return () => {
-      es.removeEventListener('notification', onPush);
+      es.removeEventListener('notification', onPush as EventListener);
       es.close();
     };
   }, [enabled, qc]);

--- a/frontend/src/host/events.ts
+++ b/frontend/src/host/events.ts
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+/**
+ * Atrium host event bus.
+ *
+ * Atrium owns one ``EventSource('/notifications/stream')`` per tab —
+ * the bell uses it to refresh on push, and host bundles use this bus
+ * to route ``{kind, payload}`` events at their own React Query cache
+ * invalidations. One connection, fanned out in-process to any number
+ * of subscribers.
+ *
+ * Lifecycle: handlers register at host-bundle import time (before the
+ * EventSource opens) and stay registered across login / logout
+ * cycles. The connection itself is opened by ``useNotificationStream``
+ * while the user is logged in; events flow through the bus only when
+ * the connection is live, so a logged-out tab is silent without each
+ * subscriber having to know.
+ *
+ * A faulty handler must not poison the rest of the fan-out: each
+ * dispatch call is wrapped in try/catch and the failure surfaces as a
+ * single console warning. Same convention as the per-kind
+ * notification renderers in ``registry.ts``.
+ */
+
+/** Wire shape of the SSE ``notification`` event published by
+ *  ``app.services.notifications.notify_user``. ``kind`` is the same
+ *  free-form string carried on the ``notifications`` row; ``payload``
+ *  is the same JSON dict. */
+export type AtriumEvent = {
+  kind: string;
+  payload: Record<string, unknown>;
+};
+
+export type AtriumEventHandler = (event: AtriumEvent) => void;
+
+const handlers = new Map<string, Set<AtriumEventHandler>>();
+
+/** Register ``handler`` for events whose ``kind`` matches exactly.
+ *
+ *  Returns an ``unsubscribe`` function — call it on unmount, route
+ *  change, or whenever the handler should stop firing. The same
+ *  ``handler`` reference can be subscribed multiple times for the
+ *  same kind (each subscription is independent and unsubscribes
+ *  separately), but doing so is almost certainly a bug; the bus does
+ *  not de-duplicate. */
+export function subscribeEvent(
+  kind: string,
+  handler: AtriumEventHandler,
+): () => void {
+  let set = handlers.get(kind);
+  if (!set) {
+    set = new Set();
+    handlers.set(kind, set);
+  }
+  set.add(handler);
+  return () => {
+    const live = handlers.get(kind);
+    if (!live) return;
+    live.delete(handler);
+    if (live.size === 0) handlers.delete(kind);
+  };
+}
+
+/** Fan ``event`` out to every handler registered for ``event.kind``.
+ *  Unhandled kinds are dropped silently — the bell handler in
+ *  ``useNotificationStream`` runs separately and refreshes regardless
+ *  of whether anything else is listening. */
+export function dispatchAtriumEvent(event: AtriumEvent): void {
+  const set = handlers.get(event.kind);
+  if (!set || set.size === 0) return;
+  // Snapshot so a handler that unsubscribes mid-fan-out doesn't mutate
+  // the iterator we're walking.
+  const snapshot = Array.from(set);
+  for (const h of snapshot) {
+    try {
+      h(event);
+    } catch (err) {
+      console.warn(
+        `[atrium-events] handler for kind "${event.kind}" threw; ` +
+          `other subscribers were unaffected`,
+        err,
+      );
+    }
+  }
+}
+
+/** Decode the SSE ``data:`` payload into an ``AtriumEvent``. Returns
+ *  ``null`` for malformed JSON, missing/non-string ``kind``, or any
+ *  other shape mismatch — callers (notably ``useNotificationStream``)
+ *  treat ``null`` as "skip the bus dispatch but still refresh the
+ *  bell", because the presence of an event is enough to drive the
+ *  unconditional list / unread-count refetch even when the body
+ *  doesn't parse. */
+export function parseAtriumEvent(raw: string): AtriumEvent | null {
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!data || typeof data !== 'object') return null;
+  const obj = data as Record<string, unknown>;
+  if (typeof obj.kind !== 'string') return null;
+  const rawPayload = obj.payload;
+  const payload =
+    rawPayload && typeof rawPayload === 'object' && !Array.isArray(rawPayload)
+      ? (rawPayload as Record<string, unknown>)
+      : {};
+  return { kind: obj.kind, payload };
+}
+
+/** Test-only: drop every subscription. Production code never calls
+ *  this — host bundles register once at boot and stay. */
+export function __resetEventBusForTests(): void {
+  handlers.clear();
+}
+
+/** Test-only: handler count for a specific kind. Used by registry
+ *  tests to assert subscribe/unsubscribe wiring without reaching into
+ *  the module-level state directly. */
+export function __eventBusSubscriberCountForTests(kind: string): number {
+  return handlers.get(kind)?.size ?? 0;
+}

--- a/frontend/src/host/registry.ts
+++ b/frontend/src/host/registry.ts
@@ -10,6 +10,13 @@
  * populated at SPA boot from a runtime-loaded host bundle (see
  * ``main.tsx`` and ``system.host_bundle_url``).
  *
+ * Alongside the render-time registries the same surface exposes
+ * ``subscribeEvent(kind, handler)`` — a tap into atrium's single
+ * ``EventSource('/notifications/stream')``. Hosts subscribe at import
+ * time and route the typed ``{kind, payload}`` event to their own
+ * React Query cache invalidations without standing up a second
+ * connection.
+ *
  * The registries are deliberately thin: each one is an array, ordered
  * by registration call order, and the consumer components iterate
  * them at first render. There is no mutation channel after boot —
@@ -29,6 +36,12 @@ import type { ReactElement } from 'react';
 
 import type { CurrentUser } from '@/lib/auth';
 import type { AppNotification } from '@/hooks/useNotifications';
+import {
+  __resetEventBusForTests as __resetEventBusForTestsRef,
+  subscribeEvent,
+} from './events';
+
+export type { AtriumEvent, AtriumEventHandler } from './events';
 
 /** Layout width for a home-page widget. ``narrow`` matches the default
  *  680px column atrium ships for the welcome content; ``wide`` extends
@@ -226,6 +239,16 @@ const baseRegistry = {
   registerAdminTab,
   registerProfileItem,
   registerNotificationKind,
+  /** Subscribe to a notification ``kind`` on the SSE stream. Atrium
+   *  owns one connection per tab; this is how a host bundle plugs
+   *  into it without standing up its own ``EventSource``. The handler
+   *  receives the published ``{kind, payload}`` event and typically
+   *  calls ``queryClient.invalidateQueries(...)`` to refresh exactly
+   *  the queries the kind affects. Returns an unsubscribe function;
+   *  host bundles usually subscribe once at import time and never
+   *  unsubscribe (the connection stays open while the user is logged
+   *  in). See ``subscribeEvent`` in ``host/events.ts``. */
+  subscribeEvent,
 } as const;
 
 export type AtriumRegistry = typeof baseRegistry;
@@ -300,6 +323,10 @@ export function __resetRegistryForTests(): void {
   adminTabs.length = 0;
   profileItems.length = 0;
   notificationRenderers.length = 0;
+  // Event bus is part of the same surface; the rest of the helpers
+  // are imported separately from ``./events`` for tests that want to
+  // exercise just the bus.
+  __resetEventBusForTestsRef();
 }
 
 declare global {
@@ -319,4 +346,5 @@ export {
   registerAdminTab,
   registerProfileItem,
   registerNotificationKind,
+  subscribeEvent,
 };

--- a/frontend/src/routes/HomePage.tsx
+++ b/frontend/src/routes/HomePage.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 
 import { HostHomeWidgets } from '@/components/HostHomeWidgets';
 import { useMe } from '@/hooks/useAuth';
+import { getHomeWidgets } from '@/host/registry';
 
 /** Minimal landing page. Host apps replace this with whatever
  *  dashboard makes sense for them; Atrium ships only the shell.
@@ -15,11 +16,18 @@ import { useMe } from '@/hooks/useAuth';
  *  ``HostHomeWidgets`` is rendered outside the welcome Container so
  *  widgets that opt into ``width: 'wide'`` or ``'full'`` can break
  *  out of the 680px column. The atrium-shipped welcome content stays
- *  in the narrow column. */
+ *  in the narrow column.
+ *
+ *  The ``home.intro`` line is integrator-facing copy: it tells someone
+ *  who's just spun up a fresh starter where to hook their own pages.
+ *  Once any host widget is registered the intro is noise, so we hide
+ *  it. The greeting + the action buttons stay either way — they're
+ *  useful chrome regardless of whether a host owns the page. */
 export function HomePage() {
   const { t } = useTranslation();
   const { data: me } = useMe();
   const isAdmin = me?.roles.includes('admin') ?? false;
+  const hasHostWidgets = getHomeWidgets().length > 0;
 
   return (
     <Stack gap="md">
@@ -31,7 +39,7 @@ export function HomePage() {
               ? t('home.welcomeNamed', { name: me.full_name })
               : t('home.welcome')}
           </Title>
-          <Text c="dimmed">{t('home.intro')}</Text>
+          {!hasHostWidgets && <Text c="dimmed">{t('home.intro')}</Text>}
           <Group>
             <Button
               component={Link}

--- a/frontend/src/test/host-events.test.ts
+++ b/frontend/src/test/host-events.test.ts
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+/**
+ * Vitest coverage for the host event bus.
+ *
+ * Pins down the contract host bundles rely on: subscribe returns an
+ * unsubscribe handle, kinds are matched exactly (no glob), unhandled
+ * kinds are silent, throwing handlers don't poison the rest of the
+ * fan-out.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import {
+  __eventBusSubscriberCountForTests,
+  __resetEventBusForTests,
+  dispatchAtriumEvent,
+  parseAtriumEvent,
+  subscribeEvent,
+} from '@/host/events';
+
+describe('host event bus', () => {
+  beforeEach(() => {
+    __resetEventBusForTests();
+  });
+
+  it('dispatch fans out to every subscriber for the matching kind', () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    subscribeEvent('booking.created', a);
+    subscribeEvent('booking.created', b);
+
+    dispatchAtriumEvent({ kind: 'booking.created', payload: { id: 7 } });
+
+    expect(a).toHaveBeenCalledWith({
+      kind: 'booking.created',
+      payload: { id: 7 },
+    });
+    expect(b).toHaveBeenCalledWith({
+      kind: 'booking.created',
+      payload: { id: 7 },
+    });
+  });
+
+  it('dispatch ignores subscribers registered for a different kind', () => {
+    const block = vi.fn();
+    const booking = vi.fn();
+    subscribeEvent('block.updated', block);
+    subscribeEvent('booking.created', booking);
+
+    dispatchAtriumEvent({ kind: 'booking.created', payload: { id: 1 } });
+
+    expect(block).not.toHaveBeenCalled();
+    expect(booking).toHaveBeenCalledOnce();
+  });
+
+  it('dispatch is silent for kinds with no subscribers', () => {
+    expect(() =>
+      dispatchAtriumEvent({ kind: 'nobody.cares', payload: {} }),
+    ).not.toThrow();
+  });
+
+  it('unsubscribe stops further fan-out for that handler only', () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    const offA = subscribeEvent('booking.created', a);
+    subscribeEvent('booking.created', b);
+
+    offA();
+    dispatchAtriumEvent({ kind: 'booking.created', payload: { id: 1 } });
+
+    expect(a).not.toHaveBeenCalled();
+    expect(b).toHaveBeenCalledOnce();
+  });
+
+  it('unsubscribe of the last handler clears the kind from the table', () => {
+    const off = subscribeEvent('booking.created', () => {});
+    expect(__eventBusSubscriberCountForTests('booking.created')).toBe(1);
+    off();
+    expect(__eventBusSubscriberCountForTests('booking.created')).toBe(0);
+  });
+
+  it('a handler that throws does not poison other subscribers', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const exploding = vi.fn(() => {
+        throw new Error('boom');
+      });
+      const ok = vi.fn();
+      subscribeEvent('booking.created', exploding);
+      subscribeEvent('booking.created', ok);
+
+      dispatchAtriumEvent({ kind: 'booking.created', payload: {} });
+
+      expect(exploding).toHaveBeenCalledOnce();
+      expect(ok).toHaveBeenCalledOnce();
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('a handler that unsubscribes mid-fan-out does not skip its sibling', () => {
+    // Snapshot semantics: dispatch iterates over a copy of the
+    // subscriber set, so a handler removing itself (or another) does
+    // not corrupt the iteration.
+    const calls: string[] = [];
+    let offA: (() => void) | null = null;
+    const a = vi.fn(() => {
+      calls.push('a');
+      offA?.();
+    });
+    const b = vi.fn(() => {
+      calls.push('b');
+    });
+    offA = subscribeEvent('booking.created', a);
+    subscribeEvent('booking.created', b);
+
+    dispatchAtriumEvent({ kind: 'booking.created', payload: {} });
+
+    expect(calls).toEqual(['a', 'b']);
+  });
+
+  it('the same handler subscribed twice for one kind fires once per dispatch', () => {
+    // Set semantics — adding the same reference twice is a no-op.
+    const handler = vi.fn();
+    subscribeEvent('booking.created', handler);
+    subscribeEvent('booking.created', handler);
+
+    dispatchAtriumEvent({ kind: 'booking.created', payload: {} });
+
+    expect(handler).toHaveBeenCalledOnce();
+  });
+});
+
+describe('parseAtriumEvent', () => {
+  it('decodes the canonical {kind, payload} wire format', () => {
+    const evt = parseAtriumEvent(
+      JSON.stringify({ kind: 'booking.created', payload: { id: 7 } }),
+    );
+    expect(evt).toEqual({
+      kind: 'booking.created',
+      payload: { id: 7 },
+    });
+  });
+
+  it('treats a missing payload as an empty object', () => {
+    const evt = parseAtriumEvent(JSON.stringify({ kind: 'block.updated' }));
+    expect(evt).toEqual({ kind: 'block.updated', payload: {} });
+  });
+
+  it('treats a non-object payload as an empty object', () => {
+    // Defensive: backend should never ship a non-object payload, but
+    // a misbehaving host (or future schema drift) shouldn't break the
+    // dispatcher.
+    const evt = parseAtriumEvent(
+      JSON.stringify({ kind: 'block.updated', payload: ['not', 'an', 'object'] }),
+    );
+    expect(evt).toEqual({ kind: 'block.updated', payload: {} });
+  });
+
+  it('returns null for malformed JSON', () => {
+    expect(parseAtriumEvent('not json')).toBeNull();
+  });
+
+  it('returns null when kind is missing', () => {
+    expect(parseAtriumEvent(JSON.stringify({ payload: {} }))).toBeNull();
+  });
+
+  it('returns null when kind is not a string', () => {
+    expect(
+      parseAtriumEvent(JSON.stringify({ kind: 42, payload: {} })),
+    ).toBeNull();
+  });
+
+  it('returns null when the message is not an object', () => {
+    expect(parseAtriumEvent(JSON.stringify('refresh'))).toBeNull();
+    expect(parseAtriumEvent(JSON.stringify(null))).toBeNull();
+  });
+});

--- a/frontend/src/test/host-registry.test.tsx
+++ b/frontend/src/test/host-registry.test.tsx
@@ -37,7 +37,12 @@ import {
   registerNotificationKind,
   registerProfileItem,
   registerRoute,
+  subscribeEvent,
 } from '@/host/registry';
+import {
+  __eventBusSubscriberCountForTests,
+  dispatchAtriumEvent,
+} from '@/host/events';
 import type { AppNotification } from '@/hooks/useNotifications';
 
 const sampleNotification = (
@@ -269,6 +274,39 @@ describe('host registry', () => {
     } finally {
       warn.mockRestore();
     }
+  });
+
+  it('subscribeEvent on the registry routes to the event bus', () => {
+    // The registry just re-exports the bus's subscribe helper; this
+    // pins down that __ATRIUM_REGISTRY__.subscribeEvent shares state
+    // with the standalone export, so a host bundle calling either one
+    // lands in the same fan-out.
+    const handler = vi.fn();
+    const off = subscribeEvent('booking.created', handler);
+    expect(__eventBusSubscriberCountForTests('booking.created')).toBe(1);
+    dispatchAtriumEvent({ kind: 'booking.created', payload: { id: 1 } });
+    expect(handler).toHaveBeenCalledOnce();
+    off();
+    expect(__eventBusSubscriberCountForTests('booking.created')).toBe(0);
+  });
+
+  it('__ATRIUM_REGISTRY__.subscribeEvent is the same helper', () => {
+    const reg = window.__ATRIUM_REGISTRY__!;
+    const handler = vi.fn();
+    const off = reg.subscribeEvent('block.updated', handler);
+    dispatchAtriumEvent({ kind: 'block.updated', payload: { id: 7 } });
+    expect(handler).toHaveBeenCalledWith({
+      kind: 'block.updated',
+      payload: { id: 7 },
+    });
+    off();
+  });
+
+  it('__resetRegistryForTests also clears event bus subscriptions', () => {
+    subscribeEvent('block.updated', () => {});
+    expect(__eventBusSubscriberCountForTests('block.updated')).toBe(1);
+    __resetRegistryForTests();
+    expect(__eventBusSubscriberCountForTests('block.updated')).toBe(0);
   });
 
   it('window.__ATRIUM_REGISTRY__ writes through to the same state', () => {

--- a/frontend/tests-e2e/smoke.spec.ts
+++ b/frontend/tests-e2e/smoke.spec.ts
@@ -37,6 +37,16 @@ test('user can log in and sees the home page', async ({ page }) => {
   await expect(page).toHaveURL('/');
   await expect(page.getByRole('heading', { name: /Welcome/i })).toBeVisible();
 
+  // No host bundle is loaded in the smoke stack, so the integrator-
+  // facing "starter shell" intro renders. (When a host bundle ships a
+  // home widget the intro auto-hides — covered by the hello-world
+  // spec.)
+  await expect(
+    page.getByText(
+      'This is the Atrium starter shell. Hook your domain pages onto the routes from here.',
+    ),
+  ).toBeVisible();
+
   // Sidebar exposes the main sections — proves the shell mounted.
   await expect(page.getByRole('link', { name: 'Profile' })).toBeVisible();
 });


### PR DESCRIPTION
## Summary

Two host-extension ergonomics tweaks landing together for v0.11.3.

**1. Typed SSE events + `subscribeEvent` host helper (closes #29).** `/notifications/stream` now publishes `{kind, payload}` mirroring the row instead of a literal `{"kind": "refresh"}`, so host bundles can route on the kind and invalidate only the React Query keys their domain cares about. A new `__ATRIUM_REGISTRY__.subscribeEvent(kind, handler)` taps atrium's single per-tab `EventSource` — hosts plug into it without standing up a second connection. The bell still refetches on every event regardless of kind, so its behaviour is unchanged.

**2. Auto-hide HomePage starter intro when a host home widget is registered (closes #28).** The "This is the Atrium starter shell..." line is integrator-facing copy. Once any host home widget mounts, the intro is noise stacked above real content. `HomePage` now reads `getHomeWidgets()` and gates the intro on the count being zero. Empty-state still shows the intro for the integrator-onboarding case.

The hello-world example exercises both: it registers `subscribeEvent('hello.toggled', ...)` (replaces its 5 s `refetchInterval` with SSE-driven invalidation) and gets the intro auto-hide for free.

## Test plan

- [x] `make test-backend` — 177 passed
- [x] `make test-frontend` (vitest) — 41 passed (8 new, covering the event bus + `subscribeEvent` registry wiring)
- [x] `pnpm typecheck` — clean
- [x] `make lint` — only pre-existing warning
- [x] `make smoke` — 9/9 passed; smoke spec now asserts the intro is visible when no host bundle loads
- [x] `make smoke-hello` — toggle test flaked on first run (api restart timing), passed cleanly on retry; the hello-world spec now asserts the intro is hidden when the widget mounts