### PR TITLE
Host registry render() + registerLocale, /admin/users role codes, host dev recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,10 @@ toggles) take effect without a restart.
 > through declared extension points without editing atrium files. The
 > guide covers the full skeleton (host package + frontend bundle +
 > Dockerfile + compose), the first-boot ritual, and a retrofit playbook
-> for moving an existing app onto atrium.
+> for moving an existing app onto atrium. Once the skeleton is up, see
+> [`docs/host-dev-recipe.md`](docs/host-dev-recipe.md) for the
+> live-reload / GHCR access / security-CI configuration the
+> walkthroughs leave to the integrator.
 
 The starter ships *only* the platform layer. To add your domain:
 

--- a/backend/app/api/admin_users.py
+++ b/backend/app/api/admin_users.py
@@ -43,23 +43,51 @@ class UserAdminUpdate(BaseModel):
 
 
 class UserAdminRead(UserRead):
-    """Admin list/detail view: standard UserRead + RBAC role ids."""
+    """Admin list/detail view: standard UserRead + RBAC role ids and codes.
+
+    ``roles`` carries the stable string codes (``"admin"``, ``"super_admin"``,
+    host-defined codes etc.); ``role_ids`` carries the per-environment
+    integer ids. Hosts that filter users by role membership ("show me
+    everyone without the agent role") read ``roles`` and avoid a
+    second ``/admin/roles`` lookup; the patch endpoint still expects
+    ``role_ids`` since ids are what the MultiSelect in the admin UI
+    binds to.
+    """
 
     role_ids: list[int] = Field(default_factory=list)
+    roles: list[str] = Field(default_factory=list)
+
+
+async def _roles_for(
+    session: AsyncSession, user_id: int
+) -> tuple[list[int], list[str]]:
+    """Return ``(role_ids, role_codes)`` for ``user_id`` from a single
+    join query. Both lists are sorted: ids ascending numerically, codes
+    ascending lexicographically. Codes are sorted independently so the
+    two lists are not positionally aligned — the consumer treats each
+    as a set, not an array of pairs."""
+    rows = (
+        await session.execute(
+            select(Role.id, Role.code)
+            .join(user_roles, user_roles.c.role_id == Role.id)
+            .where(user_roles.c.user_id == user_id)
+        )
+    ).all()
+    ids = sorted(int(r[0]) for r in rows)
+    codes = sorted(str(r[1]) for r in rows)
+    return ids, codes
 
 
 async def _role_ids_for(session: AsyncSession, user_id: int) -> list[int]:
-    rows = (
-        await session.execute(
-            select(user_roles.c.role_id).where(user_roles.c.user_id == user_id)
-        )
-    ).scalars().all()
-    return sorted(rows)
+    ids, _ = await _roles_for(session, user_id)
+    return ids
 
 
 async def _to_admin_read(session: AsyncSession, user: User) -> UserAdminRead:
     data = UserRead.model_validate(user, from_attributes=True).model_dump()
-    data["role_ids"] = await _role_ids_for(session, user.id)
+    role_ids, role_codes = await _roles_for(session, user.id)
+    data["role_ids"] = role_ids
+    data["roles"] = role_codes
     return UserAdminRead.model_validate(data)
 
 

--- a/backend/tests/api/test_rbac_admin.py
+++ b/backend/tests/api/test_rbac_admin.py
@@ -157,7 +157,32 @@ async def test_super_admin_can_grant_super_admin(client, engine):
         json={"role_ids": [owner_role_id, super_admin_role_id]},
     )
     assert r.status_code == 200, r.text
-    assert set(r.json()["role_ids"]) == {owner_role_id, super_admin_role_id}
+    body = r.json()
+    assert set(body["role_ids"]) == {owner_role_id, super_admin_role_id}
+    # The companion ``roles`` field carries the stable string codes so
+    # hosts can filter by membership without a second roles lookup.
+    assert set(body["roles"]) == {"admin", "super_admin"}
+
+
+@pytest.mark.asyncio
+async def test_admin_users_list_includes_role_codes(client, engine):
+    """``GET /admin/users`` exposes ``roles: list[str]`` alongside
+    ``role_ids`` so hosts can filter user lists by role membership in
+    one round-trip."""
+    owner = await seed_admin(engine)
+    target = await seed_admin(engine, email="target@example.com")
+    await login(client, owner.email, "admin-pw-123", engine=engine)
+
+    r = await client.get("/admin/users")
+    assert r.status_code == 200, r.text
+    rows = {row["id"]: row for row in r.json()}
+    assert target.id in rows
+    assert rows[target.id]["roles"] == ["admin"]
+    assert rows[owner.id]["roles"] == ["admin"]
+    # Both shapes are populated; old clients reading role_ids keep
+    # working.
+    assert isinstance(rows[target.id]["role_ids"], list)
+    assert all(isinstance(rid, int) for rid in rows[target.id]["role_ids"])
 
 
 @pytest.mark.asyncio

--- a/docs/host-dev-recipe.md
+++ b/docs/host-dev-recipe.md
@@ -1,0 +1,256 @@
+# Host dev recipe
+
+A working configuration for a host project layered on atrium: live-reload
+on both backend and frontend, GHCR access from CI, image / static
+analysis green on the first PR.
+
+The contract surface (image catalogue, tagging, registries) lives in
+[`published-images.md`](published-images.md); the from-scratch
+walkthrough lives in [`new-project/`](new-project/). This page picks
+up where those leave off — the integration papercuts each new host
+hits in the first few days that don't surface in either of those.
+
+The patterns below are extracted from real host integrations; the
+canonical worked-example dev stack is in
+[`../examples/hello-world/dev/compose.dev.yaml`](../examples/hello-world/dev/compose.dev.yaml).
+
+## Live reload
+
+The host dev stack runs the same atrium runtime image as prod, but
+swaps **two bind mounts** to keep the edit/save loop tight:
+
+- the host's backend package, mounted into `/host_app`, with
+  `PYTHONPATH=/host_app/src:/app`
+- the host's `frontend/dist`, watched by `vite build --watch` on the
+  developer's host and bind-mounted into the api container at
+  `/opt/atrium/static/host` (read-only)
+
+Uvicorn runs with `--reload` (via atrium's dev compose) so editing
+anything under `/host_app` triggers a backend reload. The frontend
+side is dumber but cheaper: Vite rebuilds the bundle, the api
+container's nginx-equivalent (FastAPI's `StaticFiles`) re-serves the
+new bytes on the next page load.
+
+Compose layout for the dev overlay:
+
+```yaml
+services:
+  api:
+    environment:
+      ATRIUM_HOST_MODULE: <your_pkg>.bootstrap
+      PYTHONPATH: /host_app/src:/app
+    volumes:
+      - ./backend:/host_app
+      - ./frontend/dist:/opt/atrium/static/host:ro
+
+  worker:
+    environment:
+      ATRIUM_HOST_MODULE: <your_pkg>.bootstrap
+      PYTHONPATH: /host_app/src:/app
+    volumes:
+      - ./backend:/host_app
+```
+
+Frontend watcher runs on the developer's host (Vite is happier with
+local fs events than container ones):
+
+```bash
+cd frontend && pnpm install && pnpm build --watch
+```
+
+### Hot-reload race
+
+Vite's "delete + write" sequence has a brief window where
+`/host/main.js` 404s and atrium's SPA shell falls back to
+`index.html`. If the browser tab fetches the bundle during that
+window the dynamic-import throws and the whole tab needs a refresh.
+Wait for `built in <ms>` in the Vite logs before reloading the
+browser tab. Don't add a polling reloader — the noise outweighs the
+savings.
+
+## GHCR image access
+
+Atrium publishes to `ghcr.io/brendan-bank/atrium`. Three ways the
+host's CI gets pull access:
+
+1. **Public package** — recommended. No login step in CI; `docker pull`
+   just works. Atrium itself is currently public.
+2. **Manage Actions access (private packages)** — on the atrium
+   package settings, add the host repo to "Manage Actions access",
+   then in the host workflow:
+   ```yaml
+   permissions:
+     contents: read
+     packages: read
+   steps:
+     - uses: docker/login-action@v4
+       with:
+         registry: ghcr.io
+         username: ${{ github.actor }}
+         password: ${{ secrets.GITHUB_TOKEN }}
+   ```
+   `GITHUB_TOKEN` is scoped per-job, so the login is ephemeral. No
+   long-lived secret in the host repo.
+3. **PAT in repo secrets** — only when option 2 isn't available
+   (cross-org access without inviting the host repo into the package
+   ACL). Least clean; rotate manually.
+
+For local dev the published images are pulled by Compose using your
+`docker login ghcr.io` credentials (a `gh auth token`-derived PAT
+works).
+
+## Security CI checklist
+
+Two scans, each producing SARIF that GitHub renders in the Security
+tab: Trivy (image vulnerabilities) and CodeQL (source analysis).
+
+### Workflow permissions
+
+Both uploads call `github/codeql-action/upload-sarif`, which reads
+`GET /repos/.../actions/runs/{id}` to attach run metadata. Without
+`actions: read` the upload **fails silently** with "Resource not
+accessible by integration" — the scan ran, the SARIF just never
+lands. Always declare it on each scanning job:
+
+```yaml
+permissions:
+  contents: read
+  security-events: write   # SARIF upload target
+  actions: read            # run-metadata fetch (silent failure without it)
+```
+
+### Code Security toggle
+
+Private repos default to `security_and_analysis.code_security:
+disabled`. CodeQL refuses to run with:
+
+> Code Security must be enabled for this repository to use code scanning.
+
+Click Settings → Code security & analysis → Enable, or via API:
+
+```bash
+gh api -X PATCH repos/<org>/<repo> \
+  -F 'security_and_analysis[code_security][status]=enabled'
+```
+
+This is repo-level configuration, not workflow-level — a fresh host
+clone fails CI on first push until someone flips the switch.
+
+### Trivy
+
+Image scan, post-build:
+
+```yaml
+- name: Build host image
+  run: docker build -t host-app:ci .
+
+- name: Trivy scan
+  uses: aquasecurity/trivy-action@<sha>
+  with:
+    image-ref: host-app:ci
+    format: sarif
+    output: trivy-results.sarif
+    severity: CRITICAL,HIGH
+
+- name: Upload SARIF
+  uses: github/codeql-action/upload-sarif@<sha>
+  with:
+    sarif_file: trivy-results.sarif
+    category: trivy
+```
+
+### CodeQL
+
+Two-language matrix (Python + TypeScript) is typical. The host's
+`.github/codeql/codeql-config.yml` should exclude generated /
+vendored paths so the diff stays signal-only:
+
+```yaml
+paths-ignore:
+  - frontend/dist
+  - frontend/node_modules
+  - backend/.venv
+  - "**/_generated_*.py"
+```
+
+### Dependabot
+
+One config file at `.github/dependabot.yml`, grouped so a Tuesday
+morning isn't six identical Mantine bumps:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /backend
+    schedule: { interval: weekly }
+    groups:
+      backend: { patterns: ["*"] }
+
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule: { interval: weekly }
+    groups:
+      mantine: { patterns: ["@mantine/*"] }
+      tanstack: { patterns: ["@tanstack/*"] }
+      lint: { patterns: ["eslint*", "@typescript-eslint/*", "prettier"] }
+      typescript: { patterns: ["typescript", "@types/*", "tsx"] }
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule: { interval: weekly }
+    groups:
+      actions: { patterns: ["*"] }
+```
+
+## Backend test stack
+
+Use `testcontainers-mysql` against MySQL 8.0 — the same engine
+atrium uses, so timezone / collation / `DATETIME(0)` rounding
+behaviour matches prod.
+
+Two alembic chains run against the same database:
+
+- atrium's chain (`alembic upgrade head` from `/app`) — owns the
+  `alembic_version` table.
+- the host chain (`alembic -c /host_app/alembic.ini upgrade head`)
+  — owns `alembic_version_app` (from `version_table` in the host's
+  `env.py`). See [`new-project/README.md`](new-project/README.md)
+  step 5 for the exact `env.py`.
+
+A pytest conftest pattern that drops + recreates the DB per test
+session and runs both chains keeps tests independent of each other
+and matches what atrium's own test suite does. Don't truncate inside
+test bodies — atrium's role / permission seed lives in the schema
+migration, so a TRUNCATE between tests wipes the row that
+`require_perm` looks up.
+
+## Frontend test stack
+
+- **Vitest** for unit tests (host hooks, registry calls,
+  string-formatter helpers). Runs in seconds; no server required.
+- **Playwright** for end-to-end (auth flow, host route, bell + SSE).
+  Requires the full compose stack — see the hello-world
+  `e2e` workflow for the canonical shape.
+
+Login helpers want `E2E_ADMIN_EMAIL`, `E2E_ADMIN_PASSWORD`, and a
+fixed `E2E_ADMIN_TOTP_SECRET`. In CI those come from workflow env;
+in local dev, store the seeded admin creds in 1Password and source
+them via `op run --` for the test command.
+
+Atrium ships a typed [`AtriumEvent`](../frontend/src/host/events.ts)
+contract for SSE payloads; host bundles using
+`subscribeEvent('<kind>', handler)` should mirror the same shape in
+their tests so payload assertions stay aligned with the wire
+format.
+
+## Reference layout
+
+- [`../examples/hello-world/`](../examples/hello-world/) — full
+  worked example. Backend host package, frontend bundle, alembic
+  chain, compose, dev overlay.
+- [`../examples/hello-world/dev/compose.dev.yaml`](../examples/hello-world/dev/compose.dev.yaml)
+  — the canonical dev overlay this page summarises.
+- [`new-project/`](new-project/) — from-scratch bootstrap walkthrough.
+- [`published-images.md`](published-images.md) — the registry +
+  extension contract.

--- a/docs/published-images.md
+++ b/docs/published-images.md
@@ -11,7 +11,10 @@ For a worked example that exercises every extension point, see
 walkthrough of standing up a fresh host project from nothing — including
 the retrofit playbook for moving an existing app onto atrium — see
 [`new-project/`](new-project/) ([`README.md`](new-project/README.md) for
-humans, [`SKILL.md`](new-project/SKILL.md) for AI agents).
+humans, [`SKILL.md`](new-project/SKILL.md) for AI agents). For the
+live-reload, GHCR pull access, and security-CI configuration that
+host integrations converge on, see
+[`host-dev-recipe.md`](host-dev-recipe.md).
 
 ---
 

--- a/examples/hello-world/frontend/src/main.tsx
+++ b/examples/hello-world/frontend/src/main.tsx
@@ -47,7 +47,7 @@ interface AtriumRegistry {
   registerRoute: (r: {
     key: string;
     path: string;
-    element: unknown;
+    render: () => unknown;
     requireAuth?: boolean;
     layout?: 'shell' | 'bare';
   }) => void;
@@ -62,7 +62,7 @@ interface AtriumRegistry {
     label: string;
     icon?: unknown;
     perm?: string;
-    element: unknown;
+    render: () => unknown;
   }) => void;
   registerProfileItem: (p: {
     key: string;
@@ -80,6 +80,10 @@ interface AtriumRegistry {
     render: (n: HostNotification) => unknown;
     title?: (n: HostNotification) => string;
     href?: (n: HostNotification) => string;
+  }) => void;
+  registerLocale: (o: {
+    locale: string;
+    strings: Record<string, unknown>;
   }) => void;
   subscribeEvent: (
     kind: string,
@@ -136,7 +140,7 @@ if (!reg) {
   reg.registerRoute({
     key: 'hello-page',
     path: '/hello',
-    element: makeWrapperElement(<HelloPage />),
+    render: () => makeWrapperElement(<HelloPage />),
   });
   reg.registerNavItem({
     key: 'hello-nav',
@@ -151,7 +155,7 @@ if (!reg) {
     label: 'Hello World',
     icon: AtriumReact.createElement(IconHandStop, { size: 14 }),
     perm: 'hello.toggle',
-    element: makeWrapperElement(<HelloAdminTab />),
+    render: () => makeWrapperElement(<HelloAdminTab />),
   });
   reg.registerProfileItem({
     key: 'hello-profile',

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -68,14 +68,20 @@ export default function App() {
       <Route path="/2fa" element={<TwoFactorPage />} />
 
       {publicHostRoutes.map((r) => (
-        <Route key={r.key} path={r.path} element={r.element} />
+        <Route
+          key={r.key}
+          path={r.path}
+          element={r.render ? r.render() : r.element}
+        />
       ))}
 
       {bareAuthRoutes.map((r) => (
         <Route
           key={r.key}
           path={r.path}
-          element={<RequireAuth>{r.element}</RequireAuth>}
+          element={
+            <RequireAuth>{r.render ? r.render() : r.element}</RequireAuth>
+          }
         />
       ))}
 
@@ -92,7 +98,11 @@ export default function App() {
         <Route path="/profile" element={<ProfilePage />} />
         <Route path="/notifications" element={<NotificationsPage />} />
         {shellAuthRoutes.map((r) => (
-          <Route key={r.key} path={r.path} element={r.element} />
+          <Route
+            key={r.key}
+            path={r.path}
+            element={r.render ? r.render() : r.element}
+          />
         ))}
         <Route path="*" element={<Navigate to="/" replace />} />
       </Route>

--- a/frontend/src/host/registry.ts
+++ b/frontend/src/host/registry.ts
@@ -59,7 +59,23 @@ export type HomeWidget = {
 export type RouteEntry = {
   key: string;
   path: string;
-  element: ReactElement;
+  /** Returns a fresh element each time the route mounts. Preferred over
+   *  ``element`` because the wrapper elements registered by host
+   *  bundles are typically structurally identical ``<div ref=…>`` calls;
+   *  re-using the captured element across two registered routes lets
+   *  React reuse the same DOM node when ``<Route>`` swaps, so the
+   *  second route's ref fires on a node that already has the first
+   *  route's mounted root attached. ``render`` mirrors the shape
+   *  already used by ``registerHomeWidget`` and
+   *  ``registerNotificationKind``. Exactly one of ``render`` or
+   *  ``element`` must be supplied. */
+  render?: () => ReactElement;
+  /** @deprecated Pass ``render: () => element`` instead. Captured
+   *  elements share the same DOM node across navigations, which can
+   *  carry stale state into the next route's wrapper — see the rationale
+   *  on ``render`` above. Kept for back-compat with hosts built against
+   *  pre-0.12 atrium. */
+  element?: ReactElement;
   /** Default true. Set false for public routes (e.g. host-supplied
    *  unauthenticated landing pages). */
   requireAuth?: boolean;
@@ -86,7 +102,16 @@ export type AdminTab = {
   /** Permission code; the tab is hidden for users who don't hold it.
    *  Omit to show the tab to every admin viewer. */
   perm?: string;
-  element: ReactElement;
+  /** Returns a fresh element each time the tab is selected. Preferred
+   *  over ``element`` for the same reason as ``RouteEntry.render`` —
+   *  ``Tabs`` keeps panels mounted by default, so a captured element
+   *  can hang onto a now-orphaned host React root when the host bundle
+   *  is hot-reloaded. Exactly one of ``render`` or ``element`` must be
+   *  supplied. */
+  render?: () => ReactElement;
+  /** @deprecated Pass ``render: () => element`` instead. Kept for
+   *  back-compat with hosts built against pre-0.12 atrium. */
+  element?: ReactElement;
 };
 
 /** Slot inside ``ProfilePage``'s vertical card stack where a host
@@ -151,12 +176,41 @@ export type NotificationKindRenderer = {
   href?: (n: AppNotification) => string;
 };
 
+/** Locale overlay registered by a host bundle. ``strings`` is a flat
+ *  i18next-style bundle (either dot-paths like ``"home.welcome"`` or a
+ *  nested object — both are accepted). The overlay layers on top of
+ *  atrium's shipped locale + any ``i18n.overrides`` from
+ *  ``/app-config``, so the precedence is shipped < admin overrides <
+ *  host overlay. Per-key, last-write-wins. */
+export type LocaleOverlay = {
+  locale: string;
+  strings: Record<string, unknown>;
+};
+
 const homeWidgets: HomeWidget[] = [];
 const routes: RouteEntry[] = [];
 const navItems: NavItem[] = [];
 const adminTabs: AdminTab[] = [];
 const profileItems: ProfileItem[] = [];
 const notificationRenderers: NotificationKindRenderer[] = [];
+const localeOverlays: LocaleOverlay[] = [];
+const localeOverlayListeners: Array<(o: LocaleOverlay) => void> = [];
+
+function hasRenderOrElement(
+  entry: { render?: unknown; element?: unknown },
+  fn: string,
+  key: string,
+): boolean {
+  if (entry.render === undefined && entry.element === undefined) {
+    console.warn(
+      `[atrium-registry] ${fn}({ key: "${key}" }) requires either ` +
+        `\`render: () => ReactElement\` (preferred) or \`element\` ` +
+        `(deprecated). Registration ignored.`,
+    );
+    return false;
+  }
+  return true;
+}
 
 function registerHomeWidget(widget: HomeWidget): void {
   if (homeWidgets.some((w) => w.key === widget.key)) {
@@ -171,6 +225,7 @@ function registerHomeWidget(widget: HomeWidget): void {
 }
 
 function registerRoute(route: RouteEntry): void {
+  if (!hasRenderOrElement(route, 'registerRoute', route.key)) return;
   // Path collisions are last-write-wins so a host can deliberately
   // override an atrium route, but we surface a console warning so the
   // collision is visible during integration.
@@ -199,6 +254,7 @@ function registerNavItem(item: NavItem): void {
 }
 
 function registerAdminTab(tab: AdminTab): void {
+  if (!hasRenderOrElement(tab, 'registerAdminTab', tab.key)) return;
   if (adminTabs.some((t) => t.key === tab.key)) {
     const idx = adminTabs.findIndex((t) => t.key === tab.key);
     adminTabs.splice(idx, 1);
@@ -232,6 +288,34 @@ function registerNotificationKind(renderer: NotificationKindRenderer): void {
   notificationRenderers.push(renderer);
 }
 
+function registerLocale(overlay: LocaleOverlay): void {
+  if (typeof overlay.locale !== 'string' || overlay.locale.length === 0) {
+    console.warn(
+      `[atrium-registry] registerLocale requires a non-empty \`locale\`; ` +
+        `registration ignored`,
+    );
+    return;
+  }
+  if (
+    overlay.strings === null ||
+    typeof overlay.strings !== 'object' ||
+    Array.isArray(overlay.strings)
+  ) {
+    console.warn(
+      `[atrium-registry] registerLocale({ locale: "${overlay.locale}" }) ` +
+        `requires \`strings\` to be a plain object; registration ignored`,
+    );
+    return;
+  }
+  // Multiple overlays for the same locale stack — later registrations
+  // override earlier ones per key. We don't merge into a single entry
+  // here because the i18n module re-applies overlays in order.
+  localeOverlays.push(overlay);
+  for (const listener of localeOverlayListeners) {
+    listener(overlay);
+  }
+}
+
 const baseRegistry = {
   registerHomeWidget,
   registerRoute,
@@ -239,6 +323,7 @@ const baseRegistry = {
   registerAdminTab,
   registerProfileItem,
   registerNotificationKind,
+  registerLocale,
   /** Subscribe to a notification ``kind`` on the SSE stream. Atrium
    *  owns one connection per tab; this is how a host bundle plugs
    *  into it without standing up its own ``EventSource``. The handler
@@ -314,6 +399,26 @@ export function lookupNotificationRenderer(
   return notificationRenderers.find((r) => r.kind === kind);
 }
 
+export function getLocaleOverlays(): readonly LocaleOverlay[] {
+  return localeOverlays;
+}
+
+/** Subscribe to host-bundle ``registerLocale`` calls so the i18n
+ *  module can apply each overlay onto i18next as it lands. The host
+ *  bundle's import-time side-effects fire while ``loadHostBundle()``
+ *  is awaiting; the listener picks up each overlay synchronously so
+ *  React's first render already sees the host strings. Returns an
+ *  unsubscribe. Test-only — production code subscribes once at boot. */
+export function subscribeLocaleOverlay(
+  listener: (overlay: LocaleOverlay) => void,
+): () => void {
+  localeOverlayListeners.push(listener);
+  return () => {
+    const idx = localeOverlayListeners.indexOf(listener);
+    if (idx >= 0) localeOverlayListeners.splice(idx, 1);
+  };
+}
+
 /** Test-only: drop every registration. Production code never calls
  *  this — host bundles register once at boot and stay. */
 export function __resetRegistryForTests(): void {
@@ -323,6 +428,8 @@ export function __resetRegistryForTests(): void {
   adminTabs.length = 0;
   profileItems.length = 0;
   notificationRenderers.length = 0;
+  localeOverlays.length = 0;
+  localeOverlayListeners.length = 0;
   // Event bus is part of the same surface; the rest of the helpers
   // are imported separately from ``./events`` for tests that want to
   // exercise just the bus.
@@ -346,5 +453,6 @@ export {
   registerAdminTab,
   registerProfileItem,
   registerNotificationKind,
+  registerLocale,
   subscribeEvent,
 };

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -5,6 +5,11 @@ import i18n from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
 
+import {
+  getLocaleOverlays,
+  subscribeLocaleOverlay,
+  type LocaleOverlay,
+} from '@/host/registry';
 import de from './locales/de.json';
 import en from './locales/en.json';
 import fr from './locales/fr.json';
@@ -61,6 +66,32 @@ function unflattenDotted(flat: Record<string, string>): Record<string, unknown> 
   return out;
 }
 
+function applyHostLocaleOverlay(overlay: LocaleOverlay): void {
+  // Accept either a flat dotted bundle (``{"home.welcome": "Hi"}``)
+  // or an already-nested tree. The flat form is detected by every
+  // value being a primitive — if any value is itself an object, the
+  // caller passed the nested shape directly.
+  const looksFlat = Object.values(overlay.strings).every(
+    (v) => v === null || typeof v !== 'object',
+  );
+  const bundle = looksFlat
+    ? unflattenDotted(overlay.strings as Record<string, string>)
+    : overlay.strings;
+  // ``deep=true`` merges nested objects so a host overlaying a single
+  // sub-key under ``home`` doesn't wipe atrium's other ``home.*``
+  // strings. ``overwrite=true`` is the per-key last-write-wins.
+  i18n.addResourceBundle(overlay.locale, 'translation', bundle, true, true);
+}
+
+// Drain any overlays the host bundle registered before this module
+// finished initialising (defensive — host bundle loads after this
+// module imports), then subscribe so future ``registerLocale`` calls
+// land immediately.
+for (const overlay of getLocaleOverlays()) {
+  applyHostLocaleOverlay(overlay);
+}
+subscribeLocaleOverlay(applyHostLocaleOverlay);
+
 void (async () => {
   try {
     // Resolve the API base the same way ``lib/api.ts`` does. Bare
@@ -82,6 +113,14 @@ void (async () => {
   } catch {
     // Network or parse failures fall through to the bundled defaults —
     // an admin-broken /app-config response shouldn't take down the UI.
+  } finally {
+    // Re-apply host overlays last so the precedence is deterministic
+    // (shipped < admin override < host overlay) regardless of which
+    // async path resolved first. Subsequent host registrations land
+    // via the subscription above.
+    for (const overlay of getLocaleOverlays()) {
+      applyHostLocaleOverlay(overlay);
+    }
   }
 })();
 

--- a/frontend/src/routes/AdminPage.tsx
+++ b/frontend/src/routes/AdminPage.tsx
@@ -164,7 +164,7 @@ export function AdminPage() {
         )}
         {visibleHostTabs.map((tab) => (
           <Tabs.Panel key={tab.key} value={tab.key} pt="md">
-            {tab.element}
+            {tab.render ? tab.render() : tab.element}
           </Tabs.Panel>
         ))}
       </Tabs>

--- a/frontend/src/test/host-registry.test.tsx
+++ b/frontend/src/test/host-registry.test.tsx
@@ -26,6 +26,7 @@ import {
   __resetRegistryForTests,
   getAdminTabs,
   getHomeWidgets,
+  getLocaleOverlays,
   getNavItems,
   getNotificationRenderers,
   getProfileItems,
@@ -33,11 +34,13 @@ import {
   lookupNotificationRenderer,
   registerAdminTab,
   registerHomeWidget,
+  registerLocale,
   registerNavItem,
   registerNotificationKind,
   registerProfileItem,
   registerRoute,
   subscribeEvent,
+  subscribeLocaleOverlay,
 } from '@/host/registry';
 import {
   __eventBusSubscriberCountForTests,
@@ -108,16 +111,56 @@ describe('host registry', () => {
       registerRoute({
         key: 'first',
         path: '/x',
-        element: <span>first</span>,
+        render: () => <span>first</span>,
       });
       registerRoute({
         key: 'second',
         path: '/x',
-        element: <span>second</span>,
+        render: () => <span>second</span>,
       });
       const routes = getRoutes();
       expect(routes).toHaveLength(1);
       expect(routes[0]?.key).toBe('second');
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('registerRoute carries render() through and produces a fresh element each call', () => {
+    let calls = 0;
+    registerRoute({
+      key: 'r',
+      path: '/r',
+      render: () => {
+        calls += 1;
+        return <span>r{calls}</span>;
+      },
+    });
+    const route = getRoutes()[0]!;
+    expect(typeof route.render).toBe('function');
+    const first = route.render!();
+    const second = route.render!();
+    expect(first).not.toBe(second);
+    expect(calls).toBe(2);
+  });
+
+  it('registerRoute still accepts deprecated element shape', () => {
+    registerRoute({
+      key: 'legacy',
+      path: '/legacy',
+      element: <span>legacy</span>,
+    });
+    const route = getRoutes()[0]!;
+    expect(route.element).toBeDefined();
+    expect(route.render).toBeUndefined();
+  });
+
+  it('registerRoute drops the registration when neither render nor element is supplied', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      registerRoute({ key: 'broken', path: '/broken' } as never);
+      expect(getRoutes()).toHaveLength(0);
       expect(warn).toHaveBeenCalledOnce();
     } finally {
       warn.mockRestore();
@@ -138,10 +181,39 @@ describe('host registry', () => {
       key: 't',
       label: 'Tab',
       perm: 'thing.manage',
-      element: <span>tab</span>,
+      render: () => <span>tab</span>,
     });
     const tabs = getAdminTabs();
     expect(tabs[0]?.perm).toBe('thing.manage');
+  });
+
+  it('registerAdminTab carries render() through and accepts deprecated element', () => {
+    registerAdminTab({
+      key: 'a',
+      label: 'A',
+      render: () => <span>A</span>,
+    });
+    registerAdminTab({
+      key: 'b',
+      label: 'B',
+      element: <span>B</span>,
+    });
+    const tabs = getAdminTabs();
+    expect(tabs[0]?.render).toBeDefined();
+    expect(tabs[0]?.element).toBeUndefined();
+    expect(tabs[1]?.render).toBeUndefined();
+    expect(tabs[1]?.element).toBeDefined();
+  });
+
+  it('registerAdminTab drops the registration when neither render nor element is supplied', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      registerAdminTab({ key: 'broken', label: 'Broken' } as never);
+      expect(getAdminTabs()).toHaveLength(0);
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it('registerProfileItem appends in registration order', () => {
@@ -271,6 +343,39 @@ describe('host registry', () => {
       expect(getHomeWidgets().map((w) => w.key)).toContain(
         'after-future-call',
       );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('registerLocale records overlays and notifies subscribers', () => {
+    const heard: string[] = [];
+    const off = subscribeLocaleOverlay((o) => heard.push(o.locale));
+    try {
+      registerLocale({ locale: 'en', strings: { 'app.title': 'X' } });
+      registerLocale({ locale: 'nl', strings: { 'app.title': 'X-NL' } });
+      const overlays = getLocaleOverlays();
+      expect(overlays.map((o) => o.locale)).toEqual(['en', 'nl']);
+      expect(heard).toEqual(['en', 'nl']);
+    } finally {
+      off();
+    }
+  });
+
+  it('registerLocale stacks multiple overlays for the same locale in order', () => {
+    registerLocale({ locale: 'en', strings: { 'a': '1' } });
+    registerLocale({ locale: 'en', strings: { 'b': '2' } });
+    expect(getLocaleOverlays()).toHaveLength(2);
+  });
+
+  it('registerLocale rejects empty locale and non-object strings', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      registerLocale({ locale: '', strings: { a: '1' } });
+      registerLocale({ locale: 'en', strings: null as unknown as Record<string, unknown> });
+      registerLocale({ locale: 'en', strings: ['a'] as unknown as Record<string, unknown> });
+      expect(getLocaleOverlays()).toHaveLength(0);
+      expect(warn).toHaveBeenCalledTimes(3);
     } finally {
       warn.mockRestore();
     }


### PR DESCRIPTION
## Summary

Three independent host-integration improvements bundled into one
release. Each is small enough that splitting into separate PRs would
be net churn; the diff stays reviewable as three logical commits.

- **Host registry: `render()` shape + `registerLocale` overlay**
  (closes #31, closes #35). `registerRoute` and `registerAdminTab`
  now mirror the `render: () => ReactElement` shape that
  `registerHomeWidget` and `registerNotificationKind` already use,
  so a host that registers two routes via wrapper elements doesn't
  see DOM-node reuse across `<Route>` swaps. The captured-element
  shape is kept as a deprecated alias. New `registerLocale({
  locale, strings })` lets a host overlay translation strings (chrome
  + own keys) onto i18next without standing up a parallel provider;
  precedence is shipped < admin overrides < host overlay.

- **`roles[]` on `/admin/users`** (closes #33). The admin user
  listing now emits `roles: list[str]` alongside the existing
  `role_ids: list[int]`, so hosts filtering by role membership
  ("show me everyone without the agent role") get a stable,
  environment-portable code in one round-trip. Patch endpoint still
  binds to `role_ids`; old clients reading `role_ids` keep working.

- **`docs/host-dev-recipe.md`** (closes #34). End-to-end recipe a
  new integrator picks up after the new-project bootstrap lands
  them at "skeleton runs": live-reload bind mounts, GHCR pull
  access, security-CI checklist (the `actions: read` silent-fail
  trap, Code Security repo toggle, SARIF upload), test stack split.
  Cross-linked from the README and `published-images.md`.

#32 (`workflow_dispatch` only tagging `:latest`) was already fixed
in 29b9797 / PR #27 and shipped in v0.11.3 — closed as duplicate.

## Test plan

- [x] `make test-backend` — 178 passed (added a list-endpoint roles
  assertion + extended an existing patch-endpoint assertion to cover
  the new field)
- [x] `make test-frontend` — 49 passed (up from 41; new tests cover
  render/element acceptance on routes/admin tabs and the
  `registerLocale` overlay flow + listener notifications)
- [x] `pnpm typecheck` — clean
- [x] `make lint` — clean (the pre-existing `useEffect` warning in
  `AppLayout.tsx:66` is untouched)
- [x] `make smoke` — 9/9 passed
- [x] `make smoke-hello` — 7/8 passed; the failure is the documented
  `toggle on starts the tick, toggle off stops it` flake (3/5 on
  isolated retries, fails with `socket hang up` mid-poll). Verified
  not a regression: the same flake reproduces against `master` with
  my changes stashed.