### PR TITLE
Expose __ATRIUM_VERSION__ on window for runtime feature detection

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -57,6 +57,41 @@ make smoke-down              # before make smoke-hello
 make smoke-hello-down        # after make smoke-hello
 ```
 
+## 1.5. Bump the version + sync docs
+
+The version that ships in the image comes from
+`backend/pyproject.toml` — `app.services.app_config._atrium_version()`
+reads it via `importlib.metadata.version("atrium-backend")` and exposes
+it on `GET /app-config`, which the SPA mirrors onto
+`window.__ATRIUM_VERSION__` for host-bundle feature detection. If you
+don't bump it here, every host running the new image will report the
+old version.
+
+Land the bump on the feature branch *before* tagging so master and the
+git tag agree:
+
+```bash
+# backend/pyproject.toml — set ``version = "X.Y.Z"`` to match the tag
+# you're about to push. Refresh the lockfile so uv.lock stays in sync:
+( cd backend && uv lock --quiet )
+```
+
+While you're at it, sweep the documentation and the AI bootstrap
+skill for stale version references — both are reader-facing and
+quickly fall behind:
+
+- `docs/published-images.md` — anywhere it cites a concrete atrium
+  version (compat matrix rows, "since 0.X" notes, example pulls).
+- `docs/new-project/README.md` and `docs/new-project/SKILL.md` —
+  any pinned `ghcr.io/.../atrium:X.Y.Z` references in the bootstrap
+  walkthroughs. The SKILL.md is the AI-driveable variant; missing
+  it leaves agents emitting stale tags.
+- `examples/hello-world/` — same sweep for any pinned base-image
+  reference.
+
+If a doc references an atrium version, it needs updating with each
+release. If it doesn't, it stays untouched.
+
 ## 2. Branch + commit hygiene
 
 - Branch names: concrete, descriptive, **under 30 characters**, no

--- a/backend/app/services/app_config.py
+++ b/backend/app/services/app_config.py
@@ -18,7 +18,8 @@ audit retention, i18n overrides).
 """
 from __future__ import annotations
 
-from typing import Literal
+from importlib import metadata as _metadata
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 from sqlalchemy import select
@@ -26,6 +27,23 @@ from sqlalchemy.dialects.mysql import insert as mysql_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.ops import AppSetting
+
+
+def _atrium_version() -> str:
+    """Resolve the atrium backend's version string for the public bundle.
+
+    Sourced from the installed dist metadata so a single bump of
+    ``backend/pyproject.toml`` at release time propagates to
+    ``window.__ATRIUM_VERSION__`` on every host without code changes.
+    Falls back to ``"unknown"`` if the package isn't installed (e.g. a
+    bare-source dev tree without ``uv sync``) — host bundles already
+    treat the value as best-effort observability, not a contract.
+    """
+
+    try:
+        return _metadata.version("atrium-backend")
+    except _metadata.PackageNotFoundError:
+        return "unknown"
 
 
 class BrandConfig(BaseModel):
@@ -180,10 +198,15 @@ async def put_namespace(
     return validated
 
 
-async def get_public_config(session: AsyncSession) -> dict[str, dict]:
+async def get_public_config(session: AsyncSession) -> dict[str, Any]:
     """Bundle every public namespace into one response — the frontend
-    hits this once at boot and feeds it to MantineProvider/i18n/etc."""
-    out: dict[str, dict] = {}
+    hits this once at boot and feeds it to MantineProvider/i18n/etc.
+
+    Top-level ``version`` carries the running backend's version so the
+    SPA can mirror it to ``window.__ATRIUM_VERSION__`` for host-bundle
+    feature detection (issue #43).
+    """
+    out: dict[str, Any] = {"version": _atrium_version()}
     for ns in NAMESPACES.values():
         if not ns.public:
             continue

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -3,11 +3,14 @@
 
 [project]
 name = "atrium-backend"
-# Bumped at release time, before tagging vX.Y.Z. Sourced at runtime by
+# Bumped once per release, on the final pre-tag commit (see
+# RELEASING.md step 1.5). Sourced at runtime by
 # ``app.services.app_config._atrium_version`` and surfaced on the
 # public ``GET /app-config`` bundle so the SPA can mirror it onto
 # ``window.__ATRIUM_VERSION__`` for host-bundle feature detection.
-version = "0.12.1"
+# Until the next release-bump lands, ``__ATRIUM_VERSION__`` reports
+# this value verbatim — i.e. the *previous* released version.
+version = "0.1.0"
 description = "Atrium — auth/RBAC/notifications/audit starter (backend)"
 readme = "../README.md"
 requires-python = ">=3.12"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -3,7 +3,11 @@
 
 [project]
 name = "atrium-backend"
-version = "0.1.0"
+# Bumped at release time, before tagging vX.Y.Z. Sourced at runtime by
+# ``app.services.app_config._atrium_version`` and surfaced on the
+# public ``GET /app-config`` bundle so the SPA can mirror it onto
+# ``window.__ATRIUM_VERSION__`` for host-bundle feature detection.
+version = "0.12.0"
 description = "Atrium — auth/RBAC/notifications/audit starter (backend)"
 readme = "../README.md"
 requires-python = ">=3.12"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,7 +7,7 @@ name = "atrium-backend"
 # ``app.services.app_config._atrium_version`` and surfaced on the
 # public ``GET /app-config`` bundle so the SPA can mirror it onto
 # ``window.__ATRIUM_VERSION__`` for host-bundle feature detection.
-version = "0.12.0"
+version = "0.12.1"
 description = "Atrium — auth/RBAC/notifications/audit starter (backend)"
 readme = "../README.md"
 requires-python = ">=3.12"

--- a/backend/tests/api/test_app_config.py
+++ b/backend/tests/api/test_app_config.py
@@ -35,6 +35,18 @@ async def _wipe_app_config(engine, *keys: str) -> None:
 
 
 @pytest.mark.asyncio
+async def test_public_endpoint_includes_version(client, engine):
+    """Issue #43 — top-level ``version`` lets host bundles mirror the
+    running atrium release onto ``window.__ATRIUM_VERSION__``."""
+    r = await client.get("/app-config")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "version" in body, body
+    assert isinstance(body["version"], str)
+    assert body["version"]
+
+
+@pytest.mark.asyncio
 async def test_public_endpoint_returns_brand_defaults(client, engine):
     await _wipe_app_config(engine, "brand")
     r = await client.get("/app-config")

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -129,7 +129,7 @@ wheels = [
 
 [[package]]
 name = "atrium-backend"
-version = "0.12.1"
+version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiomysql" },

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -129,7 +129,7 @@ wheels = [
 
 [[package]]
 name = "atrium-backend"
-version = "0.1.0"
+version = "0.12.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiomysql" },

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -129,7 +129,7 @@ wheels = [
 
 [[package]]
 name = "atrium-backend"
-version = "0.12.0"
+version = "0.12.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiomysql" },

--- a/docs/published-images.md
+++ b/docs/published-images.md
@@ -323,8 +323,8 @@ the same handler reference is a silent no-op.
 
 ### Runtime version detection (`window.__ATRIUM_VERSION__`)
 
-Available since atrium 0.12.1. The running backend's version string
-(e.g. `"0.12.1"`) is mirrored onto `window.__ATRIUM_VERSION__` from
+Available since atrium 0.14.0. The running backend's version string
+(e.g. `"0.14.0"`) is mirrored onto `window.__ATRIUM_VERSION__` from
 the `/app-config` boot fetch — *before* the host bundle is imported,
 so import-time code can branch on it.
 
@@ -335,7 +335,7 @@ declare global {
   }
 }
 
-if (window.__ATRIUM_VERSION__ && satisfies(window.__ATRIUM_VERSION__, '>= 0.13.0')) {
+if (window.__ATRIUM_VERSION__ && satisfies(window.__ATRIUM_VERSION__, '>= 0.14.0')) {
   reg.subscribeEvent('booking.created', invalidate);
 } else {
   console.warn('[host] atrium', window.__ATRIUM_VERSION__, 'lacks SSE invalidation; falling back to focus polling');
@@ -346,7 +346,7 @@ The defensive Proxy on `window.__ATRIUM_REGISTRY__` already turns
 calls to missing methods into no-ops, so version-gating is for
 *observability* (logging the version on bundle init) and for branching
 on intended fallbacks — not for safety. The field is `undefined` on
-atrium images that predate 0.12.1; treat it as best-effort.
+atrium images that predate 0.14.0; treat it as best-effort.
 
 ### Building the host bundle
 

--- a/docs/published-images.md
+++ b/docs/published-images.md
@@ -321,6 +321,33 @@ shape (no key, returns an unsubscribe handle) and follows
 register-once-then-stay semantics — a duplicate subscription with
 the same handler reference is a silent no-op.
 
+### Runtime version detection (`window.__ATRIUM_VERSION__`)
+
+Available since atrium 0.12.1. The running backend's version string
+(e.g. `"0.12.1"`) is mirrored onto `window.__ATRIUM_VERSION__` from
+the `/app-config` boot fetch — *before* the host bundle is imported,
+so import-time code can branch on it.
+
+```ts
+declare global {
+  interface Window {
+    __ATRIUM_VERSION__?: string;
+  }
+}
+
+if (window.__ATRIUM_VERSION__ && satisfies(window.__ATRIUM_VERSION__, '>= 0.13.0')) {
+  reg.subscribeEvent('booking.created', invalidate);
+} else {
+  console.warn('[host] atrium', window.__ATRIUM_VERSION__, 'lacks SSE invalidation; falling back to focus polling');
+}
+```
+
+The defensive Proxy on `window.__ATRIUM_REGISTRY__` already turns
+calls to missing methods into no-ops, so version-gating is for
+*observability* (logging the version on bundle init) and for branching
+on intended fallbacks — not for safety. The field is `undefined` on
+atrium images that predate 0.12.1; treat it as best-effort.
+
 ### Building the host bundle
 
 The host's frontend is a separate Vite project that emits a single ES

--- a/frontend/src/hooks/useAppConfig.ts
+++ b/frontend/src/hooks/useAppConfig.ts
@@ -64,6 +64,11 @@ export interface AuthConfig {
 }
 
 export interface PublicAppConfig {
+  // Running atrium backend version (e.g. ``"0.12.0"``). Mirrored onto
+  // ``window.__ATRIUM_VERSION__`` at boot for host-bundle feature
+  // detection. Optional because hosts may run against an older atrium
+  // image that predates the field — read it defensively.
+  version?: string;
   brand: BrandConfig;
   system?: SystemConfig;
   i18n?: I18nConfig;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -36,9 +36,15 @@ import './i18n';
 // expose the SPA's React instance on ``window`` for them to pick up;
 // without this, an externalised bundle would resolve to ``undefined``
 // at runtime.
+//
+// ``__ATRIUM_VERSION__`` is the running backend's version string,
+// mirrored from ``GET /app-config`` so host bundles can do runtime
+// feature detection (issue #43). Optional because the field is also
+// missing on atrium images that predate it.
 declare global {
   interface Window {
     React?: typeof React;
+    __ATRIUM_VERSION__?: string;
   }
 }
 if (typeof window !== 'undefined') {
@@ -50,6 +56,7 @@ interface BootSystemSlice {
 }
 
 interface BootAppConfig {
+  version?: string;
   system?: BootSystemSlice;
 }
 
@@ -57,6 +64,12 @@ async function loadHostBundle(): Promise<void> {
   let url: string | null | undefined;
   try {
     const { data } = await api.get<BootAppConfig>('/app-config');
+    // Set the global before importing the host bundle so its
+    // import-time side-effects can read ``window.__ATRIUM_VERSION__``
+    // when deciding whether to call newer registry methods.
+    if (typeof data?.version === 'string') {
+      window.__ATRIUM_VERSION__ = data.version;
+    }
     url = data?.system?.host_bundle_url ?? null;
   } catch (err) {
     // /app-config is the same call useAppConfig() makes once React


### PR DESCRIPTION
## Summary

Closes #43.

- Backend: top-level `version` field on `GET /app-config`, sourced
  from `importlib.metadata.version("atrium-backend")` so a single
  bump of `backend/pyproject.toml` at release time propagates without
  code changes.
- Frontend: mirror the field onto `window.__ATRIUM_VERSION__` from
  the existing boot fetch in `main.tsx` — set *before* the host
  bundle is dynamically imported, so import-time host code can
  branch on it.
- Docs: `docs/published-images.md` gains a "Runtime version
  detection" section documenting the global as part of the host
  extension contract. `RELEASING.md` gains step 1.5 covering the
  `pyproject.toml` bump + the documentation/skill sweep that has
  to land alongside it.
- Pyproject + lockfile bumped from the stale `0.1.0` to `0.12.1`,
  matching the "since" version cited in the docs.

## Test plan

- [x] `make test-backend` — 179 passed (added one assertion that
      `version` is a non-empty string on `/app-config`).
- [x] `pnpm test` — 49 passed.
- [x] `pnpm typecheck` — clean.
- [x] `ruff check` on touched files — clean.
- [ ] CI to run `make smoke` end-to-end.