### PR TITLE
Compat matrix + skip CI on doc-only PRs (#46)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,14 @@ name: CI
 
 on:
   pull_request:
+    # Doc-only PRs skip CI entirely. The filter triggers when *every*
+    # changed file matches one of these patterns; mixed PRs (any code
+    # file alongside docs) still run the full suite. Mirrors codeql.yml
+    # and security.yml so a doc-only PR is genuinely free.
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "LICENCE.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,12 @@ name: CodeQL
 on:
   pull_request:
     branches: [master]
+    # Doc-only PRs skip CodeQL — no Python or TS source changed, the
+    # weekly cron and on-demand dispatch still cover full scans.
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "LICENCE.md"
   schedule:
     - cron: "0 6 * * 1"
   workflow_dispatch:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,6 +20,13 @@ on:
   push:
     branches: [master]
   pull_request:
+    # Doc-only PRs skip the supply-chain scans — no lockfiles, no
+    # Dockerfile, no source touched. The master push + weekly cron
+    # still keep coverage end-to-end on whatever lands.
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "LICENCE.md"
   schedule:
     - cron: "0 6 * * 1"
   workflow_dispatch:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -80,8 +80,15 @@ While you're at it, sweep the documentation and the AI bootstrap
 skill for stale version references — both are reader-facing and
 quickly fall behind:
 
+- `docs/compat-matrix.md` — **add a row** for the release you're
+  about to cut. One row per published `vX.Y.Z`, with the alembic
+  head, any new registry hooks, deprecations, and env / config
+  changes. Cells stay terse; the release notes carry the prose. Use
+  an em-dash for axes that didn't move in this release. The link
+  in the *Atrium* column points at the release you're about to
+  publish (step 9 below).
 - `docs/published-images.md` — anywhere it cites a concrete atrium
-  version (compat matrix rows, "since 0.X" notes, example pulls).
+  version ("since 0.X" notes, example pulls).
 - `docs/new-project/README.md` and `docs/new-project/SKILL.md` —
   any pinned `ghcr.io/.../atrium:X.Y.Z` references in the bootstrap
   walkthroughs. The SKILL.md is the AI-driveable variant; missing
@@ -168,6 +175,16 @@ afterwards:
 ```bash
 gh run view <ci-run-id> --json conclusion,status -q '{conclusion,status}'
 ```
+
+**Doc-only PRs skip CI.** All three PR workflows carry a
+`paths-ignore` filter for `**.md`, `docs/**`, and `LICENCE.md`, so a
+PR whose every changed file matches one of those patterns triggers
+zero workflow runs. `gh run list --branch <branch>` will return
+nothing — that's expected, not a "CI hung" signal. Mixed PRs (any
+non-docs file alongside docs) still run the full suite; the filter
+only fires when *every* changed path is in the ignore list. The
+weekly Security cron and the on-demand `workflow_dispatch` for
+CodeQL still cover full scans regardless.
 
 ## 6. Merge
 

--- a/docs/compat-matrix.md
+++ b/docs/compat-matrix.md
@@ -1,0 +1,69 @@
+# Atrium ↔ host compat matrix
+
+A host on (e.g.) `0.10.0` planning the jump to `0.12.0` reads this page once
+and knows: no migrations to coordinate, four new optional registry hooks
+became available along the way, the SSE wire format changed in `0.11.3`,
+the registry's `element:` shape on `registerRoute` / `registerAdminTab` is
+soft-deprecated in favour of `render()`. Release notes carry the prose; the
+matrix below is the navigation aid.
+
+Your running atrium version is mirrored onto `window.__ATRIUM_VERSION__`
+(available since 0.14.0 — see the *Runtime version detection* section in
+[`published-images.md`](published-images.md)). Find that row in the table,
+then read forward to plan the upgrade path.
+
+## Matrix
+
+| Atrium | Schema (alembic head) | New registry hooks | Deprecations | Env / config |
+| ------ | --------------------- | ------------------ | ------------ | ------------ |
+| [0.9.x](https://github.com/Brendan-Bank/atrium/releases/tag/v0.9.1) | `0005_email_template_per_locale` (initial published chain) | `registerHomeWidget`, `registerRoute`, `registerNavItem`, `registerAdminTab`; backend `init_app` / `init_worker` contract; `seed_permissions` / `seed_permissions_sync` | — | new: `ATRIUM_HOST_MODULE` |
+| [0.10.0](https://github.com/Brendan-Bank/atrium/releases/tag/v0.10.0) | unchanged | — | — | new: `ATRIUM_STATIC_DIR`. **Breaking image change**: `atrium-backend` + `atrium-web` collapsed into one `atrium` image. Hosts must drop the separate `web` service and the proxy's `/api` rewrite, and bake their host SPA bundle into `/opt/atrium/static/host` |
+| 0.11.0 | unchanged | `registerProfileItem` | — | — |
+| [0.11.1](https://github.com/Brendan-Bank/atrium/releases/tag/v0.11.1) | unchanged | `registerHomeWidget({ width })` opt-out; defensive Proxy on `window.__ATRIUM_REGISTRY__` so unknown `register*` calls log + no-op instead of throwing | — | — |
+| [0.11.2](https://github.com/Brendan-Bank/atrium/releases/tag/v0.11.2) | unchanged | `registerNotificationKind` | — | — |
+| [0.11.3](https://github.com/Brendan-Bank/atrium/releases/tag/v0.11.3) | unchanged | `subscribeEvent`. **SSE wire-format change**: `/notifications/stream` events now carry the row's actual `{kind, payload}` instead of the literal `{kind: 'refresh'}` | — | — |
+| [0.12.0](https://github.com/Brendan-Bank/atrium/releases/tag/v0.12.0) | unchanged | `registerLocale`; `render()` form on `registerRoute` and `registerAdminTab`; `roles[]` (role codes) added to `/admin/users` responses | `element:` shape on `registerRoute` / `registerAdminTab` is soft-deprecated — keep working via fallback, but new code should pass `render: () => …` | — |
+
+A blank cell means "no change in this release on that axis". Schema rows
+list the alembic head a host can rely on coexisting with — atrium owns
+`alembic_version`, the host owns `alembic_version_app`, and the two heads
+advance independently (see [`published-images.md`](published-images.md#migrations)).
+
+## Schema changes since the first published image
+
+There have been **no atrium-side schema changes** since the first published
+image (0.9.1). The chain has stayed at `0005_email_template_per_locale`
+across the entire 0.9.x → 0.12.x line. A host's alembic chain that was
+written against any of these images can upgrade to the latest without
+coordinating an atrium migration.
+
+This is the column that changes most rarely; when it does (a new revision
+on `backend/alembic/versions/`), the cell will name the revision id and
+link to the migration file so a host author can read what tables / columns
+are involved before pinning past it.
+
+## SSE wire format
+
+One change since the contract debuted in 0.9.1:
+
+- **0.11.3** — `/notifications/stream` events switched from
+  `{kind: 'refresh'}` (a hardcoded literal that just told consumers to
+  refetch) to `{kind, payload}` mirroring the notification row. Atrium's
+  bell still refetches on every event regardless of kind, so existing
+  hosts that wrote their own `EventSource` and ignored the body keep
+  working. Any host that explicitly required `kind === 'refresh'` needs
+  a one-line edit. New hosts use `subscribeEvent(kind, handler)` and let
+  atrium own the connection.
+
+## How this is maintained
+
+One row per published `vX.Y.Z` release. The row is added in the same PR
+that bumps `backend/pyproject.toml` and writes the GitHub release notes —
+[`RELEASING.md`](../RELEASING.md) step 1.5 captures this as part of the
+release-time documentation sweep. Cells stay terse: the table is for
+navigation, the release notes are the source of truth.
+
+When a release introduces something for a column that has never been used
+before (e.g. the first env-var rename, the first deprecation), prefer
+adding the row's prose to the matching release notes and keeping the
+matrix cell to a one-line summary plus a link.

--- a/docs/published-images.md
+++ b/docs/published-images.md
@@ -14,7 +14,10 @@ the retrofit playbook for moving an existing app onto atrium — see
 humans, [`SKILL.md`](new-project/SKILL.md) for AI agents). For the
 live-reload, GHCR pull access, and security-CI configuration that
 host integrations converge on, see
-[`host-dev-recipe.md`](host-dev-recipe.md).
+[`host-dev-recipe.md`](host-dev-recipe.md). For the per-release
+extension surface (which versions added which registry hooks, when the
+SSE wire format changed, when something was soft-deprecated), see
+[`compat-matrix.md`](compat-matrix.md).
 
 ---
 
@@ -347,6 +350,10 @@ calls to missing methods into no-ops, so version-gating is for
 *observability* (logging the version on bundle init) and for branching
 on intended fallbacks — not for safety. The field is `undefined` on
 atrium images that predate 0.14.0; treat it as best-effort.
+
+For the per-release extension-surface delta (which versions added which
+registry hooks, when wire formats changed, when anything was
+soft-deprecated), see [`compat-matrix.md`](compat-matrix.md).
 
 ### Building the host bundle
 


### PR DESCRIPTION
## Summary

- New `docs/compat-matrix.md` page bucketing atrium 0.9.x → 0.12.x by schema head, new registry hooks, deprecations, and env / config deltas. A host on (e.g.) 0.10.0 deciding whether to jump to 0.12.0 reads one page and knows what changed and what to coordinate.
- `docs/published-images.md` cross-links the matrix from both the intro and the *Runtime version detection* section.
- `RELEASING.md` step 1.5 now requires adding a matrix row in the same PR that bumps `backend/pyproject.toml`.
- New `paths-ignore` filter on `ci.yml`, `codeql.yml`, and `security.yml` so a PR whose every changed file is `**.md` / `docs/**` / `LICENCE.md` triggers no workflow runs. Mixed PRs (any non-docs change alongside docs) still run the full suite. The master-push trigger on Security and the weekly CodeQL cron are untouched so coverage stays end-to-end.
- `RELEASING.md` step 5 documents the skip so contributors on a doc-only PR don't read "no CI runs" as a hung pipeline.

Closes #46.

## Test plan

This PR mixes docs with workflow YAML changes, so CI runs (the workflow files themselves are not on the ignore list — that's by design; YAML changes need verification). The `paths-ignore` behaviour will be visible on the next PR that touches only `**.md` / `docs/**`.

- [x] All three workflow YAMLs parse (no syntax changes beyond the added `paths-ignore` block, which mirrors GitHub's documented schema).
- [x] `RELEASING.md` reads end-to-end with the two new blocks in step 1.5 and step 5.
- [x] `docs/compat-matrix.md` matches the published `gh release view` notes for each version (0.9.1 / 0.10.0 / 0.11.1 / 0.11.2 / 0.11.3 / 0.12.0) and the intermediate v0.11.0 tag.
- [x] Cross-links from `docs/published-images.md` resolve.
- [ ] CI green on this PR (workflow YAML changes verified intact).