### PR TITLE
HostWorkerCtx: typed register_job_handler for init_worker (#44)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -533,16 +533,28 @@ startup):
 - `account_hard_delete` — tick-driven scan of users whose
   `scheduled_hard_delete_at <= now`.
 
-Host-app handlers register the same way:
+Host-app handlers register through the typed `HostWorkerCtx` atrium
+hands to `init_worker(host)`:
 
 ```python
-from app.jobs.runner import register_handler
+from app.host_sdk.worker import HostWorkerCtx
 
 async def send_welcome_email(session, job, payload):
     ...
 
-register_handler("welcome_email", send_welcome_email)
+def init_worker(host: HostWorkerCtx) -> None:
+    host.register_job_handler(
+        kind="welcome_email",
+        handler=send_welcome_email,
+        description="Send welcome email after signup",
+    )
 ```
+
+Internally `host.register_job_handler` calls
+`app.jobs.runner.register_handler` (still exported, still works) and
+adds a `host.job_handler.registered` startup log + a
+`host.job_handler.duplicate` warning when the same kind is registered
+twice.
 
 `scheduled_jobs` rows carry an opaque `entity_type` + `entity_id` so
 the host can attribute a job to a domain row without a hard FK. The

--- a/README.md
+++ b/README.md
@@ -418,8 +418,11 @@ The starter ships *only* the platform layer. To add your domain:
    public=False)` from import-time. The admin UI surface picks it up
    automatically.
 6. For background work: write a handler and register it via
-   `app.jobs.runner.register_handler("your_kind", handler)` from
-   `app/main.py` or `worker.py` startup.
+   `host.register_job_handler(kind="your_kind", handler=handler,
+   description="...")` from a host bundle's `init_worker(host)`
+   callback (where `host: app.host_sdk.worker.HostWorkerCtx`). For
+   in-tree work, call `app.jobs.runner.register_handler(...)`
+   directly from worker startup.
 7. For per-user notifications: call
    `app.services.notifications.notify_user(...)` from inside the
    transaction that mutated the domain row.

--- a/backend/app/host_sdk/worker.py
+++ b/backend/app/host_sdk/worker.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Host-side worker context.
+
+Atrium hands one of these to a host's ``init_worker(host)`` so the host
+can register APScheduler jobs and ``scheduled_jobs`` handlers through a
+typed surface — the worker-side equivalent of the frontend's six
+``__ATRIUM_REGISTRY__.register*`` methods. Hosts no longer need to
+import ``app.jobs.runner.register_handler`` directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+from app.jobs.runner import JobHandler, register_handler
+from app.logging import log
+
+
+@dataclass
+class HostWorkerCtx:
+    """Typed surface passed to a host's ``init_worker(host)`` callback.
+
+    The dataclass is the extension point: future host-facing worker
+    capabilities (e.g. a richer ``register_periodic`` helper, scheduler
+    introspection) get added as new attributes without churning the
+    callback signature.
+    """
+
+    scheduler: AsyncIOScheduler
+    """The APScheduler instance atrium runs platform ticks against.
+
+    Hosts call ``host.scheduler.add_job(...)`` for recurring inline
+    work; for durable, atomic, queue-backed work use
+    :meth:`register_job_handler` and insert ``scheduled_jobs`` rows."""
+
+    _registered_kinds: set[str] = field(default_factory=set, repr=False)
+
+    def register_job_handler(
+        self,
+        *,
+        kind: str,
+        handler: JobHandler,
+        description: str | None = None,
+    ) -> None:
+        """Register ``handler`` to drain ``scheduled_jobs`` rows of
+        ``job_type=kind``.
+
+        ``handler`` is ``async (session, job, payload) -> None``. The
+        runner already wraps every invocation in a try/except (see
+        ``app.jobs.runner.run_one``) — a thrower marks the row FAILED
+        and is logged as ``job.failed`` rather than killing the worker.
+        That mirrors the frontend ``subscribeEvent`` fan-out: one bad
+        handler can't bring the loop down.
+
+        ``description`` is a short human-readable label (used in
+        startup logs and, eventually, ``/admin/jobs`` introspection).
+
+        Re-registering the same ``kind`` is allowed (last-write-wins,
+        matching ``register_handler``) but emits a ``warning`` log so
+        an accidental collision is visible.
+        """
+        if not kind:
+            raise ValueError("register_job_handler: 'kind' must be non-empty")
+        if kind in self._registered_kinds:
+            log.warning(
+                "host.job_handler.duplicate",
+                kind=kind,
+                description=description,
+            )
+        register_handler(kind, handler)
+        self._registered_kinds.add(kind)
+        log.info(
+            "host.job_handler.registered",
+            kind=kind,
+            description=description,
+        )
+
+
+__all__ = ["HostWorkerCtx", "JobHandler"]

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -26,6 +26,7 @@ from sqlalchemy import and_, exists, select
 from sqlalchemy.dialects.mysql import insert as mysql_insert
 
 from app.db import get_engine, get_session_factory
+from app.host_sdk.worker import HostWorkerCtx
 from app.jobs.builtin_handlers import register_builtin_handlers
 from app.jobs.runner import run_one
 from app.logging import configure_logging, log
@@ -226,7 +227,7 @@ async def main() -> None:
         mod = importlib.import_module(host_module)
         init = getattr(mod, "init_worker", None)
         if callable(init):
-            init(scheduler)
+            init(HostWorkerCtx(scheduler=scheduler))
         else:
             log.info("host.init_worker.absent", module=host_module)
 

--- a/backend/tests/unit/test_host_bootstrap.py
+++ b/backend/tests/unit/test_host_bootstrap.py
@@ -124,19 +124,23 @@ def test_create_app_unimportable_module_raises(_restore_env, monkeypatch):
 
 def test_worker_bootstrap_calls_init_worker(_restore_env, monkeypatch):
     """Mirror of the api hook: the worker reads ATRIUM_HOST_MODULE and
-    invokes ``init_worker(scheduler)`` if present.
+    invokes ``init_worker(host)`` with a :class:`HostWorkerCtx` if
+    present.
 
     We exercise the inline code shape rather than spinning up
     ``worker.main()`` — that path starts an APScheduler event loop and
     is significantly more expensive to fixture than the bootstrap
     contract warrants.
     """
+    from app.host_sdk.worker import HostWorkerCtx
+
     captured: dict[str, object] = {}
 
     fake = types.ModuleType("atrium_test_host_module_w")
 
-    def init_worker(scheduler: object) -> None:
-        captured["scheduler"] = scheduler
+    def init_worker(host: HostWorkerCtx) -> None:
+        captured["host"] = host
+        captured["scheduler"] = host.scheduler
 
     fake.init_worker = init_worker
     _install_fake_module("atrium_test_host_module_w", fake)
@@ -149,8 +153,9 @@ def test_worker_bootstrap_calls_init_worker(_restore_env, monkeypatch):
             mod = importlib.import_module(host_module)
             init = getattr(mod, "init_worker", None)
             if callable(init):
-                init(scheduler_sentinel)
+                init(HostWorkerCtx(scheduler=scheduler_sentinel))  # type: ignore[arg-type]
     finally:
         _uninstall_fake_module("atrium_test_host_module_w")
 
+    assert isinstance(captured.get("host"), HostWorkerCtx)
     assert captured.get("scheduler") is scheduler_sentinel

--- a/backend/tests/unit/test_host_sdk_worker.py
+++ b/backend/tests/unit/test_host_sdk_worker.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""``HostWorkerCtx`` + the typed ``register_job_handler`` host hook.
+
+Hosts call ``host.register_job_handler(kind=..., handler=...)`` from
+``init_worker(host)``; the runner's existing dispatch (``run_one``)
+picks up the handler against the same ``_HANDLERS`` dict that internal
+``register_handler`` writes to.
+
+The contract:
+
+1. A registered handler runs when a matching ``ScheduledJob`` row is
+   drained.
+2. A handler that throws is contained — the runner marks the job
+   FAILED with ``last_error``, logs ``job.failed``, and the worker
+   keeps polling. (This is already in ``run_one``; the test here
+   pins the behaviour against the host-facing path so the contract
+   referenced in ``HostWorkerCtx.register_job_handler`` doesn't
+   regress.)
+3. An unknown ``job_type`` is rejected loudly — the row is moved to
+   CANCELLED with an explanatory ``last_error``.
+4. Calling ``register_job_handler`` with an empty ``kind`` raises
+   immediately (cheap fail-fast at startup).
+5. Re-registering the same ``kind`` is allowed but emits a
+   ``host.job_handler.duplicate`` warning so collisions are visible.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.host_sdk.worker import HostWorkerCtx
+from app.jobs.runner import clear_handlers, run_one
+from app.models.enums import JobState
+from app.models.ops import ScheduledJob
+
+
+@pytest.fixture
+def host_ctx() -> HostWorkerCtx:
+    """Fresh registry per test — clears the runner's process-wide
+    ``_HANDLERS`` dict so each case starts from a known state."""
+    clear_handlers()
+    # ``scheduler`` is unused by the registry tests; pass a sentinel so
+    # the dataclass is fully constructed without spinning up
+    # APScheduler. The contract only constrains how
+    # ``register_job_handler`` interacts with the runner.
+    return HostWorkerCtx(scheduler=object())  # type: ignore[arg-type]
+
+
+@pytest_asyncio.fixture
+async def queued_job(session: AsyncSession):
+    """Yield a callable that queues a ``ScheduledJob`` row of the
+    requested ``job_type`` for the runner to drain."""
+
+    async def _queue(job_type: str, payload: dict[str, Any] | None = None) -> int:
+        # MySQL DATETIME(0) rounds half-up; subtract a second so
+        # ``run_at <= NOW()`` is true on the next ``next_due_job``
+        # query (CLAUDE.md gotcha #1).
+        run_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(seconds=1)
+        job = ScheduledJob(
+            job_type=job_type,
+            run_at=run_at,
+            state=JobState.PENDING.value,
+            payload=payload or {},
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        return int(job.id)
+
+    return _queue
+
+
+@pytest.mark.asyncio
+async def test_registered_handler_runs(
+    session: AsyncSession, host_ctx: HostWorkerCtx, queued_job
+) -> None:
+    """The runner finds the host-registered handler and invokes it."""
+    seen: list[dict[str, Any]] = []
+
+    async def handler(sess: AsyncSession, job: ScheduledJob, payload: dict[str, Any]) -> None:
+        seen.append(payload)
+
+    host_ctx.register_job_handler(
+        kind="test.host_runs",
+        handler=handler,
+        description="unit test",
+    )
+
+    job_id = await queued_job("test.host_runs", {"hello": "world"})
+    did_work = await run_one(session)
+
+    assert did_work is True
+    assert seen == [{"hello": "world"}]
+
+    await session.commit()
+    refreshed = await session.get(ScheduledJob, job_id)
+    assert refreshed is not None
+    assert refreshed.state == JobState.DONE.value
+    assert refreshed.last_error is None
+
+
+@pytest.mark.asyncio
+async def test_handler_exception_is_contained(
+    session: AsyncSession, host_ctx: HostWorkerCtx, queued_job
+) -> None:
+    """A throwing handler marks the row FAILED and the runner returns
+    True so the worker keeps draining the next row instead of dying."""
+
+    async def boom(sess: AsyncSession, job: ScheduledJob, payload: dict[str, Any]) -> None:
+        raise RuntimeError("kaboom")
+
+    host_ctx.register_job_handler(kind="test.host_throws", handler=boom)
+
+    job_id = await queued_job("test.host_throws")
+    did_work = await run_one(session)
+
+    assert did_work is True
+
+    await session.commit()
+    refreshed = await session.get(ScheduledJob, job_id)
+    assert refreshed is not None
+    assert refreshed.state == JobState.FAILED.value
+    assert refreshed.last_error is not None
+    assert "kaboom" in refreshed.last_error
+
+
+@pytest.mark.asyncio
+async def test_unknown_kind_is_rejected_loudly(
+    session: AsyncSession, host_ctx: HostWorkerCtx, queued_job
+) -> None:
+    """Jobs without a registered handler are CANCELLED with a clear
+    ``last_error`` rather than silently retried forever."""
+    job_id = await queued_job("test.host_unknown")
+    did_work = await run_one(session)
+
+    assert did_work is True
+
+    await session.commit()
+    refreshed = await session.get(ScheduledJob, job_id)
+    assert refreshed is not None
+    assert refreshed.state == JobState.CANCELLED.value
+    assert refreshed.last_error is not None
+    assert "test.host_unknown" in refreshed.last_error
+
+
+def test_empty_kind_raises(host_ctx: HostWorkerCtx) -> None:
+    """A misconfigured registration (typo, missing constant) fails
+    fast at startup instead of silently shadowing a real kind."""
+
+    async def _noop(_s: AsyncSession, _j: ScheduledJob, _p: dict[str, Any]) -> None:
+        return None
+
+    with pytest.raises(ValueError):
+        host_ctx.register_job_handler(kind="", handler=_noop)
+
+
+def test_duplicate_registration_warns(
+    host_ctx: HostWorkerCtx, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Last-write-wins, but the collision is observable in logs.
+
+    Spy on ``log.warning`` directly — structlog's default logger
+    factory in the unconfigured (test) environment writes to stdout,
+    not stdlib logging, so ``caplog`` doesn't see the event.
+    """
+    captured: list[tuple[str, dict[str, object]]] = []
+
+    def _spy(event: str, **kwargs: object) -> None:
+        captured.append((event, kwargs))
+
+    from app.host_sdk import worker as host_worker
+
+    monkeypatch.setattr(host_worker.log, "warning", _spy)
+
+    async def first(_s, _j, _p):  # type: ignore[no-untyped-def]
+        return None
+
+    async def second(_s, _j, _p):  # type: ignore[no-untyped-def]
+        return None
+
+    host_ctx.register_job_handler(kind="test.host_dup", handler=first)
+    host_ctx.register_job_handler(kind="test.host_dup", handler=second)
+
+    duplicate_events = [
+        kwargs for event, kwargs in captured if event == "host.job_handler.duplicate"
+    ]
+    assert len(duplicate_events) == 1
+    assert duplicate_events[0]["kind"] == "test.host_dup"

--- a/docs/adr/0001-python-host-sdk.md
+++ b/docs/adr/0001-python-host-sdk.md
@@ -5,18 +5,21 @@ Status: accepted, 2026-04-28
 ## Context
 
 Atrium ships a host-extension contract today: a host module with
-`init_app(app)` / `init_worker(scheduler)`, a separate `HostBase`
+`init_app(app)` / `init_worker(host)`, a separate `HostBase`
 declarative base for host models, a separate alembic chain with its
 own version table, and registry hooks on the frontend. Hosts re-derive
 the same boilerplate every time — most painfully, the workaround
 needed to declare a foreign key from a host table to an atrium table
 without crashing the SQLAlchemy mapper at class-init.
 
-Issue #42 (this epic, wave 1) introduces the first piece of typed
+Issue #42 (this epic, wave 1) introduced the first piece of typed
 Python helper surface for hosts: a `HostForeignKey()` factory plus an
-alembic autogenerate hook. Issue #44 will add a typed
-`register_job_handler()` for the worker queue. There will be more —
-the host SDK is a long-running surface, not a single helper.
+alembic autogenerate hook. Issue #44 added the typed
+`HostWorkerCtx` (`app.host_sdk.worker`) so `init_worker(host)` exposes
+`host.scheduler` and `host.register_job_handler(...)` instead of
+forcing hosts to import the internal `app.jobs.runner.register_handler`.
+There will be more — the host SDK is a long-running surface, not a
+single helper.
 
 We need a stable home for these helpers that:
 

--- a/docs/new-project/README.md
+++ b/docs/new-project/README.md
@@ -61,7 +61,7 @@ your-app/
     src/
       your_app/
         __init__.py
-        bootstrap.py         # init_app(app), init_worker(scheduler)
+        bootstrap.py         # init_app(app), init_worker(host)
         models.py            # HostBase = DeclarativeBase()
         router.py            # APIRouter mounted by init_app
     alembic/
@@ -130,6 +130,8 @@ this module:
 from __future__ import annotations
 from fastapi import FastAPI
 
+from app.host_sdk.worker import HostWorkerCtx
+
 
 def init_app(app: FastAPI) -> None:
     """Called once during create_app(), after every atrium router is
@@ -142,18 +144,21 @@ def init_app(app: FastAPI) -> None:
     # register_namespace("your_ns", YourConfig, public=False)
 
 
-def init_worker(scheduler) -> None:  # noqa: ANN001 - APScheduler types are loose
+def init_worker(host: HostWorkerCtx) -> None:
     """Called on worker startup, after register_builtin_handlers() and
     before scheduler.start()."""
     # Recurring APScheduler tick:
     # from .schedule import tick
-    # scheduler.add_job(tick, "interval", seconds=30,
-    #                   id="your-tick", coalesce=True, max_instances=1)
+    # host.scheduler.add_job(tick, "interval", seconds=30,
+    #                        id="your-tick", coalesce=True, max_instances=1)
     #
     # Durable scheduled_jobs handler:
-    # from app.jobs.runner import register_handler
     # from .handlers import handle_thing
-    # register_handler("your_kind", handle_thing)
+    # host.register_job_handler(
+    #     kind="your_kind",
+    #     handler=handle_thing,
+    #     description="Drain your_kind scheduled_jobs rows",
+    # )
     pass
 ```
 
@@ -937,8 +942,8 @@ Adding an endpoint, a job, a UI fragment — the standard moves:
 |-------------------------------|----------------------------------------------------------|----------------------------------------------------------------------------|
 | HTTP endpoint                 | `<your_pkg>/router.py`                                   | `app.include_router(router)` in `init_app`                                 |
 | New permission                | A new alembic migration                                  | `seed_permissions_sync(op.get_bind(), [...], grants={...})`                |
-| Recurring tick                | `<your_pkg>/schedule.py` async function                  | `scheduler.add_job(fn, "interval", seconds=N, ...)` in `init_worker`       |
-| Durable async job             | A handler `(session, job, payload) -> None`              | `register_handler("kind", handler)` in `init_worker`                       |
+| Recurring tick                | `<your_pkg>/schedule.py` async function                  | `host.scheduler.add_job(fn, "interval", seconds=N, ...)` in `init_worker`  |
+| Durable async job             | A handler `(session, job, payload) -> None`              | `host.register_job_handler(kind="...", handler=..., description="...")` in `init_worker` |
 | Admin-tunable flag            | A Pydantic `BaseModel` config class                      | `register_namespace("ns", Model, public=False)` in `init_app`              |
 | Per-user notification         | Inside the txn that mutated the row                      | `from app.services.notifications import notify_user`                       |
 | Outbound email (queued)       | A template row in `email_templates` + a callsite         | `from app.email.sender import enqueue_and_log`                             |
@@ -1048,10 +1053,11 @@ Mapping an existing FastAPI/SQLAlchemy/React app onto these slots:
    `email_log` for the admin mail log.
 
 7. **Background jobs**. Each existing cron/celery task becomes either:
-   - **APScheduler tick** (`scheduler.add_job(...)`) for stateless,
+   - **APScheduler tick** (`host.scheduler.add_job(...)`) for stateless,
      idempotent recurring work.
-   - **`scheduled_jobs` queue handler** (`register_handler(...)`) for
-     work that must survive worker restarts and have retry semantics.
+   - **`scheduled_jobs` queue handler** (`host.register_job_handler(...)`)
+     for work that must survive worker restarts and have retry
+     semantics.
 
 8. **Audit**. Replace your audit log with `app.services.audit.record(...)`
    — same call signature, atrium gets impersonator-aware actor
@@ -1108,7 +1114,7 @@ from app.services.app_config import register_namespace
 from app.email.sender import send_and_log, enqueue_and_log
 
 # Jobs
-from app.jobs.runner import register_handler
+from app.host_sdk.worker import HostWorkerCtx  # type for init_worker(host)
 
 # Settings + logging
 from app.settings import get_settings

--- a/docs/new-project/SKILL.md
+++ b/docs/new-project/SKILL.md
@@ -73,9 +73,12 @@ Create these files (full contents in [`README.md`](README.md), section
   runtime deps (atrium image provides them).
 - `backend/src/<your_pkg>/__init__.py` — empty marker.
 - `backend/src/<your_pkg>/bootstrap.py` — define `init_app(app:
-  FastAPI) -> None` and optionally `init_worker(scheduler) -> None`.
-  `init_app` mounts your router. `init_worker` registers job handlers
-  and APScheduler ticks. Either may be absent (atrium logs
+  FastAPI) -> None` and optionally `init_worker(host: HostWorkerCtx)
+  -> None` (`from app.host_sdk.worker import HostWorkerCtx`).
+  `init_app` mounts your router. `init_worker` registers job
+  handlers via `host.register_job_handler(kind=..., handler=...,
+  description=...)` and APScheduler ticks via
+  `host.scheduler.add_job(...)`. Either may be absent (atrium logs
   `host.init_app.absent`); both run loud if the module fails to import.
 - `backend/src/<your_pkg>/models.py` — define `class HostBase(DeclarativeBase)`
   and your tables on it. **Never** parent host tables on `app.db.Base`.
@@ -326,7 +329,7 @@ from app.services.audit import record as record_audit    # write audit row
 from app.services.notifications import notify_user       # in-app notification + SSE
 from app.services.app_config import register_namespace   # admin-tunable namespace
 from app.email.sender import send_and_log, enqueue_and_log  # email pipeline
-from app.jobs.runner import register_handler             # scheduled_jobs handler
+from app.host_sdk.worker import HostWorkerCtx           # init_worker(host) ctx type
 from app.settings import get_settings                    # env-var settings
 from app.logging import log                              # structlog logger
 ```

--- a/docs/published-images.md
+++ b/docs/published-images.md
@@ -146,20 +146,34 @@ The module exports two optional callables:
 # host_app/bootstrap.py
 from fastapi import FastAPI
 
+from app.host_sdk.worker import HostWorkerCtx
+
 def init_app(app: FastAPI) -> None:
     """Called once during create_app(), after every atrium router is
     included and before the ASGI app starts serving."""
     from .router import router
     app.include_router(router)
 
-def init_worker(scheduler) -> None:
+def init_worker(host: HostWorkerCtx) -> None:
     """Called once during worker startup, after register_builtin_handlers()
-    and before scheduler.start()."""
-    from app.jobs.runner import register_handler
+    and before scheduler.start().
+
+    ``host`` exposes:
+      - ``host.scheduler`` — the APScheduler instance for recurring
+        ``add_job(...)`` ticks.
+      - ``host.register_job_handler(kind=..., handler=..., description=...)``
+        — the typed equivalent of importing the internal
+        ``app.jobs.runner.register_handler``. Atrium logs the
+        registration and warns on duplicate ``kind`` registrations.
+    """
     from .handler import my_handler
 
-    register_handler("my_kind", my_handler)
-    scheduler.add_job(my_tick, "interval", seconds=60)
+    host.register_job_handler(
+        kind="my_kind",
+        handler=my_handler,
+        description="Drain my_kind scheduled_jobs rows",
+    )
+    host.scheduler.add_job(my_tick, "interval", seconds=60)
 ```
 
 **Ordering guarantees**:
@@ -185,11 +199,17 @@ Through the registries atrium already exposes:
 - **App-config namespaces** — `register_namespace("my_ns", MyModel, public=False)`
   from `app.services.app_config`. Reaches the admin UI at
   `/admin/app-config` automatically.
-- **Job handlers** — `register_handler("my_kind", handler)` from
-  `app.jobs.runner`. The runner dispatches `scheduled_jobs` rows to
-  registered handlers; unknown `job_type` values are cancelled with a
-  loud `last_error` rather than retried indefinitely.
-- **APScheduler jobs** — `scheduler.add_job(...)` from `init_worker`.
+- **Job handlers** — `host.register_job_handler(kind="my_kind",
+  handler=handler, description="...")` from `init_worker(host)`. The
+  runner dispatches `scheduled_jobs` rows to registered handlers;
+  unknown `job_type` values are cancelled with a loud `last_error`
+  rather than retried indefinitely. Atrium logs every registration
+  (`host.job_handler.registered`) and warns on duplicate `kind`
+  registrations (`host.job_handler.duplicate`). Importing the
+  internal `app.jobs.runner.register_handler` directly still works
+  but is no longer the recommended path.
+- **APScheduler jobs** — `host.scheduler.add_job(...)` from
+  `init_worker(host)`.
 
 ### Permission seeding
 

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -12,7 +12,7 @@ is lying.
 | `ATRIUM_HOST_MODULE` bootstrap | `atrium_hello_world.bootstrap.init_app/init_worker`  |
 | `app.include_router`           | `/hello/state` (auth) and `/hello/toggle` (perm)     |
 | `seed_permissions_sync`        | Seeds `hello.toggle` in the host alembic migration   |
-| APScheduler `add_job`          | 3 s tick (2 s in tests) increments the counter inline |
+| APScheduler `add_job`          | 3 s tick (2 s in tests) increments the counter inline (via `host.scheduler.add_job` on the `HostWorkerCtx`) |
 | Host alembic chain             | Own `hello_state` table in `alembic_version_app`     |
 | `registerHomeWidget`           | Card on the home page                                |
 | `registerRoute`                | Dedicated `/hello` page                              |
@@ -72,7 +72,8 @@ the home page, alongside a sidebar link to `/hello` and a Hello World tab in
 the admin shell. Flip the toggle and the counter ticks every 30 seconds (the
 default `HELLO_TICK_SECONDS`). The example increments the counter inline from
 the APScheduler tick — for jobs that need durability across worker restarts,
-use atrium's `scheduled_jobs` queue + `register_handler` instead.
+use atrium's `scheduled_jobs` queue + `host.register_job_handler(...)` from
+`init_worker(host)` instead.
 
 That's it for the demo path. No proxy, no `-f` chains, no separate frontend
 container — atrium serves the SPA itself from the api process via Starlette

--- a/examples/hello-world/backend/src/atrium_hello_world/bootstrap.py
+++ b/examples/hello-world/backend/src/atrium_hello_world/bootstrap.py
@@ -13,15 +13,20 @@ The atrium image imports this module on startup when the operator sets
   form of ``app.auth.rbac_seed.seed_permissions_sync``. Migration-time
   seeding sidesteps the lifespan-vs-add_event_handler conflict in
   modern FastAPI and matches the schema-shaped nature of permissions.
-- ``init_worker(scheduler)`` runs on worker startup, after atrium's
-  built-in handlers register and before APScheduler starts. We add
-  the recurring counter-increment tick.
+- ``init_worker(host)`` runs on worker startup, after atrium's
+  built-in handlers register and before APScheduler starts. ``host``
+  is a :class:`~app.host_sdk.worker.HostWorkerCtx` that exposes the
+  APScheduler instance plus a typed ``register_job_handler`` for
+  ``scheduled_jobs`` dispatch. We add the recurring counter-increment
+  tick.
 """
 from __future__ import annotations
 
 import os
 
 from fastapi import FastAPI
+
+from app.host_sdk.worker import HostWorkerCtx
 
 # Default tick interval. Smoke tests and the dev compose overlay set
 # HELLO_TICK_SECONDS=2 so the spec lands in seconds; the standalone
@@ -35,11 +40,11 @@ def init_app(app: FastAPI) -> None:
     app.include_router(router)
 
 
-def init_worker(scheduler) -> None:  # noqa: ANN001 — APScheduler types are loose
+def init_worker(host: HostWorkerCtx) -> None:
     from .schedule import tick_hello_count
 
     seconds = int(os.environ.get("HELLO_TICK_SECONDS", str(DEFAULT_TICK_SECONDS)))
-    scheduler.add_job(
+    host.scheduler.add_job(
         tick_hello_count,
         "interval",
         seconds=seconds,
@@ -47,3 +52,11 @@ def init_worker(scheduler) -> None:  # noqa: ANN001 — APScheduler types are lo
         coalesce=True,
         max_instances=1,
     )
+
+    # Real hosts that need durable, queue-backed work register a handler
+    # for the relevant ``scheduled_jobs.job_type`` here, e.g.:
+    #     host.register_job_handler(
+    #         kind="hello.welcome_email",
+    #         handler=send_welcome_email,
+    #         description="Send welcome email after signup",
+    #     )

--- a/examples/hello-world/backend/src/atrium_hello_world/schedule.py
+++ b/examples/hello-world/backend/src/atrium_hello_world/schedule.py
@@ -15,7 +15,7 @@ air. Inline keeps the demo crisp at the configured interval (default
 3 s, smoke tests use 2 s). The ``scheduled_jobs`` queue is the right
 tool for jobs that need durability across worker restarts or atomic
 ordering — it's documented in the README's "when to use the queue"
-section, and ``app.jobs.runner.register_handler`` is still part of
+section, and ``HostWorkerCtx.register_job_handler`` is still part of
 atrium's surface even though the example no longer exercises it.
 """
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Closes #44: hosts wire ``scheduled_jobs`` handlers by importing the internal ``app.jobs.runner.register_handler`` today, while every other host extension point goes through a typed registry. This PR ships the worker-side equivalent of the frontend's six ``__ATRIUM_REGISTRY__.register*`` registries.

- New ``app.host_sdk.worker.HostWorkerCtx`` dataclass — exposes ``host.scheduler`` and ``host.register_job_handler(kind=..., handler=..., description=...)``.
- ``init_worker(host: HostWorkerCtx)`` is now the host signature; ``app/worker.py`` constructs the ctx and passes it. ``register_handler`` stays exported for in-tree callers.
- Observability: every registration logs ``host.job_handler.registered``; duplicate-kind registrations log ``host.job_handler.duplicate``. The runner's existing try/except in ``run_one`` already contains throwing handlers — pinned by a new test.
- ``examples/hello-world`` updated. Docs updated: ``docs/published-images.md``, ``docs/new-project/{README,SKILL}.md``, ``docs/adr/0001-python-host-sdk.md``, ``CLAUDE.md``, ``README.md``, hello-world README.
- ``compat-matrix.md`` is intentionally not touched here — per its convention, the row goes in the same PR that bumps ``backend/pyproject.toml`` and writes the release notes.

## Test plan

- [x] ``make test-backend`` (200 passed locally) — includes 5 new unit tests in ``tests/unit/test_host_sdk_worker.py`` covering: registered handler runs, thrown exception is contained, unknown kind is rejected loudly, empty kind raises, duplicate registration warns.
- [x] ``ruff check`` clean on the changed files.
- [x] CI green on the PR.

Closes #44.