### PR TITLE
Host frontend SDK: types, bundle-utils, react hooks (#37, #38, #40)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,8 +155,14 @@ jobs:
           cache: pnpm
           cache-dependency-path: frontend/pnpm-lock.yaml
 
+      # `--ignore-workspace` because the repo-root `pnpm-workspace.yaml`
+      # covers the host SDK packages (`packages/*` +
+      # `examples/hello-world/frontend`) but deliberately excludes
+      # atrium's main SPA. Without the flag, pnpm walks up to the
+      # workspace marker and skips installing into `frontend/`. See
+      # `frontend/.npmrc` for the rationale.
       - name: Install deps
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-workspace
 
       - name: Typecheck
         run: pnpm typecheck
@@ -244,7 +250,8 @@ jobs:
 
       - name: Install frontend deps
         working-directory: frontend
-        run: pnpm install --frozen-lockfile
+        # See the `frontend` job for why `--ignore-workspace` is needed.
+        run: pnpm install --frozen-lockfile --ignore-workspace
 
       # Cache the Chromium binary by Playwright version. ``ubuntu-latest``
       # already ships the system libs Chromium needs (libnss3, libgtk,

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,74 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: Publish npm packages
+
+# Tag-driven publish for the host SDK packages alongside the GHCR
+# image (see `publish-images.yml`). Both fire on the same `v*` tag so
+# the npm versions and the image version are always cut together. The
+# packages are published to GitHub Packages
+# (https://npm.pkg.github.com) under the `@brendan-bank` scope —
+# scope-must-match-owner is GitHub Packages' rule.
+#
+# `workflow_dispatch` lets a maintainer re-run an existing tag (e.g.
+# registry outage recovery) without retagging.
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag to (re-)publish (e.g. v1.2.3)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build + publish
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      # `setup-node` with `registry-url` writes an `.npmrc` into
+      # $RUNNER_TEMP that points the scope at GitHub Packages and
+      # injects `${NODE_AUTH_TOKEN}` for the publish — exactly the
+      # convention pnpm respects via the `npm_config_userconfig` env
+      # var setup-node sets. The committed `.npmrc` at the repo root
+      # already declares the registry mapping; the runner-supplied one
+      # adds the auth token without committing a secret.
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e  # v6.0.3
+        with:
+          version: "10.33.1"
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: "25"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@brendan-bank"
+
+      # Workspace install resolves `@brendan-bank/atrium-*` via
+      # `workspace:*` references; no token needed for this step.
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm -r --filter './packages/*' build
+
+      # `--no-git-checks` skips pnpm's "branch is not main" /
+      # "uncommitted changes" guard — we're publishing from a tag, so
+      # the working tree is fine but git HEAD is detached. `--access
+      # public` mirrors what each package.json's `publishConfig`
+      # already declares, but kept explicit so a future packageJson
+      # tweak doesn't silently flip visibility.
+      - run: pnpm -r --filter './packages/*' publish --no-git-checks --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,16 @@
+# pnpm workspace configuration for the host SDK packages
+# (`packages/*`, `examples/hello-world/frontend`).
+#
+# `@brendan-bank` packages are published to GitHub Packages, not the
+# public npm registry — this line tells pnpm where to fetch
+# (and where `pnpm publish` should push). The auth token is NOT in
+# this file; the publish workflow sets it via `NODE_AUTH_TOKEN` and
+# `setup-node`'s `registry-url`. For local installs the workspace
+# resolves `@brendan-bank/atrium-*` via `workspace:*` references, so
+# no token is needed unless you're explicitly running `pnpm publish`.
+#
+# Note: this file is at the repo root, alongside `pnpm-workspace.yaml`.
+# Atrium's main SPA at `frontend/` carries its own `.npmrc` with
+# `ignore-workspace=true` so `cd frontend && pnpm install` continues to
+# install standalone — see `frontend/.npmrc`.
+@brendan-bank:registry=https://npm.pkg.github.com

--- a/Makefile
+++ b/Makefile
@@ -235,8 +235,17 @@ test-backend:
 
 # Vitest only. Playwright lives in `make smoke` because it needs the
 # whole stack booted + a seeded admin + a fixed TOTP secret.
+#
+# `--ignore-workspace` is required because the repo root carries a
+# `pnpm-workspace.yaml` for the host SDK packages (`packages/*`,
+# `examples/hello-world/frontend`). Atrium's main SPA under
+# `frontend/` is intentionally NOT a workspace member — it ships as a
+# standalone package with its own `pnpm-lock.yaml` so the Dockerfile's
+# `COPY frontend/package.json frontend/pnpm-lock.yaml*` continues to
+# work. Without the flag, `cd frontend && pnpm install` walks up to
+# the workspace root and skips `frontend/` entirely.
 test-frontend:
-	cd frontend && pnpm install --silent && pnpm test
+	cd frontend && pnpm install --ignore-workspace --silent && pnpm test
 
 # --- Lint / format ---
 lint:
@@ -356,7 +365,7 @@ smoke-dev:
 	# Playwright runs on the host, not in the web container — the dev
 	# container is on node:22-alpine (musl libc) and Playwright's
 	# chromium binary is glibc-only. Idempotent no-op when already done.
-	cd frontend && pnpm install --silent
+	cd frontend && pnpm install --ignore-workspace --silent
 	cd frontend && pnpm exec playwright install chromium --with-deps 2>/dev/null \
 		|| pnpm exec playwright install chromium
 	cd frontend && E2E_ADMIN_EMAIL=$(SMOKE_EMAIL) E2E_ADMIN_PASSWORD=$(SMOKE_PASSWORD) \
@@ -397,8 +406,17 @@ HELLO_BUNDLE_URL_E2E := /host/main.js
 # source). The host-bundle URL must point at that sidecar so the SPA's
 # dynamic import resolves.
 smoke-hello-build-bundle-dev:
-	cd examples/hello-world/frontend && pnpm install --frozen-lockfile=false --silent && \
-		VITE_API_BASE_URL=http://localhost:8000 pnpm build
+	# `pnpm install` runs from the example dir but the workspace marker
+	# at the repo root causes it to install the whole workspace
+	# (`packages/*` + this example). The SDK packages must be built
+	# *before* the example's vite runs — the example imports from
+	# `@brendan-bank/atrium-host-bundle-utils/vite`, which resolves
+	# through the workspace symlink to `packages/host-bundle-utils/dist/`.
+	# Without the build step, that dist directory is empty and vite
+	# errors out at config load.
+	cd examples/hello-world/frontend && pnpm install --frozen-lockfile=false --silent
+	pnpm -r --filter './packages/*' build
+	cd examples/hello-world/frontend && VITE_API_BASE_URL=http://localhost:8000 pnpm build
 
 smoke-hello-dev: smoke-hello-build-bundle-dev
 	$(COMPOSE_HELLO_DEV) up -d --build api worker web mysql proxy hello-bundle

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -67,13 +67,26 @@ it on `GET /app-config`, which the SPA mirrors onto
 don't bump it here, every host running the new image will report the
 old version.
 
-Land the bump on the feature branch *before* tagging so master and the
-git tag agree:
+The frontend SDK packages (`packages/host-types`,
+`packages/host-bundle-utils`) version in **lockstep with the image**
+— a host pinning `^0.14` of either package implies "compatible with
+atrium 0.14.x runtime image". Bump all three together. The example
+under `examples/hello-world/frontend` consumes the packages via
+`workspace:*` so it picks up the new version automatically; no edit
+needed there.
+
+Land the bumps on the feature branch *before* tagging so master and
+the git tag agree:
 
 ```bash
 # backend/pyproject.toml — set ``version = "X.Y.Z"`` to match the tag
 # you're about to push. Refresh the lockfile so uv.lock stays in sync:
 ( cd backend && uv lock --quiet )
+
+# packages/host-types/package.json + packages/host-bundle-utils/package.json
+# — set ``"version": "X.Y.Z"`` (same number as the backend bump).
+# Refresh the workspace lockfile so it captures the new versions:
+pnpm install --lockfile-only
 ```
 
 While you're at it, sweep the documentation and the AI bootstrap
@@ -95,6 +108,11 @@ quickly fall behind:
   it leaves agents emitting stale tags.
 - `examples/hello-world/` — same sweep for any pinned base-image
   reference.
+- `packages/host-types/README.md` and
+  `packages/host-bundle-utils/README.md` — `^0.14` style pin
+  examples should match the image's `X.Y` once you cross a minor.
+  The version sweep is otherwise driven by the `package.json`
+  bumps above; the README values are illustrative.
 
 If a doc references an atrium version, it needs updating with each
 release. If it doesn't, it stays untouched.
@@ -217,28 +235,43 @@ git tag -s v<X.Y.Z> <merge-sha> -m "v<X.Y.Z> — <terse summary>
 
 <one-bullet-per-issue body>"
 git tag -v v<X.Y.Z>           # confirm "Good signature"
-git push origin v<X.Y.Z>      # triggers publish-images.yml
+git push origin v<X.Y.Z>      # triggers publish-images.yml + publish-npm.yml
 ```
 
 Use **signed annotated tags** (`-s`), not lightweight. Older tags in
 the repo are mixed but signed-annotated is the established direction
 and aligns with the global commit-signing default.
 
-## 8. Watch publish-images
+## 8. Watch publish-images + publish-npm
 
-The tag push fires `.github/workflows/publish-images.yml`. It builds
-`linux/amd64` + `linux/arm64` and pushes to `ghcr.io/brendan-bank/atrium`
-with the full semver fan-out (`0.11.3`, `0.11`, `0`, `latest`).
-Typical run time: ~3-5 minutes.
+The tag push fires two workflows in parallel:
+
+- `.github/workflows/publish-images.yml` — builds `linux/amd64` +
+  `linux/arm64` and pushes to `ghcr.io/brendan-bank/atrium` with the
+  full semver fan-out (`0.11.3`, `0.11`, `0`, `latest`). Typical run
+  time: ~3-5 minutes.
+- `.github/workflows/publish-npm.yml` — builds the host SDK
+  packages and publishes
+  `@brendan-bank/atrium-host-types@<X.Y.Z>` and
+  `@brendan-bank/atrium-host-bundle-utils@<X.Y.Z>` to GitHub
+  Packages (`https://npm.pkg.github.com`). Typical run time: ~1
+  minute. Uses the workflow-supplied `GITHUB_TOKEN` (`packages:
+  write` scope), so no extra secret to manage.
 
 ```bash
 gh run list --workflow=publish-images.yml --limit 3
+gh run list --workflow=publish-npm.yml --limit 3
 gh run watch <publish-run-id> --exit-status
 ```
 
-A non-zero exit here means the image isn't published — don't create
-the GitHub release until this is green, otherwise users following
-the release notes will pull a tag that doesn't exist.
+A non-zero exit on either means the corresponding artifact isn't
+published — don't create the GitHub release until both are green,
+otherwise users following the release notes will pull a tag (or a
+package version) that doesn't exist. The npm publish is idempotent
+on identical version+content; if the workflow is dispatched against
+an already-published version, pnpm reports "version already exists"
+and exits non-zero — re-tag with a bumped version rather than
+forcing.
 
 ## 9. Hand-write the release notes
 

--- a/docs/adr/0002-host-frontend-sdk-packaging.md
+++ b/docs/adr/0002-host-frontend-sdk-packaging.md
@@ -1,0 +1,151 @@
+# ADR 0002 — Host frontend SDK packaging (`@brendan-bank/atrium-host-types`, `@brendan-bank/atrium-host-bundle-utils`)
+
+Status: accepted, 2026-04-28
+
+## Context
+
+Atrium ships a host-extension contract on the frontend today
+(`window.__ATRIUM_REGISTRY__`, the dual-tree wrapper-element pattern,
+the `/users/me/context` endpoint), but every host re-implements the
+same boilerplate at module init:
+
+- `makeWrapperElement(child)` / `mountInside(el, child)` — extracted
+  by hand into each host's `main.tsx`. Includes the child-mismatch
+  unmount logic from #31, which surfaced as a real-world bug.
+- An `interface AtriumRegistry { … }` block redeclared verbatim in
+  every host. When atrium adds a registry method (e.g.
+  `subscribeEvent?` in 0.11.3, `registerLocale` later) every host's
+  declaration drifts.
+- A Vite library-mode config + `vite-plugin-css-injected-by-js` recipe
+  copy-pasted across hosts.
+- A bespoke `useMe()` / `usePerm()` shape on top of TanStack Query
+  that wraps `/users/me/context`.
+
+Casa's `frontend/src/main.tsx` and `examples/hello-world/frontend/src/main.tsx`
+each carry their own variant of the above. They drift over time.
+
+Issues #37 (`@brendan-bank/atrium-host-bundle-utils`), #38
+(`@brendan-bank/atrium-host-types`),
+and #40 (`useMe`/`usePerm`/`useUserContext` hooks) close that gap.
+This ADR records the packaging shape we land them in. It is the
+frontend-side counterpart to ADR 0001 (`app.host_sdk` namespace for
+Python helpers).
+
+## Decision
+
+### Packaging shape — in-tree pnpm workspace overlay
+
+Two npm packages live in a new top-level `packages/` directory:
+
+- `packages/host-types/` → published as `@brendan-bank/atrium-host-types`
+- `packages/host-bundle-utils/` → published as `@brendan-bank/atrium-host-bundle-utils`
+
+A repo-root `pnpm-workspace.yaml` includes `packages/*` and
+`examples/hello-world/frontend` so the example consumes the packages
+via `workspace:*` references. **Atrium's own `frontend/` is not in the
+workspace.** It keeps its standalone `pnpm-lock.yaml` so the existing
+Dockerfile (`COPY frontend/package.json frontend/pnpm-lock.yaml*`) and
+the dev-container `node_modules` volume stay untouched. The atrium
+SPA does not consume the published packages — it owns the registry
+implementation that the packages declare against.
+
+We considered:
+
+- **Sibling repo per package** — gives independent release cadence
+  but creates three places to keep aligned. Rejected: the packages
+  are tightly coupled to atrium's release; the version sync becomes
+  a chore.
+- **One sibling monorepo** — same coupling, plus a new repo to stand
+  up. Rejected for the same reason and the friction of cross-repo PRs.
+- **In-tree monorepo with everything in one workspace** (atrium
+  frontend + packages + example) — cleaner end-state but invasive:
+  forces a Dockerfile rewrite, dev-container volume restructure, and
+  Makefile adjustments for one release. Rejected as out of scope for
+  this PR; a future ADR can pull the atrium frontend in once we have
+  room to land the operational changes alongside.
+
+### Publish target — GitHub Packages, `@brendan-bank` scope
+
+Same registry family as `ghcr.io/brendan-bank/atrium` for the runtime
+image. One account/PAT covers both. Publishing happens from the same
+release pipeline (see Consequences for the workflow shape).
+
+The scope is `@brendan-bank` (matching the GitHub owner) rather than
+the more readable `@atrium` because GitHub Packages enforces
+`scope == owner` for npm publishes. The published name pattern is
+`@brendan-bank/atrium-<area>` so the relationship to atrium stays
+visible in the import path. Public-npm registration of a bare
+`@atrium` scope was attempted and refused (existing `atrium` /
+`atrium-*` packages on npmjs.com flagged it as confusable); GitHub
+Packages keeps the namespace under our control and avoids the
+trademark-adjacent friction.
+
+### Versioning — tracks atrium
+
+Both packages bump their version in lockstep with
+`backend/pyproject.toml` on every release. A consumer pinning `^0.14`
+of `@brendan-bank/atrium-host-types` implies "compatible with atrium
+`0.14.x` runtime image". This makes the compat matrix
+(`docs/compat-matrix.md`, #46) trivial — one semver column covers
+both the image and the SDK. The packages are 0.x today; pre-1.0
+semver allows a minor bump to introduce additive slot changes without
+coordinating a major.
+
+The ADR explicitly does **not** introduce changesets / a release
+tool yet. Versions are bumped by hand alongside the existing
+`RELEASING.md` step 1.5 doc sweep.
+
+### Subpath exports
+
+`@brendan-bank/atrium-host-bundle-utils` ships three subpath exports:
+
+- `.` — runtime helpers (`makeWrapperElement`, `mountInside`,
+  `unmountInside`) plus type re-exports from
+  `@brendan-bank/atrium-host-types` so a host needing only the
+  runtime can `import` from one place.
+- `./vite` — `hostBundleConfig({ entry })` factory. Imported only by
+  `vite.config.ts` so it doesn't drag Vite into the host's runtime
+  bundle.
+- `./react` — `useMe`, `usePerm`, `useRole`, `useUserContext`,
+  `<AtriumProvider>`. React is a peer dep on this entry only.
+
+`@brendan-bank/atrium-host-types` is a single types-only entry — `.d.ts` files
+under `dist/`, no JS, no runtime cost. `react` is a peer dep so
+`ReactElement` references resolve in the consumer's tree.
+
+### What stays out of scope
+
+- The `useMe`/`usePerm` hooks call the same `/users/me/context`
+  endpoint atrium's own `useMe` does, but with their own TanStack
+  Query cache. We do **not** try to share atrium's QueryClient — the
+  cache lifetimes are different (atrium clears on logout via
+  `qc.clear()`; the host's QueryClient is owned by the host bundle).
+  `<AtriumProvider>` accepts an optional `client` so a host can opt
+  in to wrapping their existing one, otherwise hooks pick up the
+  caller's enclosing `<QueryClientProvider>`.
+- We are not migrating casa from this PR. Casa's repo opens its own
+  PR after the packages publish.
+- We are not shipping a `startStream` / `EventSource` helper. Atrium
+  already owns the connection and exposes `subscribeEvent` via the
+  registry; a runtime helper would duplicate it.
+
+## Consequences
+
+- The `packages/` tree introduces a new workspace at the repo root.
+  `pnpm -r build`, `pnpm -r typecheck`, and `pnpm -r test` operate on
+  the SDK packages and the example only; atrium's own frontend
+  continues to use its in-folder pnpm scripts.
+- Future host-facing UI helpers land under `packages/host-bundle-utils`
+  (or a sibling `packages/<area>` if the surface grows beyond the
+  bundle entry-point) without another ADR. The "is this host-facing?"
+  test is the same as ADR 0001: would a host import it?
+- The publish step is added to `RELEASING.md` once the publish
+  workflow is wired up. Until then the packages can be pulled into
+  hosts via `pnpm pack` + a tarball install, which is enough for the
+  in-tree example.
+- `examples/hello-world/frontend/src/main.tsx` collapses from ~180
+  lines to ~50 lines (mostly the registration calls themselves);
+  `vite.config.ts` becomes one `hostBundleConfig({ entry })` call.
+  The shrink is the load-bearing acceptance signal — if a future
+  registry change blows that surface back out, the package is
+  carrying less weight than it should.

--- a/docs/published-images.md
+++ b/docs/published-images.md
@@ -384,72 +384,137 @@ soft-deprecated), see [`compat-matrix.md`](compat-matrix.md).
 The host's frontend is a separate Vite project that emits a single ES
 module. Browsers can't resolve bare module specifiers like `import 'react'`
 without an import map, so the bundle has to either ship its own React or
-piggy-back on atrium's via an import map. The example uses the
-**self-contained bundle** pattern — simpler, no atrium-side changes
-required, ~250 KB gzipped.
+piggy-back on atrium's via an import map. The recommended path is the
+**self-contained bundle** with the helpers from
+[`@brendan-bank/atrium-host-bundle-utils`](https://github.com/Brendan-Bank/atrium/tree/master/packages/host-bundle-utils)
+— simpler, no atrium-side changes required, ~100 KB gzipped.
 
-**Self-contained bundle** (what the example uses):
+Two atrium-published packages remove the boilerplate:
+
+- `@brendan-bank/atrium-host-types` — TypeScript declarations for
+  `AtriumRegistry`, `UserContext`, `AtriumNotification`, `AtriumEvent`,
+  the per-slot option-bag types, and the `window.React` /
+  `window.__ATRIUM_REGISTRY__` / `window.__ATRIUM_VERSION__` globals.
+  Types-only; bundlers strip it from the production output.
+- `@brendan-bank/atrium-host-bundle-utils` — runtime helpers
+  (`makeWrapperElement`, `mountInside`), a Vite preset
+  (`hostBundleConfig`), and React hooks (`useMe`, `usePerm`,
+  `useRole`, `<AtriumProvider>`) on three subpath exports (`.`,
+  `./vite`, `./react`). Re-exports the types from
+  `@brendan-bank/atrium-host-types` so a host adding only one dep
+  still gets the declarations.
+
+Both packages are published on **GitHub Packages** (the same registry
+family as the atrium GHCR image) and versioned in lockstep with the
+atrium image — pin `^0.14` for "compatible with atrium 0.14.x". The
+host project needs an `.npmrc` mapping the `@brendan-bank` scope:
+
+```
+# .npmrc — in the host's frontend project
+@brendan-bank:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+```
+
+GitHub Packages requires authentication on every install, even for
+public packages. In CI, `GITHUB_TOKEN` is provided automatically by
+Actions; locally, generate a [classic PAT](https://github.com/settings/tokens)
+with `read:packages` scope and export it as `GITHUB_TOKEN` before
+running `pnpm install`.
+
+**Vite config — one function call:**
 
 ```ts
 // vite.config.ts
-import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js';
+import { hostBundleConfig } from '@brendan-bank/atrium-host-bundle-utils/vite';
 
-export default defineConfig({
-  // Vite's lib build extracts every `import 'pkg/styles.css'` into a
-  // sibling `main.css`. atrium dynamic-imports `main.js` only — that
-  // sibling is never fetched and the bundle ships unstyled. The
-  // plugin inlines those imports as a runtime `<style>` tag so a
-  // single `main.js` carries everything.
-  plugins: [cssInjectedByJsPlugin()],
-  build: {
-    lib: { entry: 'src/main.tsx', formats: ['es'], fileName: () => 'main.js' },
-  },
-});
+export default hostBundleConfig({ entry: 'src/main.tsx' });
 ```
 
-Bundle React, ReactDOM, Mantine, TanStack Query, everything. The host
-bundle's exports are atrium-React elements (created via
-`window.React.createElement`) that own a single `<div>` wrapper each;
-the div's `ref` callback uses the *bundled* `createRoot` to mount the
-host's React tree inside it. **Two React trees coexist in the DOM** —
-atrium's React owns the shell + the wrapper element; the host's React
-owns the subtree.
+The factory returns a complete library-mode config: emits a single
+`dist/main.js` that atrium's loader dynamic-imports, inlines imported
+`.css` via runtime `<style>` tags (`vite-plugin-css-injected-by-js`),
+and defines `process.env.NODE_ENV` so the externalised React +
+TanStack Query references resolve. Pass `extraConfig` to layer
+plugins on top.
+
+**Bundle entry — ~10 lines of registration calls:**
 
 ```tsx
-// main.tsx (sketch — see examples/hello-world/frontend/src/main.tsx)
-import { createRoot } from 'react-dom/client';
-const AtriumReact = (window as any).React;
+// main.tsx — see examples/hello-world/frontend/src/main.tsx
+import {
+  type AtriumRegistry,
+  makeWrapperElement,
+} from '@brendan-bank/atrium-host-bundle-utils';
+import { MyWidget } from './MyWidget';
 
-function makeWrapperElement(child: React.ReactElement) {
-  return AtriumReact.createElement('div', {
-    ref: (el: HTMLElement | null) => {
-      if (!el || (el as any).__hostRoot) return;
-      (el as any).__hostRoot = createRoot(el);
-      (el as any).__hostRoot.render(child);
-    },
-  });
-}
-
+const reg = window.__ATRIUM_REGISTRY__ as AtriumRegistry;
 reg.registerHomeWidget({
-  key: 'my-widget',
+  key: 'my-card',
   render: () => makeWrapperElement(<MyWidget />),
 });
 ```
 
-This sidesteps the "two Reacts, one tree" hook-dispatcher trap: atrium's
-reconciler only ever calls our wrapper element's `ref` callback, never
-our component functions. Hooks inside the host subtree run under the
-host's React (the one rendering them), so state, context, and queries
-all behave normally.
+Bundle React, ReactDOM, Mantine, TanStack Query, everything inside
+the host's subtree. The host bundle's exports are atrium-React
+elements (created via `window.React.createElement`) that own a single
+`<div>` wrapper each; `makeWrapperElement` does the dual-tree mount
+internally. **Two React trees coexist in the DOM** — atrium's React
+owns the shell + the wrapper element; the host's React owns the
+subtree.
+
+This sidesteps the "two Reacts, one tree" hook-dispatcher trap:
+atrium's reconciler only ever calls the wrapper element's `ref`
+callback, never the host's component functions. Hooks inside the
+host subtree run under the host's React (the one rendering them), so
+state, context, and queries all behave normally.
 
 **Tabler icons (and other hooks-free components)** *can* be passed
-directly to atrium's `createElement` — they're plain SVG output with no
-hook calls, so atrium's reconciler can render them without the wrapper
-trick. The example does this for nav-item / admin-tab icons.
+directly to atrium's `window.React.createElement` — they're plain SVG
+output with no hook calls, so atrium's reconciler can render them
+without the wrapper trick. The example does this for nav-item /
+admin-tab icons.
+
+**Permission gating + user context — `@brendan-bank/atrium-host-bundle-utils/react`:**
+
+```tsx
+import { AtriumProvider, useMe, usePerm } from '@brendan-bank/atrium-host-bundle-utils/react';
+
+function CommissionsPage() {
+  const { data: me, isLoading } = useMe();
+  const hasPerm = usePerm();
+  if (isLoading) return <Loader />;
+  if (hasPerm('commission.view.all')) return <Admin />;
+  return <SelfCommissions userId={me?.id} />;
+}
+
+function App() {
+  return (
+    <QueryClientProvider client={hostQueryClient}>
+      <AtriumProvider apiBase="/api">
+        <CommissionsPage />
+      </AtriumProvider>
+    </QueryClientProvider>
+  );
+}
+```
+
+`useMe()` returns the typed `UserContext` shape — id, email,
+full_name, roles, permissions, impersonating_from. Single TanStack
+Query subscription per host tree, shared across `usePerm` / `useRole`
+/ `useUserContext`. `<AtriumProvider>` reads from the host's
+existing `<QueryClientProvider>` by default; pass `client=` to wrap
+one inline.
+
+**Hand-rolled bundles (without the SDK packages)** are still
+supported — declare the registry interface inline and reimplement the
+wrapper-element pattern. The example used to ship that way; consult
+git history before atrium 0.14 if you need a reference. Bumping to
+the packages for new hosts is the recommended path.
 
 **Shared React via import map** (smaller bundle, more setup): a future
-B1-side change can declare an import map mapping `react` to a URL atrium
-serves. Until then, self-contained is the path of least resistance.
+atrium-side change can declare an import map mapping `react` to a URL
+atrium serves. Until then, self-contained is the path of least
+resistance.
 
 ### Worked example: Hello World
 

--- a/examples/hello-world/Dockerfile
+++ b/examples/hello-world/Dockerfile
@@ -18,12 +18,41 @@
 ARG ATRIUM_IMAGE=ghcr.io/brendan-bank/atrium:latest
 
 # ---- frontend-builder ----
+#
+# The example consumes the host SDK packages via `workspace:*`
+# references (see `examples/hello-world/frontend/package.json`), so
+# the build needs the full pnpm workspace context — the lockfile, the
+# workspace yaml, the `.npmrc` that maps `@brendan-bank` at GitHub
+# Packages, and every workspace member's `package.json`. We bring
+# those in first (cache-friendly: lockfile changes invalidate this
+# layer but a source-only edit doesn't), install, then bring in the
+# actual source for `packages/*` and the example.
 FROM node:25-alpine AS frontend-builder
 WORKDIR /app
 RUN npm install -g pnpm@10.33.1
-COPY examples/hello-world/frontend/package.json examples/hello-world/frontend/pnpm-lock.yaml* ./
-RUN pnpm install --frozen-lockfile 2>/dev/null || pnpm install
-COPY examples/hello-world/frontend/ ./
+
+# Workspace skeleton — package.json + lockfile + workspace yaml are
+# enough for `pnpm install --frozen-lockfile` to resolve every
+# transitive dep and link the workspace members.
+COPY pnpm-lock.yaml pnpm-workspace.yaml .npmrc package.json ./
+COPY packages/host-types/package.json ./packages/host-types/
+COPY packages/host-bundle-utils/package.json ./packages/host-bundle-utils/
+COPY examples/hello-world/frontend/package.json ./examples/hello-world/frontend/
+
+RUN pnpm install --frozen-lockfile
+
+# Bring in the SDK package sources and build them — the example's
+# vite.config.ts imports from `@brendan-bank/atrium-host-bundle-utils/vite`,
+# which resolves through the workspace symlink to `packages/host-bundle-utils/dist/vite/`.
+# That dist directory must exist before vite runs.
+COPY packages/host-types/ ./packages/host-types/
+COPY packages/host-bundle-utils/ ./packages/host-bundle-utils/
+RUN pnpm -r --filter './packages/*' build
+
+# Now the example source + the actual bundle build.
+COPY examples/hello-world/frontend/ ./examples/hello-world/frontend/
+WORKDIR /app/examples/hello-world/frontend
+
 # Same default as the unified atrium image — bundle calls relative
 # paths (`/hello/state`, `/hello/toggle`) so it lands on whatever
 # origin the SPA was loaded from.
@@ -44,6 +73,6 @@ RUN /opt/venv/bin/python -m ensurepip --upgrade \
  && /opt/venv/bin/python -m pip install --no-cache-dir /opt/host_app
 
 # Bake the host bundle into atrium's static dir at /host/main.js.
-COPY --from=frontend-builder /app/dist /opt/atrium/static/host
+COPY --from=frontend-builder /app/examples/hello-world/frontend/dist /opt/atrium/static/host
 
 USER app

--- a/examples/hello-world/frontend/package.json
+++ b/examples/hello-world/frontend/package.json
@@ -10,6 +10,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@brendan-bank/atrium-host-bundle-utils": "workspace:*",
+    "@brendan-bank/atrium-host-types": "workspace:*",
     "@mantine/core": "^9.1.0",
     "@mantine/hooks": "^9.1.0",
     "@tabler/icons-react": "^3.41.1",

--- a/examples/hello-world/frontend/src/HelloProfileItem.tsx
+++ b/examples/hello-world/frontend/src/HelloProfileItem.tsx
@@ -26,23 +26,22 @@ import {
   useQueryClient,
   QueryClientProvider,
 } from '@tanstack/react-query';
+import { AtriumProvider, usePerm } from '@brendan-bank/atrium-host-bundle-utils/react';
 
 import {
   getHelloState,
-  getMeContext,
   postHelloToggle,
   type HelloState,
 } from './api';
 import { queryClient } from './queryClient';
 
 const STATE_KEY = ['hello', 'state'] as const;
-const ME_KEY = ['hello', 'me-context'] as const;
 
 function HelloProfileItemInner() {
   const qc = useQueryClient();
   const { data } = useQuery({ queryKey: STATE_KEY, queryFn: getHelloState });
-  const { data: me } = useQuery({ queryKey: ME_KEY, queryFn: getMeContext });
-  const canToggle = me?.permissions.includes('hello.toggle') ?? false;
+  const hasPerm = usePerm();
+  const canToggle = hasPerm('hello.toggle');
   const toggleMutation = useMutation({
     mutationFn: (enabled: boolean) => postHelloToggle(enabled),
     onSuccess: (next: HelloState) => qc.setQueryData(STATE_KEY, next),
@@ -73,7 +72,9 @@ export function HelloProfileItem() {
   return (
     <MantineProvider>
       <QueryClientProvider client={queryClient}>
-        <HelloProfileItemInner />
+        <AtriumProvider>
+          <HelloProfileItemInner />
+        </AtriumProvider>
       </QueryClientProvider>
     </MantineProvider>
   );

--- a/examples/hello-world/frontend/src/HelloWidget.tsx
+++ b/examples/hello-world/frontend/src/HelloWidget.tsx
@@ -9,6 +9,12 @@
  * atrium's. Two MantineProviders nested in the DOM is supported by
  * Mantine; theming inside this subtree won't follow atrium's brand
  * changes (acceptable for a demo).
+ *
+ * Permission gating uses `usePerm()` from
+ * `@brendan-bank/atrium-host-bundle-utils/react`
+ * — a single TanStack Query subscription against atrium's
+ * `/users/me/context`, shared across this widget, the dedicated
+ * page, and the admin tab.
  */
 import {
   Badge,
@@ -27,17 +33,16 @@ import {
   useQueryClient,
   QueryClientProvider,
 } from '@tanstack/react-query';
+import { AtriumProvider, usePerm } from '@brendan-bank/atrium-host-bundle-utils/react';
 
 import {
   getHelloState,
-  getMeContext,
   postHelloToggle,
   type HelloState,
 } from './api';
 import { queryClient } from './queryClient';
 
 const STATE_KEY = ['hello', 'state'] as const;
-const ME_KEY = ['hello', 'me-context'] as const;
 
 function HelloWidgetInner() {
   const qc = useQueryClient();
@@ -45,11 +50,8 @@ function HelloWidgetInner() {
     queryKey: STATE_KEY,
     queryFn: getHelloState,
   });
-  const { data: me } = useQuery({
-    queryKey: ME_KEY,
-    queryFn: getMeContext,
-  });
-  const canToggle = me?.permissions.includes('hello.toggle') ?? false;
+  const hasPerm = usePerm();
+  const canToggle = hasPerm('hello.toggle');
   const toggleMutation = useMutation({
     mutationFn: (enabled: boolean) => postHelloToggle(enabled),
     onSuccess: (next: HelloState) => {
@@ -103,7 +105,9 @@ export function HelloWidget() {
   return (
     <MantineProvider>
       <QueryClientProvider client={queryClient}>
-        <HelloWidgetInner />
+        <AtriumProvider>
+          <HelloWidgetInner />
+        </AtriumProvider>
       </QueryClientProvider>
     </MantineProvider>
   );

--- a/examples/hello-world/frontend/src/api.ts
+++ b/examples/hello-world/frontend/src/api.ts
@@ -1,25 +1,21 @@
 // Copyright (c) 2026 Brendan Bank
 // SPDX-License-Identifier: BSD-2-Clause
 
-/** Thin fetch wrapper for the host's /hello/* endpoints + the
- *  atrium /users/me/context probe used to gate the toggle.
+/** Thin fetch wrapper for the host's `/hello/*` endpoints.
  *
  * We don't import atrium's axios instance — this bundle is loaded at
  * runtime and atrium's modules aren't reachable as imports. The
  * cookie-based session is shared on the same origin so
- * ``credentials: 'include'`` is enough. */
+ * ``credentials: 'include'`` is enough.
+ *
+ * Permission gating against the signed-in user's RBAC context now
+ * lives in `@brendan-bank/atrium-host-bundle-utils/react`
+ * (`useMe` / `usePerm`);
+ * the `getMeContext` helper that used to live here is gone. */
 export interface HelloState {
   message: string;
   counter: number;
   enabled: boolean;
-}
-
-export interface MeContext {
-  id: number;
-  email: string;
-  full_name: string;
-  roles: string[];
-  permissions: string[];
 }
 
 const apiBase = (import.meta as { env?: { VITE_API_BASE_URL?: string } }).env
@@ -52,13 +48,4 @@ export async function postHelloToggle(enabled: boolean): Promise<HelloState> {
     body: JSON.stringify({ enabled }),
   });
   return jsonOrThrow<HelloState>(res);
-}
-
-export async function getMeContext(): Promise<MeContext | null> {
-  const res = await fetch(`${apiBase}/users/me/context`, {
-    credentials: 'include',
-    headers: { Accept: 'application/json' },
-  });
-  if (res.status === 401 || res.status === 403) return null;
-  return jsonOrThrow<MeContext>(res);
 }

--- a/examples/hello-world/frontend/src/main.tsx
+++ b/examples/hello-world/frontend/src/main.tsx
@@ -3,21 +3,21 @@
 
 /** Hello World host bundle entry.
  *
- * Bundles its own React + ReactDOM + Mantine + TanStack Query. The
- * registered elements are atrium-React elements (created via
- * ``window.React.createElement``) that own a single ``<div>`` wrapper
- * each; the div's ref callback mounts our React tree inside via our
- * bundled ``createRoot``. Two React trees coexist in the DOM:
- *
- *   - atrium's React owns the shell + the wrapper element + routing
- *   - our React owns the subtree (Mantine widgets, hook state, query
- *     cache)
- *
- * Hooks never cross the boundary — atrium's reconciler only ever
- * calls our ``ref`` callback, never our component functions.
+ * Atrium loads this module via `import(system.host_bundle_url)` after
+ * the SPA boots; the import-time side-effects below populate the
+ * registry. The dual-tree mount pattern (atrium-React owns the
+ * wrapper, the host's React owns the subtree) is encapsulated in
+ * `makeWrapperElement` from `@brendan-bank/atrium-host-bundle-utils` — see that
+ * package's README for the rationale. The atrium-React reference
+ * (`window.React`, exposed by atrium for host bundles) is used only
+ * for hooks-free SVG icons that don't need the wrapper trick.
  */
-import { createRoot, type Root } from 'react-dom/client';
 import { IconHandStop } from '@tabler/icons-react';
+
+import {
+  type AtriumRegistry,
+  makeWrapperElement,
+} from '@brendan-bank/atrium-host-bundle-utils';
 
 import { HelloAdminTab } from './HelloAdminTab';
 import { HelloPage } from './HelloPage';
@@ -29,110 +29,14 @@ import {
 } from './HelloNotification';
 import { queryClient } from './queryClient';
 
-interface HostNotification {
-  id: number;
-  kind: string;
-  payload: Record<string, unknown>;
-  read_at: string | null;
-  created_at: string;
-}
+const reg = window.__ATRIUM_REGISTRY__ as AtriumRegistry | undefined;
+const AtriumReact = window.React;
 
-interface AtriumEvent {
-  kind: string;
-  payload: Record<string, unknown>;
-}
-
-interface AtriumRegistry {
-  registerHomeWidget: (w: { key: string; render: () => unknown }) => void;
-  registerRoute: (r: {
-    key: string;
-    path: string;
-    render: () => unknown;
-    requireAuth?: boolean;
-    layout?: 'shell' | 'bare';
-  }) => void;
-  registerNavItem: (n: {
-    key: string;
-    label: string;
-    to: string;
-    icon?: unknown;
-  }) => void;
-  registerAdminTab: (t: {
-    key: string;
-    label: string;
-    icon?: unknown;
-    perm?: string;
-    render: () => unknown;
-  }) => void;
-  registerProfileItem: (p: {
-    key: string;
-    slot?:
-      | 'after-profile'
-      | 'after-password'
-      | 'after-2fa'
-      | 'after-roles'
-      | 'after-sessions'
-      | 'before-delete';
-    render: () => unknown;
-  }) => void;
-  registerNotificationKind: (r: {
-    kind: string;
-    render: (n: HostNotification) => unknown;
-    title?: (n: HostNotification) => string;
-    href?: (n: HostNotification) => string;
-  }) => void;
-  registerLocale: (o: {
-    locale: string;
-    strings: Record<string, unknown>;
-  }) => void;
-  subscribeEvent: (
-    kind: string,
-    handler: (event: AtriumEvent) => void,
-  ) => () => void;
-}
-
-/** atrium's React, exposed at ``window.React`` by atrium's main.tsx
- *  so host bundles can create elements that atrium's reconciler will
- *  render. Our wrapper elements use this; everything inside the
- *  wrappers uses our bundled React. */
-const AtriumReact = (
-  window as unknown as { React?: { createElement: (...a: unknown[]) => unknown } }
-).React;
-
-if (!AtriumReact) {
+if (!reg || !AtriumReact) {
   console.error(
-    '[atrium-hello-world] window.React missing — atrium SPA must mount before the host bundle loads',
+    '[atrium-hello-world] window.__ATRIUM_REGISTRY__ or window.React missing — atrium SPA must mount before the host bundle loads',
   );
-}
-
-/** Track per-element roots so we don't double-mount when atrium
- *  re-runs the ref callback (StrictMode, route remounts). */
-type MountedEl = HTMLElement & { __helloRoot?: Root };
-
-function mountInside(el: HTMLElement | null, child: React.ReactElement): void {
-  if (!el) return;
-  const slot = el as MountedEl;
-  if (slot.__helloRoot) return;
-  slot.__helloRoot = createRoot(slot);
-  slot.__helloRoot.render(child);
-}
-
-function makeWrapperElement(child: React.ReactElement): unknown {
-  return AtriumReact!.createElement('div', {
-    // The ref runs after atrium's React commits the wrapper div to
-    // the DOM; we then create our own React root inside it.
-    ref: (el: HTMLElement | null) => mountInside(el, child),
-  });
-}
-
-const reg = (window as unknown as { __ATRIUM_REGISTRY__?: AtriumRegistry })
-  .__ATRIUM_REGISTRY__;
-
-if (!reg) {
-  console.error(
-    '[atrium-hello-world] window.__ATRIUM_REGISTRY__ missing — atrium SPA must mount before the host bundle loads',
-  );
-} else if (AtriumReact) {
+} else {
   reg.registerHomeWidget({
     key: 'hello-world',
     render: () => makeWrapperElement(<HelloWidget />),
@@ -146,8 +50,6 @@ if (!reg) {
     key: 'hello-nav',
     label: 'Hello World',
     to: '/hello',
-    // The icon is rendered by atrium's React (it's part of atrium's
-    // sidebar), so we create it via atrium's React too.
     icon: AtriumReact.createElement(IconHandStop, { size: 18 }),
   });
   reg.registerAdminTab({
@@ -174,11 +76,9 @@ if (!reg) {
       ),
   });
   // Subscribe to the typed SSE event so the widget refreshes the
-  // moment another tab (or another user) flips the toggle, instead
-  // of waiting for the 5s polling interval. The QueryClient here is
-  // the host bundle's own — atrium's bell uses its own client and
-  // refetches independently. See ``queryClient.ts``: ``refetchInterval``
-  // is now off, the SSE stream owns freshness.
+  // moment another tab (or another user) flips the toggle. The
+  // QueryClient here is the host bundle's own — atrium's bell uses
+  // its own client and refetches independently.
   reg.subscribeEvent('hello.toggled', () => {
     queryClient.invalidateQueries({ queryKey: ['hello', 'state'] });
   });

--- a/examples/hello-world/frontend/vite.config.ts
+++ b/examples/hello-world/frontend/vite.config.ts
@@ -1,54 +1,10 @@
 // Copyright (c) 2026 Brendan Bank
 // SPDX-License-Identifier: BSD-2-Clause
 
-import { resolve } from 'node:path';
-import { defineConfig } from 'vite';
-import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js';
+import { hostBundleConfig } from '@brendan-bank/atrium-host-bundle-utils/vite';
 
-// Library build that emits a single ES module loaded by atrium via
-// dynamic import (`system.host_bundle_url` → `await import(url)`).
-//
-// **Strategy**: bundle everything (React, ReactDOM, Mantine, TanStack
-// Query) inside the host bundle. The exported elements are atrium-React
-// elements that own a single ``<div>`` wrapper; that div's ref callback
-// uses *our* bundled ReactDOM to mount *our* React tree inside it.
-// Two React trees, side by side in the DOM:
-//   - atrium's React owns the page shell, the wrapper div, routing
-//   - our React owns the subtree (Mantine widgets, hook state)
-// This isolates the React boundary cleanly and avoids the
-// "Invalid hook call" trap of mixing two React copies in one tree.
-//
-// Bundle is ~250 KB gzipped. Production hosts that need a smaller
-// bundle can share atrium's React via import maps — a follow-up
-// branch. The example uses the simpler self-contained pattern.
-export default defineConfig({
-  // Lib-mode builds don't auto-replace ``process.env.NODE_ENV`` the
-  // way Vite's app-mode builds do, and several deps (React internals,
-  // TanStack Query) reference it. Without these defines the bundle
-  // throws ``ReferenceError: process is not defined`` the moment the
-  // SPA dynamic-imports it.
-  define: {
-    'process.env.NODE_ENV': JSON.stringify('production'),
-    'process.env': '{}',
-  },
-  // Vite's library build extracts every imported ``.css`` to a sibling
-  // file (``main.css``) by default. Atrium dynamic-imports
-  // ``main.js`` only — sibling CSS is never fetched, leaving widgets
-  // unstyled. ``vite-plugin-css-injected-by-js`` rewrites those
-  // imports to inject the CSS via a runtime ``<style>`` tag so a
-  // single ``main.js`` is sufficient. This example doesn't import any
-  // CSS today, but the plugin stays here so the very first ``import
-  // 'pkg/styles.css'`` you add (FullCalendar, react-big-calendar,
-  // any rich-text editor) doesn't quietly ship without styles.
-  plugins: [cssInjectedByJsPlugin()],
-  build: {
-    target: 'es2022',
-    lib: {
-      entry: resolve(__dirname, 'src/main.tsx'),
-      formats: ['es'],
-      fileName: () => 'main.js',
-    },
-    emptyOutDir: true,
-    sourcemap: true,
-  },
-});
+// One function call: lib-mode build emitting `dist/main.js`, CSS
+// inlined via runtime <style> tags, defines for the externalised
+// React + TanStack Query references. See `@brendan-bank/atrium-host-bundle-utils`
+// for the rationale on each default.
+export default hostBundleConfig({ entry: 'src/main.tsx' });

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,9 @@
+# Atrium's main SPA is intentionally NOT part of the repo-root pnpm
+# workspace overlay (see ../pnpm-workspace.yaml). The Dockerfile and
+# the dev compose stack `COPY frontend/package.json
+# frontend/pnpm-lock.yaml*` and run `pnpm install` standalone — they
+# don't see the workspace root. Setting `ignore-workspace=true` here
+# makes interactive `cd frontend && pnpm install` behave the same way
+# as the container builds: walk no higher than this directory, use
+# the in-folder lockfile, install into ./node_modules.
+ignore-workspace=true

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "atrium-host-sdk-workspace",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Workspace overlay for the host-facing npm packages (@brendan-bank/atrium-host-types, @brendan-bank/atrium-host-bundle-utils) and the in-tree examples that consume them. Atrium's own SPA lives under frontend/ as a standalone package.",
+  "scripts": {
+    "build": "pnpm -r --filter './packages/*' build",
+    "typecheck": "pnpm -r --filter './packages/*' --filter './examples/*/frontend' typecheck",
+    "test": "pnpm -r --filter './packages/*' test"
+  },
+  "packageManager": "pnpm@10.33.1"
+}

--- a/packages/host-bundle-utils/README.md
+++ b/packages/host-bundle-utils/README.md
@@ -1,0 +1,119 @@
+# `@brendan-bank/atrium-host-bundle-utils`
+
+Runtime helpers, Vite preset, and React hooks for [atrium](https://github.com/Brendan-Bank/atrium)
+host bundles. Wraps the dual-tree mount pattern so a host's
+`main.tsx` collapses to ~10 lines of registration calls.
+
+```tsx
+import {
+  AtriumRegistry,
+  makeWrapperElement,
+} from '@brendan-bank/atrium-host-bundle-utils';
+import { MyWidget } from './MyWidget';
+
+const reg = window.__ATRIUM_REGISTRY__ as AtriumRegistry;
+reg.registerHomeWidget({
+  key: 'my-card',
+  render: () => makeWrapperElement(<MyWidget />),
+});
+```
+
+## Installation
+
+The package is published on **GitHub Packages**, not the public npm
+registry. Add an `.npmrc` to your host project that points the
+`@brendan-bank` scope at GitHub Packages and supplies a token with
+`read:packages` scope:
+
+```
+# .npmrc
+@brendan-bank:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+```
+
+In CI, `GITHUB_TOKEN` is provided automatically by Actions; locally,
+generate a [classic PAT](https://github.com/settings/tokens) with
+`read:packages` and export it. Then:
+
+```bash
+pnpm add @brendan-bank/atrium-host-bundle-utils \
+        @brendan-bank/atrium-host-types
+```
+
+## Three subpath entry-points
+
+| Import                                                     | What you get                                               |
+| ---------------------------------------------------------- | ---------------------------------------------------------- |
+| `@brendan-bank/atrium-host-bundle-utils`                   | `makeWrapperElement`, `mountInside`, `unmountInside`, types |
+| `@brendan-bank/atrium-host-bundle-utils/vite`              | `hostBundleConfig({ entry })` — returns a Vite config      |
+| `@brendan-bank/atrium-host-bundle-utils/react`             | `useMe`, `usePerm`, `useRole`, `useUserContext`, `<AtriumProvider>` |
+
+## Vite preset
+
+```ts
+// vite.config.ts
+import { hostBundleConfig } from '@brendan-bank/atrium-host-bundle-utils/vite';
+
+export default hostBundleConfig({ entry: 'src/main.tsx' });
+```
+
+The factory returns a complete Vite library-mode config: emits a
+single `dist/main.js` that atrium's loader dynamic-imports, inlines
+imported `.css` via runtime `<style>` tags, and defines
+`process.env.NODE_ENV` so the externalised React + TanStack Query
+references resolve. Pass `extraConfig` to layer additional plugins
+or overrides on top.
+
+`vite` and `vite-plugin-css-injected-by-js` are declared as optional
+peer deps; install them as devDependencies in the host's
+`frontend/package.json` only when building the bundle.
+
+## React hooks
+
+```tsx
+import {
+  AtriumProvider,
+  useMe,
+  usePerm,
+  useRole,
+} from '@brendan-bank/atrium-host-bundle-utils/react';
+
+function CommissionsPage() {
+  const { data: me, isLoading } = useMe();
+  const hasPerm = usePerm();
+  if (isLoading) return <Loader />;
+  if (hasPerm('commission.view.all')) return <Admin />;
+  return <SelfCommissions userId={me?.id} />;
+}
+
+function App() {
+  return (
+    <QueryClientProvider client={hostQueryClient}>
+      <AtriumProvider apiBase="/api">
+        <CommissionsPage />
+      </AtriumProvider>
+    </QueryClientProvider>
+  );
+}
+```
+
+`<AtriumProvider>` reads from your existing `<QueryClientProvider>`
+by default — no second QueryClient. Pass `client={hostQueryClient}`
+to wrap one inline; pass `fetchUserContext={...}` to inject a custom
+fetcher (useful for tests or hosts that want axios-shaped retry).
+
+## Versioning
+
+The package version tracks atrium's image version. Pin `^0.14` for
+"compatible with atrium 0.14.x"; bump together with the atrium image
+to pick up new registry slots and SDK helpers.
+
+## See also
+
+- [`@brendan-bank/atrium-host-types`](../host-types/) — the typed
+  registry declarations this package re-exports.
+- [`docs/published-images.md`](../../docs/published-images.md) — the
+  full host-extension contract.
+- [`examples/hello-world/`](../../examples/hello-world/) — the
+  canonical worked example exercising every extension slot through
+  these helpers.

--- a/packages/host-bundle-utils/package.json
+++ b/packages/host-bundle-utils/package.json
@@ -1,0 +1,77 @@
+{
+  "name": "@brendan-bank/atrium-host-bundle-utils",
+  "version": "0.14.0",
+  "description": "Runtime helpers, Vite preset, and React hooks for atrium host bundles. Wraps the dual-tree mount pattern, the host-bundle Vite library config, and the /users/me/context hook so a host's main.tsx is ~10 lines of registration calls.",
+  "license": "BSD-2-Clause",
+  "type": "module",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./vite": {
+      "types": "./dist/vite/index.d.ts",
+      "default": "./dist/vite/index.js"
+    },
+    "./react": {
+      "types": "./dist/react/index.d.ts",
+      "default": "./dist/react/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@brendan-bank/atrium-host-types": "workspace:*"
+  },
+  "peerDependencies": {
+    "@tanstack/react-query": "^5.0.0",
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0",
+    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+    "vite-plugin-css-injected-by-js": "^3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "vite": {
+      "optional": true
+    },
+    "vite-plugin-css-injected-by-js": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@tanstack/react-query": "^5.100.5",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/node": "^25.6.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "jsdom": "^29.0.2",
+    "msw": "^2.7.0",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.10",
+    "vite-plugin-css-injected-by-js": "^3.5.2",
+    "vitest": "^4.1.5"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://npm.pkg.github.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Brendan-Bank/atrium.git",
+    "directory": "packages/host-bundle-utils"
+  }
+}

--- a/packages/host-bundle-utils/src/index.ts
+++ b/packages/host-bundle-utils/src/index.ts
@@ -1,0 +1,175 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+/**
+ * Atrium host-bundle runtime helpers.
+ *
+ * Atrium loads each host's frontend as a single ES module via
+ * `import(system.host_bundle_url)` after the SPA boots. The host
+ * bundle calls `window.__ATRIUM_REGISTRY__.register*(...)` at import
+ * time. The elements registered are atrium-React elements (created
+ * via `window.React.createElement`) whose ref callback mounts the
+ * host's *own* React tree inside via `react-dom/client`'s
+ * `createRoot`. Two React trees coexist in the DOM:
+ *
+ *   - atrium's React owns the page shell + the wrapper `<div>`
+ *   - the host's React owns the subtree (Mantine, hook state, query
+ *     cache)
+ *
+ * `makeWrapperElement` and `mountInside` package up the dual-tree
+ * pattern so the host's `main.tsx` becomes ten lines of registration
+ * calls — see `examples/hello-world/frontend/src/main.tsx` for the
+ * canonical use.
+ *
+ * Type re-exports below let a host that only needs the runtime
+ * helpers add a single dep instead of two.
+ */
+import type { ReactElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+export type {
+  AdminUserRow,
+  AdminTab,
+  AtriumEvent,
+  AtriumEventHandler,
+  AtriumNotification,
+  AtriumRegistry,
+  HomeWidget,
+  HomeWidgetWidth,
+  LocaleOverlay,
+  NavItem,
+  NotificationKindRenderer,
+  ProfileItem,
+  ProfileSlot,
+  RouteEntry,
+  UserContext,
+} from '@brendan-bank/atrium-host-types';
+
+interface AtriumReactGlobal {
+  createElement: (
+    type: string,
+    props: Record<string, unknown>,
+    ...children: unknown[]
+  ) => unknown;
+}
+
+/** Resolve the React instance atrium exposes on `window.React`. Throws
+ *  with a clear message when missing — the host bundle's import-time
+ *  side-effects are running before the SPA mounted, which means the
+ *  bundle is being loaded outside atrium's own loader. */
+function getAtriumReact(): AtriumReactGlobal {
+  if (typeof window === 'undefined') {
+    throw new Error(
+      '[atrium-host-bundle-utils] makeWrapperElement requires a browser ' +
+        'environment; called from a non-window context',
+    );
+  }
+  const r = (window as unknown as { React?: AtriumReactGlobal }).React;
+  if (!r || typeof r.createElement !== 'function') {
+    throw new Error(
+      '[atrium-host-bundle-utils] window.React is missing — atrium SPA ' +
+        'must mount and expose its React on window.React before the host ' +
+        'bundle is imported. Check that the bundle is being loaded via ' +
+        "atrium's host_bundle_url loader and not by the host's own SPA.",
+    );
+  }
+  return r;
+}
+
+interface MountState {
+  root: Root;
+  child: ReactElement;
+}
+
+// WeakMap so a DOM element going away (host route swap, profile card
+// re-render) doesn't pin the React root in memory. The entry is GC'd
+// alongside the element.
+const mounted = new WeakMap<HTMLElement, MountState>();
+
+/** Mount `child` inside `el` using a fresh React root, idempotent on
+ *  the same `el`/`child` pair.
+ *
+ *  Behaviour:
+ *
+ *  - First call: `createRoot(el).render(child)` and remember the root.
+ *  - Same `el` + same `child` reference: no-op (handles `<StrictMode>`
+ *    double-invoke and ref-callback re-fires on remount).
+ *  - Same `el` + different `child` reference: re-renders into the
+ *    existing root — cheaper than unmount/remount and preserves
+ *    component state where the new child's tree matches.
+ *
+ *  Hosts use this directly only when they want to manage their own
+ *  ref semantics. The common case is `makeWrapperElement(child)`
+ *  below, which closes over a single child and tracks the mounted
+ *  node via the ref callback's `null` signal so unmount is exact. */
+export function mountInside(el: HTMLElement, child: ReactElement): void {
+  const existing = mounted.get(el);
+  if (existing) {
+    if (existing.child === child) return;
+    existing.root.render(child);
+    existing.child = child;
+    return;
+  }
+  const root = createRoot(el);
+  root.render(child);
+  mounted.set(el, { root, child });
+}
+
+/** Unmount the React root previously attached to `el` by `mountInside`.
+ *  No-op when there is no tracked root. Called automatically by the
+ *  ref callback returned from `makeWrapperElement`; hosts only call
+ *  this directly when managing their own ref semantics. */
+export function unmountInside(el: HTMLElement): void {
+  const existing = mounted.get(el);
+  if (!existing) return;
+  existing.root.unmount();
+  mounted.delete(el);
+}
+
+/** Build an atrium-React element whose ref callback mounts `child` via
+ *  the host's own React. Returns a `ReactElement` so it slots
+ *  directly into the registry option-bag types (`render: () =>
+ *  makeWrapperElement(<MyWidget />)`).
+ *
+ *  Each call captures the supplied `child` in a closure and tracks the
+ *  mounted DOM node so the React unmount fires when atrium drops the
+ *  wrapper (route swap, tab change). The closure-style tracking is the
+ *  correct fix for issue #31 — using a module-level WeakMap alone
+ *  meant a child swap on a reused DOM node could leave the previous
+ *  child's tree mounted; pinning state to one closure-per-call
+ *  guarantees one wrapper element owns one mount.
+ *
+ *  Note: the returned object is created via *atrium's* React, not the
+ *  host bundle's. The two trees only meet at this `<div>`; everything
+ *  inside the ref callback runs under the host's React. The
+ *  `ReactElement` cast is safe because atrium's React exposes the
+ *  same element shape — the type system can't tell them apart, and
+ *  the registry consumer treats either as opaque.
+ *
+ *  Tabler icons (and other hooks-free SVG components) can be passed
+ *  directly to `window.React.createElement(...)` — they don't need
+ *  the wrapper. The wrapper is only required for trees that use
+ *  hooks, context, or anything that depends on the host's React copy. */
+export function makeWrapperElement(child: ReactElement): ReactElement {
+  const AtriumReact = getAtriumReact();
+  let mountedNode: HTMLElement | null = null;
+  let mountedRoot: Root | null = null;
+
+  return AtriumReact.createElement('div', {
+    ref: (el: HTMLElement | null) => {
+      // React calls the ref with `null` on unmount and again with the
+      // node on mount. Same node twice in a row is the StrictMode /
+      // remount case — skip.
+      if (el === mountedNode) return;
+      if (mountedRoot && mountedNode) {
+        mountedRoot.unmount();
+        mountedRoot = null;
+      }
+      mountedNode = el;
+      if (el) {
+        mountedRoot = createRoot(el);
+        mountedRoot.render(child);
+      }
+    },
+  }) as ReactElement;
+}

--- a/packages/host-bundle-utils/src/react/index.ts
+++ b/packages/host-bundle-utils/src/react/index.ts
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+/**
+ * React hooks + provider for atrium host bundles.
+ *
+ * One TanStack Query subscription serves the whole host tree:
+ * `useMe()` fetches `/users/me/context` once and shares the result
+ * with every `usePerm()`, `useRole()`, and `useUserContext()` caller.
+ * The hooks read the API base URL from `<AtriumProvider>` (default
+ * `'/api'`) so a host serving its bundle on a different prefix can
+ * point them at the right origin without forking the package.
+ *
+ * The hooks reuse the host's enclosing `<QueryClientProvider>` if one
+ * is already mounted; pass `client={hostQueryClient}` to
+ * `<AtriumProvider>` only if you want this provider to wrap the
+ * QueryClient too. Two QueryClients (atrium's + the host's) is the
+ * intended state — atrium clears its cache on logout via `qc.clear()`,
+ * and a shared client would lose host queries the user still wants.
+ */
+import {
+  createContext,
+  createElement,
+  useCallback,
+  useContext,
+  useMemo,
+  type ReactNode,
+} from 'react';
+import {
+  QueryClientProvider,
+  useQuery,
+  type QueryClient,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+
+import type { UserContext } from '@brendan-bank/atrium-host-types';
+
+export type { UserContext } from '@brendan-bank/atrium-host-types';
+
+interface AtriumContextValue {
+  apiBase: string;
+  fetchUserContext: () => Promise<UserContext | null>;
+}
+
+const DEFAULT_API_BASE = '/api';
+
+async function defaultFetchUserContext(
+  apiBase: string,
+): Promise<UserContext | null> {
+  const res = await fetch(`${apiBase}/users/me/context`, {
+    credentials: 'include',
+    headers: { Accept: 'application/json' },
+  });
+  if (res.status === 401 || res.status === 403) return null;
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`/users/me/context: ${res.status} ${body}`.trim());
+  }
+  return (await res.json()) as UserContext;
+}
+
+const AtriumContext = createContext<AtriumContextValue | null>(null);
+
+export interface AtriumProviderProps {
+  /** API base URL the hooks prefix on every fetch. Default `'/api'` —
+   *  matches atrium's convention of mounting the API behind `/api/*`
+   *  on the same origin as the SPA. */
+  apiBase?: string;
+  /** Optional TanStack QueryClient. When supplied the provider wraps
+   *  children in a `<QueryClientProvider>`; otherwise the hooks
+   *  inherit the caller's enclosing one. Use this only when the host
+   *  hasn't already set up its own provider. */
+  client?: QueryClient;
+  /** Override the fetcher for `/users/me/context`. Useful for tests
+   *  and for hosts that want to layer an axios interceptor or extra
+   *  headers on top. The default uses `fetch` with `credentials:
+   *  'include'`. */
+  fetchUserContext?: () => Promise<UserContext | null>;
+  children: ReactNode;
+}
+
+/** Provider that supplies `apiBase` and (optionally) a QueryClient
+ *  to the atrium hooks below. Hosts that already wrap their tree in
+ *  `<QueryClientProvider>` can omit `client` — the hooks use the
+ *  caller's existing QueryClient. */
+export function AtriumProvider({
+  apiBase = DEFAULT_API_BASE,
+  client,
+  fetchUserContext,
+  children,
+}: AtriumProviderProps) {
+  const value = useMemo<AtriumContextValue>(() => {
+    const fetcher = fetchUserContext ?? (() => defaultFetchUserContext(apiBase));
+    return { apiBase, fetchUserContext: fetcher };
+  }, [apiBase, fetchUserContext]);
+
+  const inner = createElement(AtriumContext.Provider, { value }, children);
+
+  if (client) {
+    return createElement(QueryClientProvider, { client }, inner);
+  }
+  return inner;
+}
+
+/** Stable cache key for the `/users/me/context` query. Exported so
+ *  hosts can `queryClient.invalidateQueries({ queryKey: ME_QUERY_KEY })`
+ *  after a flow that changed the user's roles or permissions. */
+export const ME_QUERY_KEY = ['atrium', 'me'] as const;
+
+// Module-level fallback so hooks work without an explicit
+// `<AtriumProvider>` — convenient for hosts that don't need to
+// override the API base or the fetcher. Lazily-allocated so the
+// import has no side effects.
+let DEFAULT_CTX: AtriumContextValue | null = null;
+function defaultCtx(): AtriumContextValue {
+  if (!DEFAULT_CTX) {
+    DEFAULT_CTX = {
+      apiBase: DEFAULT_API_BASE,
+      fetchUserContext: () => defaultFetchUserContext(DEFAULT_API_BASE),
+    };
+  }
+  return DEFAULT_CTX;
+}
+
+function useAtriumContextOrDefault(): AtriumContextValue {
+  const ctx = useContext(AtriumContext);
+  return ctx ?? defaultCtx();
+}
+
+/** Fetch the signed-in user's RBAC context. Returns the standard
+ *  TanStack Query result so callers can surface loading and error
+ *  states — `data` is `null` when the user is not signed in (atrium
+ *  responded 401/403) and the typed `UserContext` otherwise.
+ *
+ *  Cache is shared with `usePerm` / `useRole` / `useUserContext` —
+ *  one network request per host tree. Stale time is 60s, matching
+ *  atrium's own `useMe` so the host's cache invalidation rhythm
+ *  doesn't fight atrium's. */
+export function useMe(): UseQueryResult<UserContext | null> {
+  const { fetchUserContext } = useAtriumContextOrDefault();
+  return useQuery<UserContext | null>({
+    queryKey: ME_QUERY_KEY,
+    queryFn: fetchUserContext,
+    staleTime: 60_000,
+    retry: false,
+  });
+}
+
+/** Alias for `useMe()` — present because issue #40 documents both
+ *  names. The shape is identical; pick whichever reads better at the
+ *  call site. */
+export function useUserContext(): UseQueryResult<UserContext | null> {
+  return useMe();
+}
+
+/** Returns a stable predicate `(code) => boolean` over the signed-in
+ *  user's permissions. While `useMe` is still loading or if the user
+ *  is signed out, the predicate returns `false` for every code — so
+ *  callers default to "not allowed" which is the safe fallback for
+ *  RBAC gating.
+ *
+ *  Returning a function (not a boolean) is deliberate: a single
+ *  call site can check several codes against one query subscription,
+ *  matching the pattern in issue #40:
+ *
+ *  ```tsx
+ *  const hasPerm = usePerm();
+ *  if (hasPerm('commission.view.all')) return <Admin />;
+ *  if (hasPerm('commission.view.own')) return <SelfCommissions />;
+ *  ```
+ */
+export function usePerm(): (code: string) => boolean {
+  const { data: me } = useMe();
+  return useCallback(
+    (code: string) => (me?.permissions ?? []).includes(code),
+    [me?.permissions],
+  );
+}
+
+/** Convenience: does the signed-in user hold the named role? Returns
+ *  `false` while loading and when signed out, mirroring `usePerm`. */
+export function useRole(code: string): boolean {
+  const { data: me } = useMe();
+  return (me?.roles ?? []).includes(code);
+}

--- a/packages/host-bundle-utils/src/vite/index.ts
+++ b/packages/host-bundle-utils/src/vite/index.ts
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+/**
+ * Vite preset for atrium host bundles.
+ *
+ * Imported only by `vite.config.ts`, never by runtime code, so Vite
+ * stays out of the host's production bundle. Vite + the css-injection
+ * plugin are declared as optional peer deps; install them only when
+ * building (typical: as devDependencies in the host's
+ * `frontend/package.json`).
+ *
+ * The preset returns a complete Vite config that:
+ *
+ *  - Builds in library mode (`build.lib`) emitting a single ES module
+ *    at `dist/main.js`. Atrium's loader does
+ *    `import(system.host_bundle_url)` with that URL — no IIFE / UMD
+ *    needed.
+ *  - Inlines every imported `.css` via a runtime `<style>` tag
+ *    (`vite-plugin-css-injected-by-js`). Without this Vite extracts
+ *    CSS to a sibling `main.css` that atrium's dynamic-import never
+ *    fetches, and Mantine / FullCalendar / any rich-text editor ships
+ *    silently unstyled.
+ *  - Defines `process.env.NODE_ENV` so the externalised React +
+ *    TanStack Query references resolve in lib-mode builds (Vite's
+ *    app-mode auto-replaces this; lib-mode does not).
+ *
+ *  Hosts can override anything by passing `extraConfig` (merged into
+ *  the returned object) — typical use: a host needing a SVG plugin or
+ *  a dev-only proxy. The defaults match the canonical
+ *  self-contained-bundle pattern documented in
+ *  `docs/published-images.md`.
+ */
+import { resolve } from 'node:path';
+
+// `vite` and `vite-plugin-css-injected-by-js` are optional peer deps;
+// import via `await import` so a host that imports the runtime entry
+// at production time isn't forced to install them. Tooling-only entry
+// uses dynamic imports lazily inside the factory.
+
+export interface HostBundleConfigOptions {
+  /** Path to the host bundle's entry. Resolved against the directory
+   *  containing the `vite.config.ts` that calls this factory. */
+  entry: string;
+  /** Output filename for the built bundle. Default `'main.js'` —
+   *  matches atrium's documented `system.host_bundle_url` of
+   *  `/host/main.js`. */
+  fileName?: string;
+  /** Output directory inside the host's frontend project. Default
+   *  `'dist'` — matches Vite's default and the `COPY --from=frontend-builder
+   *  /app/dist /opt/atrium/static/host` Dockerfile pattern. */
+  outDir?: string;
+  /** Include sourcemaps in the build. Default `true` — they are tiny
+   *  next to the bundle and make production debugging tractable. */
+  sourcemap?: boolean;
+  /** Override the JS target. Default `'es2022'`. */
+  target?: string;
+  /** Extra Vite config to merge on top of the defaults. Plugins are
+   *  appended; everything else uses Vite's standard merge semantics. */
+  extraConfig?: Record<string, unknown>;
+}
+
+/** Build a Vite config for an atrium host bundle.
+ *
+ *  Usage in the host's `vite.config.ts`:
+ *
+ *  ```ts
+ *  import { hostBundleConfig } from '@brendan-bank/atrium-host-bundle-utils/vite';
+ *
+ *  export default hostBundleConfig({ entry: 'src/main.tsx' });
+ *  ```
+ *
+ *  The factory is async because it lazy-imports `vite` and the css
+ *  injection plugin so they can stay optional peer deps.
+ */
+export async function hostBundleConfig(
+  options: HostBundleConfigOptions,
+): Promise<Record<string, unknown>> {
+  const {
+    entry,
+    fileName = 'main.js',
+    outDir = 'dist',
+    sourcemap = true,
+    target = 'es2022',
+    extraConfig = {},
+  } = options;
+
+  const [vite, cssInjectedByJs] = await Promise.all([
+    import('vite'),
+    import('vite-plugin-css-injected-by-js'),
+  ]);
+
+  const mergeConfig = (vite as { mergeConfig: (a: unknown, b: unknown) => unknown }).mergeConfig;
+  const cssPluginFactory =
+    ((cssInjectedByJs as unknown as { default?: () => unknown }).default ??
+      (cssInjectedByJs as unknown as () => unknown)) as () => unknown;
+
+  // Build the config as a plain object — `defineConfig` is only a
+  // typing helper, and its strict `Plugin` typing fights the
+  // dynamically-imported CSS plugin. The merged config is what Vite
+  // actually consumes at build time.
+  const base: Record<string, unknown> = {
+    // Lib-mode builds don't auto-replace `process.env.NODE_ENV` the
+    // way Vite's app-mode builds do, and several deps (React internals,
+    // TanStack Query) reference it. Without these defines the bundle
+    // throws `ReferenceError: process is not defined` the moment the
+    // SPA dynamic-imports it.
+    define: {
+      'process.env.NODE_ENV': JSON.stringify('production'),
+      'process.env': '{}',
+    },
+    plugins: [cssPluginFactory()],
+    build: {
+      target,
+      lib: {
+        entry: resolve(process.cwd(), entry),
+        formats: ['es'],
+        fileName: () => fileName,
+      },
+      outDir,
+      emptyOutDir: true,
+      sourcemap,
+    },
+  };
+
+  return mergeConfig(base, extraConfig) as Record<string, unknown>;
+}

--- a/packages/host-bundle-utils/test/makeWrapperElement.test.tsx
+++ b/packages/host-bundle-utils/test/makeWrapperElement.test.tsx
@@ -1,0 +1,201 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import React, { type ReactElement } from 'react';
+import { act } from '@testing-library/react';
+
+// Stand in for `window.React` — atrium exposes its own React on the
+// global so host bundles can `createElement` atrium-React elements
+// without bundling a second React copy. The dual-tree pattern relies
+// on this — see `frontend/src/main.tsx`. The package reads `window.React`
+// at call time, so installing it in `beforeEach` is enough.
+import { makeWrapperElement, mountInside, unmountInside } from '../src/index';
+
+declare global {
+  interface Window {
+    React?: typeof React;
+  }
+}
+
+beforeEach(() => {
+  window.React = React;
+});
+
+afterEach(() => {
+  delete window.React;
+  document.body.innerHTML = '';
+  // Drain any pending React.act() work so a previous test's pending
+  // root teardown doesn't bleed into the next.
+  return new Promise<void>((resolve) => setTimeout(resolve, 0));
+});
+
+function attachWrapper(child: ReactElement): HTMLDivElement {
+  // makeWrapperElement returns an atrium-React element. In a real
+  // host atrium's reconciler renders it; in the test we mimic that
+  // by extracting the ref callback and invoking it with a fresh DOM
+  // node, which is exactly what the reconciler does on commit.
+  const wrapper = makeWrapperElement(child) as {
+    props: { ref: (el: HTMLElement | null) => void };
+  };
+  const slot = document.createElement('div');
+  document.body.appendChild(slot);
+  act(() => {
+    wrapper.props.ref(slot);
+  });
+  return slot as HTMLDivElement;
+}
+
+describe('mountInside', () => {
+  test('mounts the host React tree into the slot element', () => {
+    const slot = document.createElement('div');
+    document.body.appendChild(slot);
+
+    act(() => {
+      mountInside(slot, <p data-testid="child">hello</p>);
+    });
+
+    expect(slot.querySelector('p')).not.toBeNull();
+    expect(slot.querySelector('p')?.textContent).toBe('hello');
+  });
+
+  test('is idempotent on the same el+child reference', () => {
+    const slot = document.createElement('div');
+    document.body.appendChild(slot);
+    const child = <p data-testid="child">a</p>;
+
+    act(() => {
+      mountInside(slot, child);
+    });
+    const first = slot.querySelector('p');
+
+    act(() => {
+      mountInside(slot, child);
+    });
+    const second = slot.querySelector('p');
+
+    // Same DOM node — no re-render.
+    expect(second).toBe(first);
+    expect(slot.querySelectorAll('p')).toHaveLength(1);
+  });
+
+  test('re-renders into the existing root when child swaps', () => {
+    const slot = document.createElement('div');
+    document.body.appendChild(slot);
+
+    act(() => {
+      mountInside(slot, <p>first</p>);
+    });
+    expect(slot.textContent).toBe('first');
+
+    act(() => {
+      mountInside(slot, <p>second</p>);
+    });
+    expect(slot.textContent).toBe('second');
+    // Single root, single tree — no leaked siblings from the prior child.
+    expect(slot.querySelectorAll('p')).toHaveLength(1);
+  });
+
+  test('unmountInside tears the root down', () => {
+    const slot = document.createElement('div');
+    document.body.appendChild(slot);
+    act(() => {
+      mountInside(slot, <p>x</p>);
+    });
+    expect(slot.querySelector('p')).not.toBeNull();
+
+    act(() => {
+      unmountInside(slot);
+    });
+    expect(slot.querySelector('p')).toBeNull();
+  });
+});
+
+describe('makeWrapperElement', () => {
+  test('throws a clear error when window.React is missing', () => {
+    delete window.React;
+    expect(() => makeWrapperElement(<p>x</p>)).toThrow(
+      /window\.React is missing/,
+    );
+  });
+
+  test('mounts the child when atrium ref-callbacks the slot', () => {
+    const slot = attachWrapper(<p data-testid="hello">hi</p>);
+    expect(slot.querySelector('p')?.textContent).toBe('hi');
+  });
+
+  test('child swap across separate makeWrapperElement calls does not leak the previous tree', () => {
+    // Issue #31: two `<Route>` registrations with structurally identical
+    // wrapper divs share the same DOM node when react-router swaps
+    // between them. Each call captures its own child via closure;
+    // when the second wrapper's ref fires on the same slot, the
+    // first wrapper's ref should have fired with `null` first,
+    // unmounting that root cleanly.
+    const wrapperA = makeWrapperElement(<p>route-A</p>) as {
+      props: { ref: (el: HTMLElement | null) => void };
+    };
+    const wrapperB = makeWrapperElement(<p>route-B</p>) as {
+      props: { ref: (el: HTMLElement | null) => void };
+    };
+
+    const slot = document.createElement('div');
+    document.body.appendChild(slot);
+
+    act(() => {
+      wrapperA.props.ref(slot);
+    });
+    expect(slot.textContent).toBe('route-A');
+
+    // React would call A's ref with null when the route is removed,
+    // then B's ref with the new (or reused) DOM node when the next
+    // route mounts.
+    act(() => {
+      wrapperA.props.ref(null);
+    });
+    act(() => {
+      wrapperB.props.ref(slot);
+    });
+
+    // Only B's tree is present; A's tree was unmounted.
+    expect(slot.textContent).toBe('route-B');
+    expect(slot.querySelectorAll('p')).toHaveLength(1);
+  });
+
+  test('repeat ref calls with the same DOM node do not re-mount', () => {
+    // StrictMode double-invoke — ref fires multiple times with the
+    // same node. The implementation should treat the redundant calls
+    // as no-ops; the DOM should still have exactly one rendered tree
+    // and React shouldn't warn about double-mounting.
+    const wrapper = makeWrapperElement(<p>once</p>) as {
+      props: { ref: (el: HTMLElement | null) => void };
+    };
+    const slot = document.createElement('div');
+    document.body.appendChild(slot);
+
+    act(() => {
+      wrapper.props.ref(slot);
+      wrapper.props.ref(slot);
+      wrapper.props.ref(slot);
+    });
+
+    expect(slot.querySelectorAll('p')).toHaveLength(1);
+    expect(slot.textContent).toBe('once');
+  });
+
+  test('ref(null) unmounts the host React tree', () => {
+    const wrapper = makeWrapperElement(<p data-testid="x">value</p>) as {
+      props: { ref: (el: HTMLElement | null) => void };
+    };
+    const slot = document.createElement('div');
+    document.body.appendChild(slot);
+    act(() => {
+      wrapper.props.ref(slot);
+    });
+    expect(slot.querySelector('p')).not.toBeNull();
+
+    act(() => {
+      wrapper.props.ref(null);
+    });
+    expect(slot.querySelector('p')).toBeNull();
+  });
+});

--- a/packages/host-bundle-utils/test/setup.ts
+++ b/packages/host-bundle-utils/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/packages/host-bundle-utils/test/useMe.test.tsx
+++ b/packages/host-bundle-utils/test/useMe.test.tsx
@@ -1,0 +1,241 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
+import React from 'react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+
+import {
+  AtriumProvider,
+  ME_QUERY_KEY,
+  useMe,
+  usePerm,
+  useRole,
+  useUserContext,
+} from '../src/react/index';
+import type { UserContext } from '@brendan-bank/atrium-host-types';
+
+const ALICE: UserContext = {
+  id: 7,
+  email: 'alice@example.com',
+  full_name: 'Alice Example',
+  is_active: true,
+  roles: ['admin', 'user'],
+  permissions: ['user.manage', 'audit.read'],
+  impersonating_from: null,
+};
+
+const server = setupServer(
+  http.get('/api/users/me/context', () => HttpResponse.json(ALICE)),
+);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  cleanup();
+  server.resetHandlers();
+});
+afterAll(() => server.close());
+
+function makeClient() {
+  // Disable retries so a 401 surfaces immediately and tests don't
+  // wait for backoff.
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+function withProviders(node: React.ReactNode, client = makeClient()) {
+  return (
+    <QueryClientProvider client={client}>
+      <AtriumProvider>{node}</AtriumProvider>
+    </QueryClientProvider>
+  );
+}
+
+function MeProbe() {
+  const { data, isLoading } = useMe();
+  if (isLoading) return <span>loading</span>;
+  if (!data) return <span>signed-out</span>;
+  return <span data-testid="email">{data.email}</span>;
+}
+
+function UserContextProbe() {
+  const { data } = useUserContext();
+  return <span data-testid="ctx">{data ? data.full_name : '—'}</span>;
+}
+
+function PermProbe({ codes }: { codes: string[] }) {
+  const hasPerm = usePerm();
+  return (
+    <ul>
+      {codes.map((c) => (
+        <li key={c} data-testid={`perm-${c}`}>
+          {hasPerm(c) ? 'yes' : 'no'}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function RoleProbe({ code }: { code: string }) {
+  const has = useRole(code);
+  return <span data-testid={`role-${code}`}>{has ? 'yes' : 'no'}</span>;
+}
+
+describe('useMe', () => {
+  test('fetches and exposes the user context', async () => {
+    render(withProviders(<MeProbe />));
+    await waitFor(() =>
+      expect(screen.getByTestId('email').textContent).toBe('alice@example.com'),
+    );
+  });
+
+  test('useUserContext is an alias for useMe', async () => {
+    render(withProviders(<UserContextProbe />));
+    await waitFor(() =>
+      expect(screen.getByTestId('ctx').textContent).toBe('Alice Example'),
+    );
+  });
+
+  test('returns null when atrium responds 401', async () => {
+    server.use(
+      http.get('/api/users/me/context', () => new HttpResponse(null, { status: 401 })),
+    );
+    render(withProviders(<MeProbe />));
+    await waitFor(() =>
+      expect(screen.getByText('signed-out')).toBeInTheDocument(),
+    );
+  });
+
+  test('shares one query subscription across hooks', async () => {
+    let calls = 0;
+    server.use(
+      http.get('/api/users/me/context', () => {
+        calls += 1;
+        return HttpResponse.json(ALICE);
+      }),
+    );
+
+    function Multi() {
+      // Three hook calls in one tree must share a single fetch.
+      useMe();
+      useMe();
+      const { data } = useMe();
+      return <span data-testid="multi">{data?.id ?? -1}</span>;
+    }
+
+    render(withProviders(<Multi />));
+    await waitFor(() =>
+      expect(screen.getByTestId('multi').textContent).toBe('7'),
+    );
+    expect(calls).toBe(1);
+  });
+
+  test('ME_QUERY_KEY is a stable referenced key', () => {
+    // Hosts depend on this for invalidation after flows that change
+    // the user's roles or permissions. The exported tuple must be
+    // structurally stable across renders.
+    expect(ME_QUERY_KEY).toEqual(['atrium', 'me']);
+  });
+});
+
+describe('usePerm', () => {
+  test('returns true for permissions the user holds and false otherwise', async () => {
+    render(
+      withProviders(
+        <PermProbe codes={['user.manage', 'audit.read', 'role.manage']} />,
+      ),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('perm-user.manage').textContent).toBe('yes'),
+    );
+    expect(screen.getByTestId('perm-audit.read').textContent).toBe('yes');
+    expect(screen.getByTestId('perm-role.manage').textContent).toBe('no');
+  });
+
+  test('returns false for every code while loading', () => {
+    render(withProviders(<PermProbe codes={['user.manage']} />));
+    // Synchronous render — the query hasn't resolved yet, so the
+    // predicate must default to "deny".
+    expect(screen.getByTestId('perm-user.manage').textContent).toBe('no');
+  });
+});
+
+describe('useRole', () => {
+  test('returns true for roles the user holds and false otherwise', async () => {
+    render(
+      withProviders(
+        <>
+          <RoleProbe code="admin" />
+          <RoleProbe code="super_admin" />
+        </>,
+      ),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('role-admin').textContent).toBe('yes'),
+    );
+    expect(screen.getByTestId('role-super_admin').textContent).toBe('no');
+  });
+});
+
+describe('AtriumProvider', () => {
+  test('apiBase override changes the fetch URL', async () => {
+    let hit = false;
+    server.use(
+      http.get('/v2/users/me/context', () => {
+        hit = true;
+        return HttpResponse.json({ ...ALICE, email: 'v2@example.com' });
+      }),
+    );
+    const client = makeClient();
+    render(
+      <QueryClientProvider client={client}>
+        <AtriumProvider apiBase="/v2">
+          <MeProbe />
+        </AtriumProvider>
+      </QueryClientProvider>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('email').textContent).toBe('v2@example.com'),
+    );
+    expect(hit).toBe(true);
+  });
+
+  test('custom fetchUserContext bypasses fetch entirely', async () => {
+    const client = makeClient();
+    render(
+      <QueryClientProvider client={client}>
+        <AtriumProvider
+          fetchUserContext={async () => ({
+            ...ALICE,
+            email: 'injected@example.com',
+          })}
+        >
+          <MeProbe />
+        </AtriumProvider>
+      </QueryClientProvider>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('email').textContent).toBe(
+        'injected@example.com',
+      ),
+    );
+  });
+
+  test('client prop wraps children in QueryClientProvider', async () => {
+    // No outer QueryClientProvider — the provider supplies one itself.
+    const client = makeClient();
+    render(
+      <AtriumProvider client={client}>
+        <MeProbe />
+      </AtriumProvider>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('email').textContent).toBe('alice@example.com'),
+    );
+  });
+});

--- a/packages/host-bundle-utils/tsconfig.json
+++ b/packages/host-bundle-utils/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "verbatimModuleSyntax": false,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["test", "dist", "node_modules"]
+}

--- a/packages/host-bundle-utils/vitest.config.ts
+++ b/packages/host-bundle-utils/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: false,
+    setupFiles: ['./test/setup.ts'],
+    include: ['test/**/*.test.{ts,tsx}'],
+  },
+});

--- a/packages/host-types/README.md
+++ b/packages/host-types/README.md
@@ -1,0 +1,81 @@
+# `@brendan-bank/atrium-host-types`
+
+TypeScript declarations for the [atrium](https://github.com/Brendan-Bank/atrium)
+host-extension contract.
+
+```ts
+import type {
+  AtriumRegistry,
+  AtriumNotification,
+  AtriumEvent,
+  UserContext,
+  AdminUserRow,
+} from '@brendan-bank/atrium-host-types';
+
+const reg = window.__ATRIUM_REGISTRY__ as AtriumRegistry;
+reg.registerHomeWidget({ key: 'my-card', render: () => /* ... */ });
+```
+
+The package is **types-only** — no runtime, no JS payload at runtime.
+Bundlers strip it from the production output.
+
+## Installation
+
+The package is published on **GitHub Packages**, not the public npm
+registry. Add an `.npmrc` to your host project that points the
+`@brendan-bank` scope at GitHub Packages:
+
+```
+# .npmrc
+@brendan-bank:registry=https://npm.pkg.github.com
+```
+
+GitHub Packages requires an authenticated install even for public
+packages — give npm a token with at least the `read:packages` scope:
+
+```
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+```
+
+In CI, `GITHUB_TOKEN` is provided automatically by Actions; locally,
+generate a [classic PAT](https://github.com/settings/tokens) with
+`read:packages` and export it. Then:
+
+```bash
+pnpm add -D @brendan-bank/atrium-host-types
+```
+
+## Versioning
+
+The package version tracks atrium's image version. Pin `^0.14` for
+"compatible with atrium 0.14.x"; bump together with the atrium image
+to pick up new registry slots. New slots land as **optional** members
+on `AtriumRegistry` first so a host that hasn't bumped yet still
+type-checks.
+
+## What ships
+
+- `AtriumRegistry` — every `register*` slot atrium exposes plus
+  `subscribeEvent`.
+- `UserContext` — `/users/me/context` shape.
+- `AdminUserRow` — `/admin/users` row shape.
+- `AtriumNotification` — notification row body.
+- `AtriumEvent` / `AtriumEventHandler` — SSE typed event shape.
+- Per-slot option-bag types: `HomeWidget`, `RouteEntry`, `NavItem`,
+  `AdminTab`, `ProfileItem`, `NotificationKindRenderer`,
+  `LocaleOverlay`.
+- `ProfileSlot`, `HomeWidgetWidth` — string unions.
+- A `declare global` block that types `window.React`,
+  `window.__ATRIUM_VERSION__`, and `window.__ATRIUM_REGISTRY__`.
+
+## See also
+
+- [`@brendan-bank/atrium-host-bundle-utils`](../host-bundle-utils/) —
+  runtime helpers, Vite preset, and React hooks. Re-exports the types
+  from this package, so a host adding only one dep still gets the
+  declarations.
+- [`docs/published-images.md`](../../docs/published-images.md) — the
+  full host-extension contract (image catalogue, loader behaviour,
+  registry semantics).
+- [`docs/compat-matrix.md`](../../docs/compat-matrix.md) — which
+  atrium release added which slot.

--- a/packages/host-types/package.json
+++ b/packages/host-types/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@brendan-bank/atrium-host-types",
+  "version": "0.14.0",
+  "description": "TypeScript declarations for the atrium host-extension contract: AtriumRegistry, UserContext, AdminUserRow, AtriumNotification, AtriumEvent. Source-of-truth shapes a host bundle types against, kept in sync with atrium's published image major.minor.",
+  "license": "BSD-2-Clause",
+  "type": "module",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "react": "^19.2.5",
+    "typescript": "^6.0.3"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://npm.pkg.github.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Brendan-Bank/atrium.git",
+    "directory": "packages/host-types"
+  }
+}

--- a/packages/host-types/src/index.ts
+++ b/packages/host-types/src/index.ts
@@ -1,0 +1,236 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+/**
+ * Source-of-truth TypeScript declarations for the atrium host-extension
+ * contract. A host bundle imports these types so its registration calls
+ * are checked against the same shapes atrium's own consumer components
+ * read.
+ *
+ * The package version tracks atrium's image version (`^0.14` of this
+ * package implies "compatible with atrium 0.14.x"). New registry slots
+ * land here when they ship in atrium; bumping the package picks them
+ * up. A host that calls a method missing on the pinned major gets a
+ * TypeScript error before runtime — the runtime Proxy on
+ * `window.__ATRIUM_REGISTRY__` is a belt-and-braces fallback for
+ * version skew, not a substitute for typing.
+ */
+
+import type { ReactElement } from 'react';
+
+// ---------------------------------------------------------------------------
+// Identity / context
+// ---------------------------------------------------------------------------
+
+/** Shape of `GET /users/me/context` — the atrium-owned RBAC view of the
+ *  signed-in user. The bundled hook in `@brendan-bank/atrium-host-bundle-utils/react`
+ *  returns this exact shape. */
+export interface UserContext {
+  id: number;
+  email: string;
+  full_name: string;
+  is_active: boolean;
+  roles: string[];
+  permissions: string[];
+  impersonating_from: { id: number; email: string; full_name: string } | null;
+}
+
+/** Shape of `GET /admin/users` rows (and `/admin/users/{id}` responses).
+ *  Hosts that render their own admin UIs against atrium's user list
+ *  read this shape. The patch endpoint accepts `role_ids`; the read
+ *  shape carries both `role_ids` and the human-readable `roles` codes. */
+export interface AdminUserRow {
+  id: number;
+  email: string;
+  is_active: boolean;
+  is_verified: boolean;
+  full_name: string;
+  phone: string | null;
+  preferred_language: 'en' | 'nl';
+  role_ids: number[];
+  roles: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Notification + event payloads
+// ---------------------------------------------------------------------------
+
+/** A single notification row as the SPA sees it. `kind` is host-defined;
+ *  `payload` is opaque JSON. `read_at` is null until the user clears the
+ *  bell; `created_at` is the server-side timestamp. */
+export interface AtriumNotification {
+  id: number;
+  kind: string;
+  payload: Record<string, unknown>;
+  read_at: string | null;
+  created_at: string;
+}
+
+/** SSE `notification` event published by `app.services.notifications.notify_user`.
+ *  Same wire shape as the row's body — `kind` matches what
+ *  `registerNotificationKind` listens on. */
+export interface AtriumEvent {
+  kind: string;
+  payload: Record<string, unknown>;
+}
+
+export type AtriumEventHandler = (event: AtriumEvent) => void;
+
+// ---------------------------------------------------------------------------
+// Registry slot shapes
+// ---------------------------------------------------------------------------
+
+/** Layout width for a home-page widget. `narrow` matches atrium's default
+ *  680px column; `wide` extends to a comfortable dashboard column; `full`
+ *  takes the whole panel inside `AppShell.Main`. Default `narrow`. */
+export type HomeWidgetWidth = 'narrow' | 'wide' | 'full';
+
+export interface HomeWidget {
+  key: string;
+  render: () => ReactElement;
+  width?: HomeWidgetWidth;
+}
+
+export interface RouteEntry {
+  key: string;
+  path: string;
+  /** Returns a fresh element each time the route mounts. Strongly
+   *  preferred — see the host-bundle wrapper-element rationale in
+   *  `docs/published-images.md`. Exactly one of `render` / `element`
+   *  must be supplied. */
+  render?: () => ReactElement;
+  /** @deprecated Pass `render: () => element` instead. Captured
+   *  elements share the same DOM node across navigations and can carry
+   *  stale state. Kept for back-compat with hosts built against
+   *  pre-0.12 atrium. */
+  element?: ReactElement;
+  /** Default `true`. Set false for public routes (e.g. host landing pages). */
+  requireAuth?: boolean;
+  /** Default `'shell'`. `'bare'` skips atrium's AppLayout wrapper. */
+  layout?: 'shell' | 'bare';
+}
+
+export interface NavItem {
+  key: string;
+  label: string;
+  to: string;
+  icon?: ReactElement;
+  /** Optional visibility predicate. Default: always visible. `me` is
+   *  null until the SPA's auth probe resolves. */
+  condition?: (ctx: { me: UserContext | null }) => boolean;
+}
+
+export interface AdminTab {
+  key: string;
+  label: string;
+  icon?: ReactElement;
+  /** Permission code; the tab is hidden for users without it. Omit to
+   *  show the tab to every viewer with admin access. */
+  perm?: string;
+  /** Returns a fresh element each time the tab is selected. Strongly
+   *  preferred — see `RouteEntry.render`. Exactly one of `render` /
+   *  `element` must be supplied. */
+  render?: () => ReactElement;
+  /** @deprecated Pass `render: () => element` instead. */
+  element?: ReactElement;
+}
+
+/** Insertion slot inside `ProfilePage`'s vertical card stack. Default
+ *  `'after-roles'` — the natural place for extra preferences. */
+export type ProfileSlot =
+  | 'after-profile'
+  | 'after-password'
+  | 'after-2fa'
+  | 'after-roles'
+  | 'after-sessions'
+  | 'before-delete';
+
+export interface ProfileItem {
+  key: string;
+  /** Insertion slot. Default `'after-roles'`. */
+  slot?: ProfileSlot;
+  /** Optional visibility predicate. The profile page early-returns on a
+   *  missing user, so `me` is never null when this fires. */
+  condition?: (ctx: { me: UserContext }) => boolean;
+  render: () => ReactElement;
+}
+
+/** Per-kind renderer for a notification row. Atrium emits `{kind,
+ *  payload}` rows but ships no built-in formatting — host apps register
+ *  one renderer per kind they care about. */
+export interface NotificationKindRenderer {
+  /** Notification `kind` string this renderer handles. Match is exact;
+   *  no glob / prefix matching. Duplicate registrations for the same
+   *  kind warn and last-write-wins. */
+  kind: string;
+  /** Detail-modal body. Receives the full row. */
+  render: (n: AtriumNotification) => ReactElement;
+  /** Compact summary for the bell + inbox row line and the modal title. */
+  title?: (n: AtriumNotification) => string;
+  /** App-internal href. When set, the row click navigates instead of
+   *  opening the detail modal. */
+  href?: (n: AtriumNotification) => string;
+}
+
+/** Locale overlay registered by a host. `strings` is a flat
+ *  i18next-style bundle (dot-paths or nested object — both accepted).
+ *  Layered on top of atrium's shipped locale + admin overrides;
+ *  precedence is shipped < admin overrides < host overlay. */
+export interface LocaleOverlay {
+  locale: string;
+  strings: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Registry surface
+// ---------------------------------------------------------------------------
+
+/** The runtime-discovered registry exposed at `window.__ATRIUM_REGISTRY__`.
+ *
+ *  Optional methods are slots that landed in a later atrium release
+ *  than the one that introduced this type — type-narrow before calling
+ *  if you intend to support older images, or use the runtime
+ *  `__ATRIUM_VERSION__` global for explicit gating. The Proxy on the
+ *  registry already turns calls to missing methods into a console
+ *  warning + no-op; this is for clean TypeScript checking on top of
+ *  that runtime safety net.
+ *
+ *  When atrium adds a new slot, this type bumps and the slot becomes
+ *  optional first; once a release window has passed and `^0.X` no
+ *  longer covers the pre-slot images, the slot becomes required. */
+export interface AtriumRegistry {
+  registerHomeWidget: (widget: HomeWidget) => void;
+  registerRoute: (route: RouteEntry) => void;
+  registerNavItem: (item: NavItem) => void;
+  registerAdminTab: (tab: AdminTab) => void;
+  registerProfileItem: (item: ProfileItem) => void;
+  registerNotificationKind: (renderer: NotificationKindRenderer) => void;
+  registerLocale: (overlay: LocaleOverlay) => void;
+  subscribeEvent: (kind: string, handler: AtriumEventHandler) => () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Window globals atrium exposes for host bundles
+// ---------------------------------------------------------------------------
+
+declare global {
+  interface Window {
+    /** atrium's React instance. Host bundles read this so their
+     *  wrapper elements can call `React.createElement(...)` without
+     *  bundling a second React copy that atrium's reconciler would
+     *  refuse to render. Available since the host-bundle pattern
+     *  shipped (atrium 0.10+). */
+    React?: typeof import('react');
+    /** Backend version string (e.g. "0.14.0") mirrored from
+     *  `GET /app-config` before the host bundle is imported, so
+     *  import-time code can branch on it. Available since atrium
+     *  0.14.0; treat as best-effort on older images. */
+    __ATRIUM_VERSION__?: string;
+    /** The registry. Populated by atrium before the host bundle
+     *  imports; host bundles read it and call its `register*` methods
+     *  at module init. */
+    __ATRIUM_REGISTRY__?: AtriumRegistry;
+  }
+}
+
+export {};

--- a/packages/host-types/tsconfig.json
+++ b/packages/host-types/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,2148 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}
+
+  examples/hello-world/frontend:
+    dependencies:
+      '@brendan-bank/atrium-host-bundle-utils':
+        specifier: workspace:*
+        version: link:../../../packages/host-bundle-utils
+      '@brendan-bank/atrium-host-types':
+        specifier: workspace:*
+        version: link:../../../packages/host-types
+      '@mantine/core':
+        specifier: ^9.1.0
+        version: 9.1.1(@mantine/hooks@9.1.1(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@mantine/hooks':
+        specifier: ^9.1.0
+        version: 9.1.1(react@19.2.5)
+      '@tabler/icons-react':
+        specifier: ^3.41.1
+        version: 3.41.1(react@19.2.5)
+      '@tanstack/react-query':
+        specifier: ^5.100.1
+        version: 5.100.6(react@19.2.5)
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      otplib:
+        specifier: ^13.4.0
+        version: 13.4.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.10
+        version: 8.0.10(@types/node@25.6.0)
+      vite-plugin-css-injected-by-js:
+        specifier: ^3.5.2
+        version: 3.5.2(vite@8.0.10(@types/node@25.6.0))
+
+  packages/host-bundle-utils:
+    dependencies:
+      '@brendan-bank/atrium-host-types':
+        specifier: workspace:*
+        version: link:../host-types
+    devDependencies:
+      '@tanstack/react-query':
+        specifier: ^5.100.5
+        version: 5.100.6(react@19.2.5)
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.1.0(@noble/hashes@2.2.0)
+      msw:
+        specifier: ^2.7.0
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.10
+        version: 8.0.10(@types/node@25.6.0)
+      vite-plugin-css-injected-by-js:
+        specifier: ^3.5.2
+        version: 3.5.2(vite@8.0.10(@types/node@25.6.0))
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.0(@noble/hashes@2.2.0))(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0))
+
+  packages/host-types:
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
+packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.0':
+    resolution: {integrity: sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.0':
+    resolution: {integrity: sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3':
+    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/react@0.27.19':
+    resolution: {integrity: sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==}
+    peerDependencies:
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@inquirer/ansi@2.0.5':
+    resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/confirm@6.0.12':
+    resolution: {integrity: sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.1.9':
+    resolution: {integrity: sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@2.0.5':
+    resolution: {integrity: sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/type@4.0.5':
+    resolution: {integrity: sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@mantine/core@9.1.1':
+    resolution: {integrity: sha512-vClOZdCeZ4oLYuA/3jAOgKGQ6dXbF6ZkzpYz09Gied9nZpB7HcQeb3dcMh8UPBE4f+EM7KlYWk6dch7GoASeaA==}
+    peerDependencies:
+      '@mantine/hooks': 9.1.1
+      react: ^19.2.0
+      react-dom: ^19.2.0
+
+  '@mantine/hooks@9.1.1':
+    resolution: {integrity: sha512-tTJK73nGFyy1v214TLdvBq0be7QCoc6osfbXVuJgOH3YG85lWk9Mvvor6k+w6hC6HXSqKMqLKePyiGm83xGcMg==}
+    peerDependencies:
+      react: ^19.2.0
+
+  '@mswjs/interceptors@0.41.6':
+    resolution: {integrity: sha512-qmDvJIjcNsZ6tXWy2G9yuCgMPTTn35GMA3dPpSLm7QJVpbQzYdw0ALy1bKoivXnEM3U93/OrK+/M719b+fg84Q==}
+    engines: {node: '>=18'}
+
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/deferred-promise@3.0.0':
+    resolution: {integrity: sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@otplib/core@13.4.0':
+    resolution: {integrity: sha512-JqOGcvZQi2wIkEQo8f3/iAjstavpXy6gouIDMHygjNuH6Q0FjbHOiXMdcE94RwfgDNMABhzwUmvaPsxvgm9NYw==}
+
+  '@otplib/hotp@13.4.0':
+    resolution: {integrity: sha512-MJjE0x06mn2ptymz5qZmQveb+vWFuaIftqE0b5/TZZqUOK7l97cV8lRTmid5BpAQMwJDNLW6RnYxGeCRiNdekw==}
+
+  '@otplib/plugin-base32-scure@13.4.0':
+    resolution: {integrity: sha512-/t9YWJmMbB8bF5z8mXrBZc2FXBe8B/3hG5FhWr9K8cFwFhyxScbPysmZe8s1UTzSA6N+s8Uv8aIfCtVXPNjJWw==}
+
+  '@otplib/plugin-crypto-noble@13.4.0':
+    resolution: {integrity: sha512-KrvE4m7Zv+TT1944HzgqFJWJpKb6AyoxDbvhPStmBqdMlv5Gekb80d66cuFRL08kkPgJ5gXUSb5SFpYeB+bACg==}
+
+  '@otplib/totp@13.4.0':
+    resolution: {integrity: sha512-dK+vl0f0ekzf6mCENRI9AKS2NJUC7OjI3+X8e7QSnhQ2WM7I+i4PGpb3QxKi5hxjTtwVuoZwXR2CFtXdcRtNdQ==}
+
+  '@otplib/uri@13.4.0':
+    resolution: {integrity: sha512-x1ozBa5bPbdZCrrTL/HK21qchiK7jYElTu+0ft22abeEhiLYgH1+SIULvOcVk3CK8YwF4kdcidvkq4ciejucJA==}
+
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
+
+  '@scure/base@2.2.0':
+    resolution: {integrity: sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tabler/icons-react@3.41.1':
+    resolution: {integrity: sha512-kUgweE+DJtAlMZVIns1FTDdcbpRVnkK7ZpUOXmoxy3JAF0rSHj0TcP4VHF14+gMJGnF+psH2Zt26BLT6owetBA==}
+    peerDependencies:
+      react: '>= 16'
+
+  '@tabler/icons@3.41.1':
+    resolution: {integrity: sha512-OaRnVbRmH2nHtFeg+RmMJ/7m2oBIF9XCJAUD5gQnMrpK9f05ydj8MZrAf3NZQqOXyxGN1UBL0D5IKLLEUfr74Q==}
+
+  '@tanstack/query-core@5.100.6':
+    resolution: {integrity: sha512-Os2CPUr98to98RYm+D4qGqGkiffn7MGSyl2547a4MljVkHE30AMJRqTiyCqBfMwzAx/I91vCkAxp5tHSla6Twg==}
+
+  '@tanstack/react-query@5.100.6':
+    resolution: {integrity: sha512-uVSrps0PV16Cxmcn2rvL+dUhwTpTUtiRW347AEeYxMZXO2pZe9ja7E24PAMGoQ5u2g89DD8u4QhOviBk+RN8RA==}
+    peerDependencies:
+      react: ^18 || ^19
+
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/set-cookie-parser@2.4.10':
+    resolution: {integrity: sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==}
+
+  '@types/statuses@2.0.6':
+    resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
+
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-wrap-ansi@0.2.0:
+    resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
+
+  graphql@16.13.2:
+    resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
+  headers-polyfill@5.0.1:
+    resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
+
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@29.1.0:
+    resolution: {integrity: sha512-YNUc7fB9QuvSSQWfrH0xF+TyABkxUwx8sswgIDaCrw4Hol8BghdZDkITtZheRJeMtzWlnTfsM3bBBusRvpO1wg==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lru-cache@11.3.5:
+    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
+    engines: {node: 20 || >=22}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
+  msw@2.13.6:
+    resolution: {integrity: sha512-GAJbQy8Ra/Ydjt0Hb2MGT2qhzd83J3+QZMHdH85uW7r/XkKc846+Ma2PLif5hGvTm5Yqa+wkcstpim0WeLZU9g==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>= 4.8.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  otplib@13.4.0:
+    resolution: {integrity: sha512-RUcYcRMCgRWhUE/XabRppXpUwCwaWBNHe5iPXhdvP8wwDGpGpsIf/kxX/ec3zFsOaM1Oq8lEhUqDwk6W7DHkwg==}
+
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
+
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+    peerDependencies:
+      react: ^19.2.5
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-number-format@5.4.5:
+    resolution: {integrity: sha512-y8O2yHHj3w0aE9XO8d2BCcUOOdQTRSVq+WIuMlLVucAm5XNjJAy+BoOJiuQMldVYVOKTMyvVNfnbl2Oqp+YxGw==}
+    peerDependencies:
+      react: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+    engines: {node: '>=0.10.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  rettime@0.11.8:
+    resolution: {integrity: sha512-0fERGXktJTyJ+h8fBEiPxHPEFOu0h15JY7JtwrOVqR5K+vb99ho6IyOo7ekLS3h4sJCzIDy4VWKIbZUfe9njmg==}
+
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  set-cookie-parser@3.1.0:
+    resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tabbable@6.4.0:
+    resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
+
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.0.29:
+    resolution: {integrity: sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==}
+
+  tldts@7.0.29:
+    resolution: {integrity: sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==}
+    hasBin: true
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-fest@5.6.0:
+    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+    engines: {node: '>=20'}
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
+
+  until-async@3.0.2:
+    resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
+
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  vite-plugin-css-injected-by-js@3.5.2:
+    resolution: {integrity: sha512-2MpU/Y+SCZyWUB6ua3HbJCrgnF0KACAsmzOQt1UvRVJCGF6S8xdA3ZUhWcWdM9ivG4I5az8PnQmwwrkC2CAQrQ==}
+    peerDependencies:
+      vite: '>2.0.0-0'
+
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
+snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/runtime@7.29.2': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@exodus/bytes@1.15.0(@noble/hashes@2.2.0)':
+    optionalDependencies:
+      '@noble/hashes': 2.2.0
+
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@floating-ui/react@0.27.19(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      tabbable: 6.4.0
+
+  '@floating-ui/utils@0.2.11': {}
+
+  '@inquirer/ansi@2.0.5': {}
+
+  '@inquirer/confirm@6.0.12(@types/node@25.6.0)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@25.6.0)
+      '@inquirer/type': 4.0.5(@types/node@25.6.0)
+    optionalDependencies:
+      '@types/node': 25.6.0
+
+  '@inquirer/core@11.1.9(@types/node@25.6.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@25.6.0)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.0
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+
+  '@inquirer/figures@2.0.5': {}
+
+  '@inquirer/type@4.0.5(@types/node@25.6.0)':
+    optionalDependencies:
+      '@types/node': 25.6.0
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@mantine/core@9.1.1(@mantine/hooks@9.1.1(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@floating-ui/react': 0.27.19(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@mantine/hooks': 9.1.1(react@19.2.5)
+      clsx: 2.1.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-number-format: 5.4.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.5)
+      type-fest: 5.6.0
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@mantine/hooks@9.1.1(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@mswjs/interceptors@0.41.6':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@noble/hashes@2.2.0': {}
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/deferred-promise@3.0.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
+
+  '@otplib/core@13.4.0': {}
+
+  '@otplib/hotp@13.4.0':
+    dependencies:
+      '@otplib/core': 13.4.0
+      '@otplib/uri': 13.4.0
+
+  '@otplib/plugin-base32-scure@13.4.0':
+    dependencies:
+      '@otplib/core': 13.4.0
+      '@scure/base': 2.2.0
+
+  '@otplib/plugin-crypto-noble@13.4.0':
+    dependencies:
+      '@noble/hashes': 2.2.0
+      '@otplib/core': 13.4.0
+
+  '@otplib/totp@13.4.0':
+    dependencies:
+      '@otplib/core': 13.4.0
+      '@otplib/hotp': 13.4.0
+      '@otplib/uri': 13.4.0
+
+  '@otplib/uri@13.4.0':
+    dependencies:
+      '@otplib/core': 13.4.0
+
+  '@oxc-project/types@0.127.0': {}
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
+
+  '@scure/base@2.2.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tabler/icons-react@3.41.1(react@19.2.5)':
+    dependencies:
+      '@tabler/icons': 3.41.1
+      react: 19.2.5
+
+  '@tabler/icons@3.41.1': {}
+
+  '@tanstack/query-core@5.100.6': {}
+
+  '@tanstack/react-query@5.100.6(react@19.2.5)':
+    dependencies:
+      '@tanstack/query-core': 5.100.6
+      react: 19.2.5
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@25.6.0':
+    dependencies:
+      undici-types: 7.19.2
+
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
+  '@types/set-cookie-parser@2.4.10':
+    dependencies:
+      '@types/node': 25.6.0
+
+  '@types/statuses@2.0.6': {}
+
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
+      vite: 8.0.10(@types/node@25.6.0)
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
+  assertion-error@2.0.1: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
+  chai@6.2.2: {}
+
+  cli-width@4.1.0: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  clsx@2.1.1: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
+
+  csstype@3.2.3: {}
+
+  data-urls@7.0.0(@noble/hashes@2.2.0):
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  decimal.js@10.6.0: {}
+
+  dequal@2.0.3: {}
+
+  detect-libc@2.1.2: {}
+
+  detect-node-es@1.1.0: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
+  emoji-regex@8.0.0: {}
+
+  entities@8.0.0: {}
+
+  es-module-lexer@2.1.0: {}
+
+  escalade@3.2.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.0:
+    dependencies:
+      fast-string-width: 3.0.2
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.2:
+    optional: true
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-caller-file@2.0.5: {}
+
+  get-nonce@1.0.1: {}
+
+  graphql@16.13.2: {}
+
+  headers-polyfill@5.0.1:
+    dependencies:
+      '@types/set-cookie-parser': 2.4.10
+      set-cookie-parser: 3.1.0
+
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
+    dependencies:
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  indent-string@4.0.0: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-node-process@1.2.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
+
+  js-tokens@4.0.0: {}
+
+  jsdom@29.1.0(@noble/hashes@2.2.0):
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
+      css-tree: 3.2.1
+      data-urls: 7.0.0(@noble/hashes@2.2.0)
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.2.0)
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.5
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.25.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  lru-cache@11.3.5: {}
+
+  lz-string@1.5.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mdn-data@2.27.1: {}
+
+  min-indent@1.0.1: {}
+
+  msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3):
+    dependencies:
+      '@inquirer/confirm': 6.0.12(@types/node@25.6.0)
+      '@mswjs/interceptors': 0.41.6
+      '@open-draft/deferred-promise': 3.0.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.13.2
+      headers-polyfill: 5.0.1
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.11.8
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.1
+      type-fest: 5.6.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@types/node'
+
+  mute-stream@3.0.0: {}
+
+  nanoid@3.3.11: {}
+
+  obug@2.1.1: {}
+
+  otplib@13.4.0:
+    dependencies:
+      '@otplib/core': 13.4.0
+      '@otplib/hotp': 13.4.0
+      '@otplib/plugin-base32-scure': 13.4.0
+      '@otplib/plugin-crypto-noble': 13.4.0
+      '@otplib/totp': 13.4.0
+      '@otplib/uri': 13.4.0
+
+  outvariant@1.4.3: {}
+
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
+  path-to-regexp@6.3.0: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  postcss@8.5.12:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  punycode@2.3.1: {}
+
+  react-dom@19.2.5(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      scheduler: 0.27.0
+
+  react-is@17.0.2: {}
+
+  react-number-format@5.4.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.5)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.5)
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.5)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.5)
+      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.5
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react@19.2.5: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
+  require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
+
+  rettime@0.11.8: {}
+
+  rolldown@1.0.0-rc.17:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
+  scheduler@0.27.0: {}
+
+  set-cookie-parser@3.1.0: {}
+
+  siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
+
+  std-env@4.1.0: {}
+
+  strict-event-emitter@0.5.1: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
+  symbol-tree@3.2.4: {}
+
+  tabbable@6.4.0: {}
+
+  tagged-tag@1.0.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.1: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  tldts-core@7.0.29: {}
+
+  tldts@7.0.29:
+    dependencies:
+      tldts-core: 7.0.29
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.29
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
+
+  tslib@2.8.1: {}
+
+  type-fest@5.6.0:
+    dependencies:
+      tagged-tag: 1.0.0
+
+  typescript@6.0.3: {}
+
+  undici-types@7.19.2: {}
+
+  undici@7.25.0: {}
+
+  until-async@3.0.2: {}
+
+  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.5
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  vite-plugin-css-injected-by-js@3.5.2(vite@8.0.10(@types/node@25.6.0)):
+    dependencies:
+      vite: 8.0.10(@types/node@25.6.0)
+
+  vite@8.0.10(@types/node@25.6.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.12
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.6.0
+      fsevents: 2.3.3
+
+  vitest@4.1.5(@types/node@25.6.0)(jsdom@29.1.0(@noble/hashes@2.2.0))(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.10(@types/node@25.6.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+      jsdom: 29.1.0(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1(@noble/hashes@2.2.0):
+    dependencies:
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
+
+  y18n@5.0.8: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'packages/*'
+  - 'examples/hello-world/frontend'


### PR DESCRIPTION
## Summary

Wave 2 of the Host SDK epic — ships the foundation host frontend SDK as two packages on GitHub Packages, consumed end-to-end by `examples/hello-world` through pnpm `workspace:*` references.

- **`@brendan-bank/atrium-host-types`** — TypeScript declarations: `AtriumRegistry`, `UserContext`, `AdminUserRow`, `AtriumNotification`, `AtriumEvent`, every per-slot option-bag type, plus the `window.React` / `window.__ATRIUM_REGISTRY__` / `window.__ATRIUM_VERSION__` `declare global` block. Types-only.
- **`@brendan-bank/atrium-host-bundle-utils`** — runtime helpers + Vite preset + React hooks on three subpath exports (`.`, `./vite`, `./react`). `makeWrapperElement` carries the closure-tracked dual-tree mount with the issue #31 child-mismatch fix; `hostBundleConfig({ entry })` returns a complete library-mode Vite config; `useMe` / `usePerm` / `useRole` / `useUserContext` share one `/users/me/context` query subscription per host tree.
- **`examples/hello-world/frontend`** migrated: `main.tsx` 186 → 85 lines, `vite.config.ts` 55 → 10. `HelloWidget` and `HelloProfileItem` use the bundled `usePerm()`.

Closes #37, #38, #40.

### Packaging decisions (see `docs/adr/0002-host-frontend-sdk-packaging.md`)

- **In-tree pnpm workspace overlay** at the repo root listing `packages/*` and `examples/hello-world/frontend`. Atrium's main SPA at `frontend/` is intentionally NOT a workspace member (carries `frontend/.npmrc` with `ignore-workspace=true`) so the existing Dockerfile and dev compose stay untouched.
- **Versions track atrium**: `^0.14` of either package implies "compatible with atrium 0.14.x runtime image".
- **GitHub Packages** publish target. `@atrium` was rejected on public npm (existing `atrium` / `atrium-*` packages flagged confusable) and GitHub Packages enforces scope=owner, so the published name pattern is `@brendan-bank/atrium-<area>`.
- **Workflow**: `.github/workflows/publish-npm.yml` fires on the same `v*` tag as `publish-images.yml`, uses `GITHUB_TOKEN` with `packages: write` (now unlocked at the enterprise + repo level).

### Tests added

20 vitest cases under `packages/host-bundle-utils/test/`:

- `makeWrapperElement`: mount, idempotency on same el+child, child swap re-render, route-swap-on-shared-DOM-node guarding (#31), StrictMode double-invoke, `ref(null)` unmount.
- React hooks: msw-mocked `/users/me/context` happy path, `useUserContext` alias, 401 → null, single-subscription sharing across multiple `useMe` calls, `usePerm` deny-by-default during loading, `useRole` membership, `apiBase` override, custom `fetchUserContext` fetcher, `client` prop wrapping `<QueryClientProvider>`.

### Build infra

- `examples/hello-world/Dockerfile` stages the workspace skeleton (`pnpm-lock.yaml`, `pnpm-workspace.yaml`, `.npmrc`, every workspace member's `package.json`), runs `pnpm install --frozen-lockfile`, builds the SDK packages, then builds the bundle.
- `smoke-hello-build-bundle-dev` Makefile target runs `pnpm -r --filter './packages/*' build` before vite for the dev path.
- Makefile `cd frontend && pnpm install` lines pass `--ignore-workspace` so atrium's standalone SPA install path stays unchanged.

### Docs

- `docs/published-images.md` "Building the host bundle" rewritten to recommend the packages, with the new ~10-line snippets and the consumer-side `.npmrc` setup.
- `RELEASING.md` step 1.5 calls out the lockstep package version bump (`pnpm install --lockfile-only`); step 8 watches both publish workflows.
- Both package READMEs document the GitHub Packages install setup.

## Test plan

- [x] `pnpm typecheck` (packages + example) — clean
- [x] `pnpm test` (SDK packages) — 20/20
- [x] `make lint` (ruff + eslint) — clean (1 pre-existing eslint warning per RELEASING.md)
- [x] `make test-frontend` (atrium SPA vitest) — 49/49
- [x] `make test-backend` (pytest + testcontainers) — 200/200
- [x] `make smoke` (Playwright prod stack) — 9/9
- [x] `make smoke-hello` (Playwright hello-world stack) — 8/8 incl. the flaky tick test on first try