### PR TITLE
Wave 3: shared i18n keys + @brendan-bank/atrium-test-utils (#41, #45 part b)

### DIFF
--- a/docs/host-i18n.md
+++ b/docs/host-i18n.md
@@ -1,0 +1,137 @@
+# Host i18n
+
+Atrium translates a small set of structural strings (verbs, labels,
+confirmation patterns) and exposes them to host bundles through the
+shared `common.*` namespace. A host that calls
+`__atrium_t__('common.save')` gets the right string in every locale
+atrium ships, and any new locale atrium adds upstream (e.g. a future
+`pt-BR`) reaches every host on the next package update — no host
+release required.
+
+The helper is the i18n complement to the [stable theme
+tokens](theme.md): atrium picks a small, opinionated subset and
+commits to it; the host depends on the subset and contributes its
+own domain-specific strings on top.
+
+## Available since
+
+`__atrium_t__` is exported from
+`@brendan-bank/atrium-host-bundle-utils@>=0.14.0` (both the package
+root and the `/react` subpath). It reads
+`window.__atrium_i18n__`, populated by atrium 0.14.0 from the SPA's
+i18n module before the host bundle imports.
+
+On older atrium images the global is undefined and the helper falls
+back to returning the key. Hosts pinning `^0.14` in
+`backend/pyproject.toml` get the helper everywhere.
+
+## Usage
+
+```tsx
+import { __atrium_t__ } from '@brendan-bank/atrium-host-bundle-utils';
+
+<Button onClick={save}>{__atrium_t__('common.save')}</Button>
+<Text>{__atrium_t__('common.welcomeNamed', { name: me.full_name })}</Text>
+```
+
+Plain function — call it directly from a render. It is **not** a
+hook, so it does not subscribe to locale changes; a host page that
+needs to re-render on language switch should use react-i18next's
+`useTranslation` against atrium's instance, or call `__atrium_t__`
+inside a tree that already re-renders on the host's own locale state.
+
+The function returns a `string`. Resolution order:
+
+1. The active locale on `window.__atrium_i18n__`.
+2. English (atrium's `fallbackLng`).
+3. The literal key (so a typo is visible in the rendered output, not
+   silently empty).
+
+Interpolation uses `{{name}}` placeholders; pass values as the second
+arg.
+
+## The `common.*` keys
+
+Verbs:
+
+| Key                | English       |
+| ------------------ | ------------- |
+| `common.save`      | Save          |
+| `common.cancel`    | Cancel        |
+| `common.delete`    | Delete        |
+| `common.edit`      | Edit          |
+| `common.new`       | New           |
+| `common.close`     | Close         |
+| `common.confirm`   | Confirm       |
+| `common.back`      | Back          |
+
+Structural / status:
+
+| Key               | English                  |
+| ----------------- | ------------------------ |
+| `common.loading`  | Loading…                 |
+| `common.empty`    | Nothing here yet.        |
+| `common.error`    | Something went wrong.    |
+| `common.search`   | Search                   |
+| `common.required` | Required                 |
+| `common.language` | Language                 |
+
+Confirmation patterns:
+
+| Key                       | English                                          |
+| ------------------------- | ------------------------------------------------ |
+| `common.confirmDelete`    | Delete this item? This cannot be undone.         |
+| `common.confirmDiscard`   | Discard unsaved changes?                         |
+
+Translations ship for every locale atrium supports today: `en`,
+`nl`, `de`, `fr`. Add a locale upstream and it appears for every
+host on the next package update.
+
+## What does **not** belong here
+
+`common.*` is verbs and structural labels only. Anything
+domain-shaped goes in the host's own i18n bundle:
+
+- `common.user`, `common.role`, `common.invoice` — domain semantics
+  drift across hosts (a "role" in casa is not a "role" in atrium).
+- `common.welcome` outside of a generic shell context — host
+  homepages have their own voice.
+- Anything plural or count-aware — i18next plurals are locale-aware
+  and the host should own the domain noun the count attaches to.
+
+When in doubt: if removing the key from atrium would surprise a
+host integrator, it belongs here; otherwise it doesn't.
+
+## Adding a key
+
+1. Add the new key to every locale JSON under
+   `frontend/src/i18n/locales/{en,nl,de,fr}.json` in the `common`
+   section. Translations should ship together — landing an English
+   key without translations puts every non-English host on the
+   English fallback until a follow-up.
+2. Update the table in this file.
+3. Bump the docstring in
+   `packages/host-bundle-utils/src/i18n.ts` if the key requires
+   special interpolation rules; otherwise no code change is needed.
+
+The package version that exposes the key has to be `>=` the atrium
+version that ships the locale JSONs. We bump in lockstep — one
+release covers both.
+
+## Adding a locale
+
+Follow the same pattern as adding the four locales atrium ships
+today:
+
+1. Drop a `frontend/src/i18n/locales/<code>.json` with every key the
+   existing locales carry. The `common.*` namespace is the
+   minimum; the rest of the chrome strings are the bulk of the file.
+2. Wire the locale into `frontend/src/i18n/index.ts` — add it to the
+   `SUPPORTED` tuple and to the `resources` block.
+3. Bump `backend/pyproject.toml`, publish a new atrium image, and
+   the new locale reaches every host on the next image pull.
+
+The `i18n.enabled_locales` admin control in
+`/admin/app-config` filters which locales the SPA exposes in the
+language picker — atrium can ship more locales than a given
+deployment chooses to expose.

--- a/docs/published-images.md
+++ b/docs/published-images.md
@@ -21,7 +21,9 @@ SSE wire format changed, when something was soft-deprecated), see
 of the Mantine theme tokens host bundles inherit (which `--mantine-*`
 custom properties atrium commits to keeping stable, which are
 override-friendly through `BrandConfig`, and which are internal), see
-[`theme.md`](theme.md).
+[`theme.md`](theme.md). For the shared `common.*` i18n key set host
+bundles can read via `__atrium_t__`, see
+[`host-i18n.md`](host-i18n.md).
 
 ---
 
@@ -389,7 +391,7 @@ piggy-back on atrium's via an import map. The recommended path is the
 [`@brendan-bank/atrium-host-bundle-utils`](https://github.com/Brendan-Bank/atrium/tree/master/packages/host-bundle-utils)
 — simpler, no atrium-side changes required, ~100 KB gzipped.
 
-Two atrium-published packages remove the boilerplate:
+Three atrium-published packages remove the boilerplate:
 
 - `@brendan-bank/atrium-host-types` — TypeScript declarations for
   `AtriumRegistry`, `UserContext`, `AtriumNotification`, `AtriumEvent`,
@@ -398,11 +400,21 @@ Two atrium-published packages remove the boilerplate:
   Types-only; bundlers strip it from the production output.
 - `@brendan-bank/atrium-host-bundle-utils` — runtime helpers
   (`makeWrapperElement`, `mountInside`), a Vite preset
-  (`hostBundleConfig`), and React hooks (`useMe`, `usePerm`,
-  `useRole`, `<AtriumProvider>`) on three subpath exports (`.`,
-  `./vite`, `./react`). Re-exports the types from
-  `@brendan-bank/atrium-host-types` so a host adding only one dep
-  still gets the declarations.
+  (`hostBundleConfig`), the shared-i18n helper
+  (`__atrium_t__`, see [`host-i18n.md`](host-i18n.md)), and React
+  hooks (`useMe`, `usePerm`, `useRole`, `<AtriumProvider>`) on three
+  subpath exports (`.`, `./vite`, `./react`). Re-exports the types
+  from `@brendan-bank/atrium-host-types` so a host adding only one
+  dep still gets the declarations.
+- `@brendan-bank/atrium-test-utils` — vitest helpers for unit-testing
+  host bundles. `mockAtriumRegistry({ me })` installs a recording
+  fake on `window`, `renderWithAtrium(ui)` wraps
+  `@testing-library/react`'s `render` with a fresh QueryClient +
+  AtriumProvider, and `fireAtriumEvent(kind, payload)` dispatches
+  synthetic SSE events to handlers registered via the fake. Replaces
+  the hand-rolled `vi.fn()` mocks every host used to write — see the
+  package's [`README`](https://github.com/Brendan-Bank/atrium/tree/master/packages/test-utils)
+  for the worked example.
 
 Both packages are published on **GitHub Packages** (the same registry
 family as the atrium GHCR image) and versioned in lockstep with the

--- a/examples/hello-world/frontend/package.json
+++ b/examples/hello-world/frontend/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "build": "vite build",
     "build:watch": "vite build --watch",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@brendan-bank/atrium-host-bundle-utils": "workspace:*",
@@ -20,12 +22,17 @@
     "react-dom": "^19.2.5"
   },
   "devDependencies": {
+    "@brendan-bank/atrium-test-utils": "workspace:*",
     "@playwright/test": "^1.59.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "jsdom": "^29.0.2",
     "otplib": "^13.4.0",
     "typescript": "^6.0.3",
     "vite": "^8.0.10",
-    "vite-plugin-css-injected-by-js": "^3.5.2"
+    "vite-plugin-css-injected-by-js": "^3.5.2",
+    "vitest": "^4.1.5"
   }
 }

--- a/examples/hello-world/frontend/src/HelloWidget.tsx
+++ b/examples/hello-world/frontend/src/HelloWidget.tsx
@@ -33,7 +33,11 @@ import {
   useQueryClient,
   QueryClientProvider,
 } from '@tanstack/react-query';
-import { AtriumProvider, usePerm } from '@brendan-bank/atrium-host-bundle-utils/react';
+import {
+  __atrium_t__,
+  AtriumProvider,
+  usePerm,
+} from '@brendan-bank/atrium-host-bundle-utils/react';
 
 import {
   getHelloState,
@@ -68,10 +72,17 @@ function HelloWidgetInner() {
             {data?.enabled ? 'enabled' : 'disabled'}
           </Badge>
         </Group>
-        {isLoading && <Loader size="xs" />}
+        {isLoading && (
+          <Group gap="xs">
+            <Loader size="xs" />
+            <Text size="sm" c="dimmed">
+              {__atrium_t__('common.loading')}
+            </Text>
+          </Group>
+        )}
         {error && (
           <Text c="red" size="sm">
-            Failed to load: {(error as Error).message}
+            {__atrium_t__('common.error')}: {(error as Error).message}
           </Text>
         )}
         {data && (

--- a/examples/hello-world/frontend/src/test/HelloWidget.test.tsx
+++ b/examples/hello-world/frontend/src/test/HelloWidget.test.tsx
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+/**
+ * Worked example of testing a host bundle component with
+ * `@brendan-bank/atrium-test-utils`.
+ *
+ * The widget calls `usePerm()` to gate the toggle on the
+ * `hello.toggle` permission and reads `__atrium_t__('common.loading')`
+ * for the spinner caption. Both come from atrium's host SDK; the
+ * test installs the fakes once via `mockAtriumRegistry` and asserts
+ * the gating + the translation without standing up the SPA.
+ *
+ * Note on the wrapping pattern: HelloWidget self-wraps in its own
+ * `<MantineProvider><QueryClientProvider><AtriumProvider>` stack — the
+ * canonical host-bundle shape, since the bundle has no enclosing
+ * providers in production. The widget's inner `<AtriumProvider>` uses
+ * the default fetch-based fetcher, so the test stubs
+ * `/users/me/context` directly. The configured `me` from
+ * `mockAtriumRegistry` reaches both the outer ``renderWithAtrium``
+ * provider and (via the same fetch stub) the inner one, exactly the
+ * way casa tests will end up structured.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, screen, waitFor } from '@testing-library/react';
+
+import {
+  mockAtriumRegistry,
+  renderWithAtrium,
+  type MockAtriumHandles,
+  type UserContext,
+} from '@brendan-bank/atrium-test-utils';
+
+import { HelloWidget } from '../HelloWidget';
+import { queryClient } from '../queryClient';
+
+const ALICE_OWNER: UserContext = {
+  id: 1,
+  email: 'alice@example.com',
+  full_name: 'Alice',
+  is_active: true,
+  roles: ['admin'],
+  permissions: ['hello.toggle'],
+  impersonating_from: null,
+};
+
+const BOB_VIEWER: UserContext = {
+  id: 2,
+  email: 'bob@example.com',
+  full_name: 'Bob',
+  is_active: true,
+  roles: [],
+  permissions: [],
+  impersonating_from: null,
+};
+
+let handles: MockAtriumHandles;
+let currentMe: UserContext | null = null;
+
+function stubFetch() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string) => {
+      if (url.endsWith('/users/me/context')) {
+        if (!currentMe) return new Response(null, { status: 401 });
+        return new Response(JSON.stringify(currentMe), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/hello/state')) {
+        return new Response(
+          JSON.stringify({
+            message: 'Hello, atrium!',
+            counter: 3,
+            enabled: false,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      return new Response('{}', { status: 200 });
+    }),
+  );
+}
+
+beforeEach(() => {
+  stubFetch();
+});
+
+afterEach(() => {
+  cleanup();
+  handles?.cleanup();
+  // The widget self-wraps in a module-singleton QueryClient (the
+  // canonical host-bundle pattern), so clear it between tests
+  // otherwise the previous test's `me` leaks via the cache.
+  queryClient.clear();
+  currentMe = null;
+  vi.unstubAllGlobals();
+});
+
+describe('HelloWidget', () => {
+  test('users with hello.toggle can flip the switch', async () => {
+    currentMe = ALICE_OWNER;
+    handles = mockAtriumRegistry({ me: ALICE_OWNER });
+    renderWithAtrium(<HelloWidget />);
+    const input = (await screen.findByTestId('hello-toggle')) as HTMLInputElement;
+    await waitFor(() => expect(input).not.toBeDisabled());
+    expect(screen.getByText('Increment counter')).toBeInTheDocument();
+  });
+
+  test('users without hello.toggle see the disabled label', async () => {
+    currentMe = BOB_VIEWER;
+    handles = mockAtriumRegistry({ me: BOB_VIEWER });
+    renderWithAtrium(<HelloWidget />);
+    const input = (await screen.findByTestId('hello-toggle')) as HTMLInputElement;
+    await waitFor(() =>
+      expect(screen.getByText(/admin only/)).toBeInTheDocument(),
+    );
+    expect(input).toBeDisabled();
+  });
+});

--- a/examples/hello-world/frontend/src/test/setup.ts
+++ b/examples/hello-world/frontend/src/test/setup.ts
@@ -1,0 +1,21 @@
+import '@testing-library/jest-dom/vitest';
+
+// jsdom doesn't ship window.matchMedia; Mantine's MantineProvider
+// reads it on mount to decide the initial colour scheme. Stub a
+// "no preference" response so component tests can render the host
+// widgets without a runtime error.
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}

--- a/examples/hello-world/frontend/vitest.config.ts
+++ b/examples/hello-world/frontend/vitest.config.ts
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+import { defineConfig } from 'vitest/config';
+
+// Vite's built-in esbuild loader handles tsx via the project's
+// tsconfig (`jsx: react-jsx`). No `@vitejs/plugin-react` needed for
+// unit tests — the package isn't listed as a peer dep so we'd be
+// adding one for tests alone, which the host-bundle pattern keeps
+// out by design.
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: false,
+    setupFiles: ['./src/test/setup.ts'],
+    include: ['src/**/*.test.{ts,tsx}'],
+  },
+});

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -39,6 +39,23 @@ i18n
     },
   });
 
+// Expose the i18next instance on window so host bundles can resolve
+// shared keys (e.g. ``__atrium_t__('common.save')`` from
+// ``@brendan-bank/atrium-host-bundle-utils``) against atrium's bundled
+// resources + admin overrides + host overlays. The host bundle reads
+// the active locale dynamically — a user's language switch reaches the
+// next ``t()`` call without re-registering. Available since atrium
+// 0.14.0; older images leave the global undefined and the helper falls
+// back to returning the key.
+declare global {
+  interface Window {
+    __atrium_i18n__?: typeof i18n;
+  }
+}
+if (typeof window !== 'undefined') {
+  window.__atrium_i18n__ = i18n;
+}
+
 interface I18nOverrides {
   enabled_locales?: string[];
   overrides?: Record<string, Record<string, string>>;

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -19,9 +19,18 @@
     "cancel": "Abbrechen",
     "delete": "Löschen",
     "edit": "Bearbeiten",
+    "new": "Neu",
+    "close": "Schließen",
+    "confirm": "Bestätigen",
+    "back": "Zurück",
     "language": "Sprache",
     "loading": "Wird geladen…",
-    "required": "Pflichtfeld"
+    "empty": "Hier ist noch nichts.",
+    "error": "Etwas ist schiefgelaufen.",
+    "search": "Suchen",
+    "required": "Pflichtfeld",
+    "confirmDelete": "Diesen Eintrag löschen? Das kann nicht rückgängig gemacht werden.",
+    "confirmDiscard": "Nicht gespeicherte Änderungen verwerfen?"
   },
   "password": {
     "tooShort": "Das Passwort ist zu kurz.",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -19,9 +19,18 @@
     "cancel": "Cancel",
     "delete": "Delete",
     "edit": "Edit",
+    "new": "New",
+    "close": "Close",
+    "confirm": "Confirm",
+    "back": "Back",
     "language": "Language",
     "loading": "Loading…",
-    "required": "Required"
+    "empty": "Nothing here yet.",
+    "error": "Something went wrong.",
+    "search": "Search",
+    "required": "Required",
+    "confirmDelete": "Delete this item? This cannot be undone.",
+    "confirmDiscard": "Discard unsaved changes?"
   },
   "password": {
     "tooShort": "Password is too short.",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -19,9 +19,18 @@
     "cancel": "Annuler",
     "delete": "Supprimer",
     "edit": "Modifier",
+    "new": "Nouveau",
+    "close": "Fermer",
+    "confirm": "Confirmer",
+    "back": "Retour",
     "language": "Langue",
     "loading": "Chargement…",
-    "required": "Obligatoire"
+    "empty": "Rien ici pour le moment.",
+    "error": "Une erreur est survenue.",
+    "search": "Rechercher",
+    "required": "Obligatoire",
+    "confirmDelete": "Supprimer cet élément ? Cette action est irréversible.",
+    "confirmDiscard": "Abandonner les modifications non enregistrées ?"
   },
   "password": {
     "tooShort": "Le mot de passe est trop court.",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -19,9 +19,18 @@
     "cancel": "Annuleren",
     "delete": "Verwijderen",
     "edit": "Bewerken",
+    "new": "Nieuw",
+    "close": "Sluiten",
+    "confirm": "Bevestigen",
+    "back": "Terug",
     "language": "Taal",
     "loading": "Laden…",
-    "required": "Verplicht"
+    "empty": "Hier staat nog niets.",
+    "error": "Er is iets misgegaan.",
+    "search": "Zoeken",
+    "required": "Verplicht",
+    "confirmDelete": "Dit item verwijderen? Dit kan niet ongedaan worden gemaakt.",
+    "confirmDiscard": "Niet-opgeslagen wijzigingen verwerpen?"
   },
   "password": {
     "tooShort": "Wachtwoord is te kort.",

--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "atrium-host-sdk-workspace",
   "version": "0.0.0",
   "private": true,
-  "description": "Workspace overlay for the host-facing npm packages (@brendan-bank/atrium-host-types, @brendan-bank/atrium-host-bundle-utils) and the in-tree examples that consume them. Atrium's own SPA lives under frontend/ as a standalone package.",
+  "description": "Workspace overlay for the host-facing npm packages (@brendan-bank/atrium-host-types, @brendan-bank/atrium-host-bundle-utils, @brendan-bank/atrium-test-utils) and the in-tree examples that consume them. Atrium's own SPA lives under frontend/ as a standalone package.",
   "scripts": {
     "build": "pnpm -r --filter './packages/*' build",
     "typecheck": "pnpm -r --filter './packages/*' --filter './examples/*/frontend' typecheck",
-    "test": "pnpm -r --filter './packages/*' test"
+    "test": "pnpm -r --filter './packages/*' --filter './examples/*/frontend' test"
   },
   "packageManager": "pnpm@10.33.1"
 }

--- a/packages/host-bundle-utils/src/i18n.ts
+++ b/packages/host-bundle-utils/src/i18n.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+/**
+ * Shared-i18n helper for host bundles.
+ *
+ * Atrium ships a small ``common.*`` key set (verbs, structural labels,
+ * confirmation patterns) translated to every locale atrium supports.
+ * A host bundle that calls ``__atrium_t__('common.save')`` gets the
+ * right string in nl / de / fr automatically, and any new locale
+ * atrium adds upstream (e.g. a future ``pt-BR``) reaches every host
+ * on the next package update — no host release required.
+ *
+ * Resolution path:
+ *
+ *   1. ``window.__atrium_i18n__`` — atrium's i18next instance,
+ *      published since atrium 0.14.0 from the SPA's i18n module. Reads
+ *      the active locale dynamically, so a user switching language in
+ *      the profile page reaches the next ``__atrium_t__`` call without
+ *      the host re-rendering.
+ *   2. Fallback to English bundled in i18next via ``fallbackLng``. A
+ *      key without a translation in the active locale resolves to the
+ *      English string instead of the literal key.
+ *   3. Final fallback: the literal key itself. This kicks in when the
+ *      atrium image predates 0.14.0 (no ``window.__atrium_i18n__``)
+ *      or when the key is unknown to atrium. Returning the key (not
+ *      empty string) makes the missing-key visible at the call site so
+ *      a typo is debuggable.
+ *
+ * The helper is a plain function, not a hook. Atrium's i18next
+ * instance fires its own change events on locale switch; host
+ * components that need to re-render on switch should consume
+ * ``react-i18next``'s ``useTranslation`` against the shared instance,
+ * or call ``__atrium_t__`` inside a component subscribed to atrium's
+ * locale via the host's own state. The function is enough for the
+ * static-render case which covers the bulk of host UI.
+ */
+
+interface MinimalI18n {
+  /** The active locale code (e.g. ``'nl'``). */
+  language?: string;
+  /** i18next's ``t`` — `key` is a flat dot-path, ``vars`` are the
+   *  interpolation values. ``defaultValue`` makes the key the safe
+   *  fallback when the lookup misses. */
+  t: (
+    key: string,
+    options?: Record<string, unknown> & { defaultValue?: string },
+  ) => string;
+}
+
+/** Translate a shared atrium key against the running atrium image's
+ *  i18next instance.
+ *
+ *  ```ts
+ *  import { __atrium_t__ } from '@brendan-bank/atrium-host-bundle-utils';
+ *
+ *  <Button>{__atrium_t__('common.save')}</Button>
+ *  <Text>{__atrium_t__('common.welcome', { name: me.full_name })}</Text>
+ *  ```
+ *
+ *  - Missing atrium image (pre-0.14): returns the literal key.
+ *  - Missing key: returns the literal key (not empty string), so a
+ *    typo is visible in the rendered output.
+ *  - Missing translation in the active locale: falls back to English
+ *    via i18next's ``fallbackLng``. */
+export function __atrium_t__(
+  key: string,
+  vars?: Record<string, string | number>,
+): string {
+  if (typeof window === 'undefined') return key;
+  const i18n = (window as unknown as { __atrium_i18n__?: MinimalI18n })
+    .__atrium_i18n__;
+  if (!i18n || typeof i18n.t !== 'function') return key;
+  // ``defaultValue: key`` is the explicit "missing key → key" rule.
+  // i18next's default behaviour already returns the key when the
+  // lookup misses, but spelling it out makes the intent unambiguous
+  // and survives any future i18next config change in atrium.
+  const out = i18n.t(key, { ...vars, defaultValue: key });
+  return typeof out === 'string' ? out : key;
+}

--- a/packages/host-bundle-utils/src/index.ts
+++ b/packages/host-bundle-utils/src/index.ts
@@ -27,6 +27,8 @@
 import type { ReactElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
+export { __atrium_t__ } from './i18n';
+
 export type {
   AdminUserRow,
   AdminTab,

--- a/packages/host-bundle-utils/src/react/index.ts
+++ b/packages/host-bundle-utils/src/react/index.ts
@@ -36,6 +36,7 @@ import {
 import type { UserContext } from '@brendan-bank/atrium-host-types';
 
 export type { UserContext } from '@brendan-bank/atrium-host-types';
+export { __atrium_t__ } from '../i18n';
 
 interface AtriumContextValue {
   apiBase: string;

--- a/packages/host-bundle-utils/test/i18n.test.ts
+++ b/packages/host-bundle-utils/test/i18n.test.ts
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+import { afterEach, describe, expect, test } from 'vitest';
+
+import { __atrium_t__ } from '../src/i18n';
+
+interface MinimalI18n {
+  language?: string;
+  t: (
+    key: string,
+    options?: Record<string, unknown> & { defaultValue?: string },
+  ) => string;
+}
+
+function installFakeI18n(
+  bundles: Record<string, Record<string, string>>,
+  language: string,
+): MinimalI18n {
+  const fake: MinimalI18n = {
+    language,
+    t(key, options) {
+      const langs = [language, 'en'];
+      for (const l of langs) {
+        const hit = bundles[l]?.[key];
+        if (typeof hit === 'string') {
+          return interpolate(hit, options);
+        }
+      }
+      const def = options?.defaultValue;
+      return typeof def === 'string' ? def : key;
+    },
+  };
+  (window as unknown as { __atrium_i18n__?: MinimalI18n }).__atrium_i18n__ =
+    fake;
+  return fake;
+}
+
+function interpolate(
+  s: string,
+  vars?: Record<string, unknown> & { defaultValue?: string },
+): string {
+  if (!vars) return s;
+  return s.replace(/\{\{(\w+)\}\}/g, (_, key) => {
+    if (key === 'defaultValue') return _;
+    const v = vars[key];
+    return v == null ? _ : String(v);
+  });
+}
+
+afterEach(() => {
+  delete (window as unknown as { __atrium_i18n__?: unknown }).__atrium_i18n__;
+});
+
+describe('__atrium_t__', () => {
+  test('resolves a key against the active locale', () => {
+    installFakeI18n(
+      {
+        en: { 'common.save': 'Save' },
+        nl: { 'common.save': 'Opslaan' },
+      },
+      'nl',
+    );
+    expect(__atrium_t__('common.save')).toBe('Opslaan');
+  });
+
+  test('falls back to English when the active locale lacks the key', () => {
+    installFakeI18n(
+      {
+        en: { 'common.confirmDelete': 'Delete this item?' },
+        nl: {},
+      },
+      'nl',
+    );
+    expect(__atrium_t__('common.confirmDelete')).toBe('Delete this item?');
+  });
+
+  test('returns the literal key when neither locale has it', () => {
+    installFakeI18n({ en: {}, nl: {} }, 'nl');
+    expect(__atrium_t__('common.unknownKey')).toBe('common.unknownKey');
+  });
+
+  test('returns the literal key when atrium did not expose i18next', () => {
+    // The pre-0.14 fallback path — host bundle running against an older
+    // atrium image that never installed window.__atrium_i18n__.
+    expect(__atrium_t__('common.save')).toBe('common.save');
+  });
+
+  test('interpolates vars into the resolved string', () => {
+    installFakeI18n(
+      {
+        en: { 'common.welcomeNamed': 'Welcome, {{name}}' },
+      },
+      'en',
+    );
+    expect(__atrium_t__('common.welcomeNamed', { name: 'Alice' })).toBe(
+      'Welcome, Alice',
+    );
+  });
+
+  test('coerces numeric vars to strings via the provider', () => {
+    installFakeI18n(
+      {
+        en: { 'common.itemsLeft': '{{count}} items left' },
+      },
+      'en',
+    );
+    expect(__atrium_t__('common.itemsLeft', { count: 3 })).toBe(
+      '3 items left',
+    );
+  });
+});

--- a/packages/test-utils/README.md
+++ b/packages/test-utils/README.md
@@ -1,0 +1,153 @@
+# `@brendan-bank/atrium-test-utils`
+
+Vitest helpers for unit-testing [atrium](https://github.com/Brendan-Bank/atrium)
+host bundles. Replaces hand-rolled mocks of `window.__ATRIUM_REGISTRY__`
++ `window.React` + `useMe()` so a host can render permission-gated
+components and fire synthetic SSE events without spinning up the SPA.
+
+## Why
+
+Before this package, casa-style host tests had to wire mocks like:
+
+```ts
+beforeEach(() => {
+  (window as any).__ATRIUM_REGISTRY__ = {
+    registerHomeWidget: vi.fn(),
+    /* …seven more vi.fn()s… */
+    subscribeEvent: vi.fn(),
+  };
+  (window as any).React = require('react');
+});
+```
+
+…and stub `useMe`'s underlying fetch separately. The seam is the same
+in every host, so most teams skipped the unit tests and relied on
+Playwright. This package gives them back.
+
+## Installation
+
+```
+pnpm add -D @brendan-bank/atrium-test-utils
+```
+
+The package is published on **GitHub Packages**, same scope as the
+other atrium SDK packages — see the host-bundle-utils
+[`README`](../host-bundle-utils/README.md) for the `.npmrc` setup.
+
+`vitest`, `@testing-library/react`, `react`, `react-dom`, and
+`@tanstack/react-query` are peer deps — install them once in your
+host's `frontend/package.json`; this package will not bundle a
+second copy.
+
+## Usage
+
+```tsx
+import {
+  fireAtriumEvent,
+  mockAtriumRegistry,
+  renderWithAtrium,
+  type MockAtriumHandles,
+  type UserContext,
+} from '@brendan-bank/atrium-test-utils';
+
+const ALICE: UserContext = {
+  id: 1, email: 'alice@example.com', full_name: 'Alice',
+  is_active: true,
+  roles: ['owner'],
+  permissions: ['commission.view.all'],
+  impersonating_from: null,
+};
+
+let handles: MockAtriumHandles;
+
+beforeEach(() => {
+  handles = mockAtriumRegistry({ me: ALICE });
+});
+
+afterEach(() => {
+  handles.cleanup();
+});
+
+test('owners see the per-agent picker, not the self view', () => {
+  const { getByLabelText } = renderWithAtrium(<CommissionsPage />);
+  expect(getByLabelText('Agent')).toBeInTheDocument();
+});
+
+test('the host bundle registers a home widget on import', async () => {
+  await import('../src/main');
+  expect(handles.homeWidgets).toHaveLength(1);
+  expect(handles.homeWidgets[0].key).toBe('commission-card');
+});
+
+test('refetches bookings on booking.created', async () => {
+  renderWithAtrium(<BookingsPage />);
+  fireAtriumEvent('booking.created', { booking_id: 42 });
+  // …assert refetch fired
+});
+```
+
+## API
+
+### `mockAtriumRegistry(options?)`
+
+Installs a recording fake on `window.__ATRIUM_REGISTRY__`, exposes
+React via `window.React`, and stubs `window.__atrium_i18n__` with
+the bundled `common.*` keys. Returns handles:
+
+| Field                  | Type                          | Description                                           |
+| ---------------------- | ----------------------------- | ----------------------------------------------------- |
+| `registry`             | `AtriumRegistry`              | The fake (also at `window.__ATRIUM_REGISTRY__`).      |
+| `homeWidgets`          | `HomeWidget[]`                | Recorded `registerHomeWidget` calls in order.         |
+| `routes`               | `RouteEntry[]`                | Recorded `registerRoute` calls.                       |
+| `navItems`             | `NavItem[]`                   | Recorded `registerNavItem` calls.                     |
+| `adminTabs`            | `AdminTab[]`                  | Recorded `registerAdminTab` calls.                    |
+| `profileItems`         | `ProfileItem[]`               | Recorded `registerProfileItem` calls.                 |
+| `notificationKinds`    | `NotificationKindRenderer[]`  | Recorded `registerNotificationKind` calls.            |
+| `localeOverlays`       | `LocaleOverlay[]`             | Recorded `registerLocale` calls.                      |
+| `reset()`              | `() => void`                  | Drop registrations + subscribers, keep window mocks.  |
+| `cleanup()`            | `() => void`                  | Restore pre-mock window state. Call in `afterEach`.   |
+
+Options:
+
+| Option              | Description                                                                  |
+| ------------------- | ---------------------------------------------------------------------------- |
+| `me`                | What `useMe()` resolves to. Pass `null` for signed-out. Default `null`.      |
+| `i18n.resources`    | Locale → flat dot-path → string. Default: bundled English `common.*`.        |
+| `i18n.language`     | Active locale. Default `'en'`.                                               |
+
+### `renderWithAtrium(ui, options?)`
+
+`@testing-library/react`'s `render` pre-wired with a fresh
+`QueryClient` and `<AtriumProvider>` pointed at the configured `me`.
+Returns the standard `RenderResult` so existing assertions
+(`getByRole`, `rerender`, `unmount`) work unchanged.
+
+Options extend the standard `RenderOptions` with:
+
+| Option        | Description                                                              |
+| ------------- | ------------------------------------------------------------------------ |
+| `me`          | Override `me` for this render. Falls back to the registry default.       |
+| `queryClient` | Share a client across renders so cache assertions survive remounts.      |
+| `wrap`        | Additional wrapper component (e.g. `MantineProvider`, `RouterProvider`). |
+
+### `fireAtriumEvent(kind, payload)`
+
+Dispatches a synthetic SSE-style event to every handler the host
+registered via the fake registry's `subscribeEvent`. No-op when
+called outside a `mockAtriumRegistry` scope, so a forgotten setup
+shows as an empty assertion rather than a crash.
+
+## Versioning
+
+Tracks `@brendan-bank/atrium-host-bundle-utils`'s public API. When a
+new registry slot lands in host-bundle-utils, the matching mock
+shows up here in the next minor.
+
+## See also
+
+- [`@brendan-bank/atrium-host-bundle-utils`](../host-bundle-utils/) — the
+  runtime helpers + hooks this package mocks.
+- [`@brendan-bank/atrium-host-types`](../host-types/) — typed registry
+  shapes.
+- [`docs/published-images.md`](../../docs/published-images.md) — the
+  full host-extension contract.

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@brendan-bank/atrium-test-utils",
+  "version": "0.14.0",
+  "description": "Vitest helpers for unit-testing atrium host bundles. Installs a fake __ATRIUM_REGISTRY__ + window.React, wires a working QueryClient, and exposes a synthetic event bus that mirrors atrium's subscribeEvent semantics — so a host can render permission-gated components and fire SSE events from a test without standing up the SPA.",
+  "license": "BSD-2-Clause",
+  "type": "module",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@brendan-bank/atrium-host-bundle-utils": "workspace:*",
+    "@brendan-bank/atrium-host-types": "workspace:*"
+  },
+  "peerDependencies": {
+    "@tanstack/react-query": "^5.0.0",
+    "@testing-library/react": "^16.0.0",
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0",
+    "vitest": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+  },
+  "devDependencies": {
+    "@tanstack/react-query": "^5.100.5",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/node": "^25.6.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "jsdom": "^29.0.2",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://npm.pkg.github.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Brendan-Bank/atrium.git",
+    "directory": "packages/test-utils"
+  }
+}

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,0 +1,427 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+/**
+ * Vitest helpers for unit-testing atrium host bundles.
+ *
+ * Atrium loads a host bundle by setting ``window.__ATRIUM_REGISTRY__``
+ * and ``window.React`` and then ``await import()``-ing the bundle.
+ * Hosts that test components touching that surface have to fake the
+ * registry by hand — most casa tests today reach for Playwright
+ * instead, which is much slower and more brittle.
+ *
+ * This package installs the fakes once per test:
+ *
+ *  - ``mockAtriumRegistry({ me })`` — installs a recording fake on
+ *    ``window.__ATRIUM_REGISTRY__``, mirrors atrium's
+ *    ``subscribeEvent`` semantics with an in-memory bus, exposes
+ *    React via ``window.React`` (re-using the host's copy — atrium
+ *    uses a single shared React in production), and stubs
+ *    ``window.__atrium_i18n__`` so ``__atrium_t__`` calls resolve
+ *    against an English fallback bundle. Returns handles so the test
+ *    can assert against what the import-time side-effects registered.
+ *  - ``renderWithAtrium(ui)`` — wraps ``@testing-library/react``'s
+ *    ``render`` with a fresh ``QueryClient`` + ``<AtriumProvider>``
+ *    pre-wired to return the configured ``me``. Returns the standard
+ *    ``RenderResult`` so existing assertions work unchanged.
+ *  - ``fireAtriumEvent(kind, payload)`` — dispatches a synthetic
+ *    event the same way atrium's SSE stream would. Subscribers
+ *    registered via the fake registry's ``subscribeEvent`` see it.
+ *
+ * Peer deps only — vitest, @testing-library/react, react,
+ * @tanstack/react-query are the host's, not bundled. The package
+ * provides the seam, not the framework.
+ */
+import {
+  createElement,
+  type ComponentType,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+import * as ReactNS from 'react';
+import {
+  QueryClient,
+  QueryClientProvider,
+} from '@tanstack/react-query';
+import { render, type RenderOptions, type RenderResult } from '@testing-library/react';
+
+import {
+  AtriumProvider,
+  type UserContext,
+} from '@brendan-bank/atrium-host-bundle-utils/react';
+import type {
+  AdminTab,
+  AtriumEvent,
+  AtriumEventHandler,
+  AtriumRegistry,
+  HomeWidget,
+  LocaleOverlay,
+  NavItem,
+  NotificationKindRenderer,
+  ProfileItem,
+  RouteEntry,
+} from '@brendan-bank/atrium-host-types';
+
+export type {
+  AdminTab,
+  AtriumEvent,
+  AtriumEventHandler,
+  AtriumRegistry,
+  HomeWidget,
+  LocaleOverlay,
+  NavItem,
+  NotificationKindRenderer,
+  ProfileItem,
+  RouteEntry,
+  UserContext,
+};
+
+// ---------------------------------------------------------------------------
+// Fake i18n — minimum surface __atrium_t__ reads via window.__atrium_i18n__
+// ---------------------------------------------------------------------------
+
+interface MinimalI18n {
+  language?: string;
+  t: (
+    key: string,
+    options?: Record<string, unknown> & { defaultValue?: string },
+  ) => string;
+}
+
+function makeFakeI18n(
+  resources: Record<string, Record<string, string>>,
+  language: string,
+): MinimalI18n {
+  return {
+    language,
+    t(key, options) {
+      const langs = [language, 'en'];
+      for (const l of langs) {
+        const hit = resources[l]?.[key];
+        if (typeof hit === 'string') {
+          return interpolate(hit, options);
+        }
+      }
+      const def = options?.defaultValue;
+      return typeof def === 'string' ? def : key;
+    },
+  };
+}
+
+function interpolate(
+  s: string,
+  vars?: Record<string, unknown> & { defaultValue?: string },
+): string {
+  if (!vars) return s;
+  return s.replace(/\{\{(\w+)\}\}/g, (match, key) => {
+    if (key === 'defaultValue') return match;
+    const v = vars[key];
+    return v == null ? match : String(v);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Module-level event bus
+// ---------------------------------------------------------------------------
+
+type Subscribers = Map<string, Set<AtriumEventHandler>>;
+
+let activeSubscribers: Subscribers | null = null;
+
+/** Dispatch an atrium SSE-style event to every handler the host
+ *  subscribed via the fake registry. No-op when called outside a
+ *  ``mockAtriumRegistry`` scope so a test that forgets to call
+ *  ``mockAtriumRegistry`` first surfaces as an empty assertion rather
+ *  than a TypeError. */
+export function fireAtriumEvent(
+  kind: string,
+  payload: Record<string, unknown>,
+): void {
+  const subs = activeSubscribers;
+  if (!subs) return;
+  const handlers = subs.get(kind);
+  if (!handlers || handlers.size === 0) return;
+  const event: AtriumEvent = { kind, payload };
+  // Snapshot so a handler that unsubscribes mid-fire doesn't skip a
+  // sibling handler that's later in iteration order.
+  for (const handler of [...handlers]) {
+    handler(event);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mock registry handles
+// ---------------------------------------------------------------------------
+
+/** Recorded registrations + reset/cleanup hooks returned by
+ *  ``mockAtriumRegistry``. Tests assert against the array fields and
+ *  call ``cleanup()`` from ``afterEach`` to drop the
+ *  window globals back to their pre-mock state. */
+export interface MockAtriumHandles {
+  /** The fake registry installed on ``window.__ATRIUM_REGISTRY__``.
+   *  Test bodies that want to call register methods directly (instead
+   *  of through a host bundle's import-time side-effects) reach for
+   *  this. */
+  registry: AtriumRegistry;
+  homeWidgets: HomeWidget[];
+  routes: RouteEntry[];
+  navItems: NavItem[];
+  adminTabs: AdminTab[];
+  profileItems: ProfileItem[];
+  notificationKinds: NotificationKindRenderer[];
+  localeOverlays: LocaleOverlay[];
+  /** Drop every recorded registration + every event subscriber.
+   *  Useful between tests inside the same ``describe`` that want to
+   *  share the rest of the mock context. */
+  reset(): void;
+  /** Restore the pre-mock window state. Call from ``afterEach`` so
+   *  the next test's ``mockAtriumRegistry`` starts from a clean
+   *  baseline. */
+  cleanup(): void;
+}
+
+export interface MockAtriumOptions {
+  /** What ``useMe()`` resolves to. Pass ``null`` to simulate a
+   *  signed-out user (atrium responded 401/403). Defaults to
+   *  ``null``. */
+  me?: UserContext | null;
+  /** Locale resources the fake ``__atrium_t__`` resolves against.
+   *  Keys are flat dot-paths (``'common.save'``); the outer key is
+   *  the locale code. Defaults to a minimal English bundle covering
+   *  the keys atrium ships in ``common.*``. Pass an empty object to
+   *  exercise the missing-key fallback. */
+  i18n?: {
+    resources?: Record<string, Record<string, string>>;
+    language?: string;
+  };
+}
+
+interface SavedGlobals {
+  registry: AtriumRegistry | undefined;
+  React: unknown;
+  i18n: unknown;
+}
+
+const DEFAULT_I18N_EN: Record<string, string> = {
+  'common.save': 'Save',
+  'common.cancel': 'Cancel',
+  'common.delete': 'Delete',
+  'common.edit': 'Edit',
+  'common.new': 'New',
+  'common.close': 'Close',
+  'common.confirm': 'Confirm',
+  'common.back': 'Back',
+  'common.loading': 'Loading…',
+  'common.empty': 'Nothing here yet.',
+  'common.error': 'Something went wrong.',
+  'common.search': 'Search',
+  'common.required': 'Required',
+  'common.language': 'Language',
+};
+
+function buildFakeRegistry(handles: MockAtriumHandles, subs: Subscribers): AtriumRegistry {
+  return {
+    registerHomeWidget(widget) {
+      handles.homeWidgets.push(widget);
+    },
+    registerRoute(route) {
+      handles.routes.push(route);
+    },
+    registerNavItem(item) {
+      handles.navItems.push(item);
+    },
+    registerAdminTab(tab) {
+      handles.adminTabs.push(tab);
+    },
+    registerProfileItem(item) {
+      handles.profileItems.push(item);
+    },
+    registerNotificationKind(renderer) {
+      handles.notificationKinds.push(renderer);
+    },
+    registerLocale(overlay) {
+      handles.localeOverlays.push(overlay);
+    },
+    subscribeEvent(kind, handler) {
+      let set = subs.get(kind);
+      if (!set) {
+        set = new Set();
+        subs.set(kind, set);
+      }
+      set.add(handler);
+      return () => {
+        set?.delete(handler);
+      };
+    },
+  };
+}
+
+/** Install a recording fake registry on ``window`` for the duration of
+ *  a test. The handles returned record every register* call so tests
+ *  can assert that a host bundle wired up the slots it claims to.
+ *
+ *  ```ts
+ *  let handles: MockAtriumHandles;
+ *  beforeEach(() => {
+ *    handles = mockAtriumRegistry({
+ *      me: {
+ *        id: 1, email: 'alice@example.com', full_name: 'Alice',
+ *        is_active: true, roles: ['admin'],
+ *        permissions: ['hello.toggle'], impersonating_from: null,
+ *      },
+ *    });
+ *  });
+ *  afterEach(() => handles.cleanup());
+ *
+ *  test('host bundle registers a home widget', async () => {
+ *    await import('../src/main');
+ *    expect(handles.homeWidgets).toHaveLength(1);
+ *    expect(handles.homeWidgets[0].key).toBe('hello-world');
+ *  });
+ *  ```
+ *
+ *  Side effects:
+ *   - ``window.__ATRIUM_REGISTRY__`` is replaced with the fake.
+ *   - ``window.React`` is set to the package's React copy so
+ *     ``makeWrapperElement(...)`` calls resolve. Tests that need a
+ *     specific React identity can override after the call.
+ *   - ``window.__atrium_i18n__`` is set to a fake i18n with the
+ *     bundled English ``common.*`` strings (override via the
+ *     ``i18n`` option). */
+export function mockAtriumRegistry(
+  options: MockAtriumOptions = {},
+): MockAtriumHandles {
+  if (typeof window === 'undefined') {
+    throw new Error(
+      '[atrium-test-utils] mockAtriumRegistry requires a jsdom-style ' +
+        'window — set vitest.environment to "jsdom" in vitest.config.ts',
+    );
+  }
+
+  const w = window as unknown as {
+    __ATRIUM_REGISTRY__?: AtriumRegistry;
+    React?: unknown;
+    __atrium_i18n__?: unknown;
+  };
+
+  const saved: SavedGlobals = {
+    registry: w.__ATRIUM_REGISTRY__,
+    React: w.React,
+    i18n: w.__atrium_i18n__,
+  };
+
+  const subs: Subscribers = new Map();
+  const handles: MockAtriumHandles = {
+    registry: undefined as unknown as AtriumRegistry,
+    homeWidgets: [],
+    routes: [],
+    navItems: [],
+    adminTabs: [],
+    profileItems: [],
+    notificationKinds: [],
+    localeOverlays: [],
+    reset() {
+      handles.homeWidgets.length = 0;
+      handles.routes.length = 0;
+      handles.navItems.length = 0;
+      handles.adminTabs.length = 0;
+      handles.profileItems.length = 0;
+      handles.notificationKinds.length = 0;
+      handles.localeOverlays.length = 0;
+      subs.clear();
+    },
+    cleanup() {
+      w.__ATRIUM_REGISTRY__ = saved.registry;
+      w.React = saved.React;
+      w.__atrium_i18n__ = saved.i18n;
+      if (activeSubscribers === subs) {
+        activeSubscribers = null;
+      }
+      subs.clear();
+    },
+  };
+
+  handles.registry = buildFakeRegistry(handles, subs);
+
+  w.__ATRIUM_REGISTRY__ = handles.registry;
+  w.React = ReactNS;
+
+  const i18nResources = options.i18n?.resources ?? { en: DEFAULT_I18N_EN };
+  const language = options.i18n?.language ?? 'en';
+  w.__atrium_i18n__ = makeFakeI18n(i18nResources, language);
+
+  // Stash the configured ``me`` on a module-level slot so
+  // ``renderWithAtrium`` can pass it through to AtriumProvider's
+  // ``fetchUserContext`` override without each call site re-passing
+  // it. Cleared by ``cleanup()`` via the activeSubscribers reset.
+  configuredMe = options.me ?? null;
+
+  activeSubscribers = subs;
+
+  return handles;
+}
+
+// ---------------------------------------------------------------------------
+// renderWithAtrium
+// ---------------------------------------------------------------------------
+
+let configuredMe: UserContext | null = null;
+
+export interface RenderWithAtriumOptions extends RenderOptions {
+  /** Override ``me`` for this single render. Useful for
+   *  parameterised tests that vary the signed-in user without
+   *  re-installing the registry. Falls back to the value from
+   *  ``mockAtriumRegistry({ me })``. */
+  me?: UserContext | null;
+  /** Provide your own QueryClient — useful if the test asserts
+   *  against cached data or invalidations. Defaults to a fresh client
+   *  with retries disabled so a 401 surfaces immediately. */
+  queryClient?: QueryClient;
+  /** Wrap children in additional providers (MantineProvider,
+   *  RouterProvider, etc.). Default: identity. */
+  wrap?: ComponentType<{ children: ReactNode }>;
+}
+
+function makeTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+/** ``@testing-library/react``'s ``render`` pre-wired with a fresh
+ *  QueryClient and ``<AtriumProvider>`` pointed at the configured
+ *  ``me``. Returns the standard ``RenderResult`` so existing
+ *  assertions (``getByRole``, ``rerender``, ``unmount``) work
+ *  unchanged.
+ *
+ *  ```tsx
+ *  test('owners see the per-agent picker', () => {
+ *    const { getByLabelText } = renderWithAtrium(<CommissionsPage />);
+ *    expect(getByLabelText('Agent')).toBeInTheDocument();
+ *  });
+ *  ```
+ *
+ *  Pass ``me`` to override the value from ``mockAtriumRegistry`` for
+ *  a single render — handy in parameterised tests. Pass
+ *  ``queryClient`` to share a client across renders so cache
+ *  assertions survive the second mount. */
+export function renderWithAtrium(
+  ui: ReactElement,
+  options: RenderWithAtriumOptions = {},
+): RenderResult {
+  const { me, queryClient, wrap, ...rest } = options;
+  const client = queryClient ?? makeTestQueryClient();
+  const meValue = me === undefined ? configuredMe : me;
+  const Wrap = wrap;
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    const inner = createElement(AtriumProvider, {
+      fetchUserContext: async () => meValue,
+      children,
+    });
+    const wrapped = Wrap ? createElement(Wrap, { children: inner }) : inner;
+    return createElement(QueryClientProvider, { client, children: wrapped });
+  }
+
+  return render(ui, { wrapper: Wrapper, ...rest });
+}

--- a/packages/test-utils/test/registry.test.tsx
+++ b/packages/test-utils/test/registry.test.tsx
@@ -1,0 +1,236 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { cleanup, screen, waitFor } from '@testing-library/react';
+
+import {
+  fireAtriumEvent,
+  mockAtriumRegistry,
+  renderWithAtrium,
+  type MockAtriumHandles,
+  type UserContext,
+} from '../src/index';
+import {
+  __atrium_t__,
+  useMe,
+  usePerm,
+} from '@brendan-bank/atrium-host-bundle-utils/react';
+
+const ALICE: UserContext = {
+  id: 7,
+  email: 'alice@example.com',
+  full_name: 'Alice Example',
+  is_active: true,
+  roles: ['admin'],
+  permissions: ['hello.toggle', 'audit.read'],
+  impersonating_from: null,
+};
+
+let handles: MockAtriumHandles;
+
+beforeEach(() => {
+  handles = mockAtriumRegistry({ me: ALICE });
+});
+
+afterEach(() => {
+  cleanup();
+  handles.cleanup();
+});
+
+describe('mockAtriumRegistry', () => {
+  test('records register* calls so a host bundle can be asserted against', () => {
+    handles.registry.registerHomeWidget({
+      key: 'hello',
+      render: () => null as unknown as React.ReactElement,
+    });
+    handles.registry.registerNavItem({ key: 'nav', label: 'Hi', to: '/hi' });
+    handles.registry.registerAdminTab({
+      key: 'tab',
+      label: 'Tab',
+      perm: 'audit.read',
+      render: () => null as unknown as React.ReactElement,
+    });
+
+    expect(handles.homeWidgets).toHaveLength(1);
+    expect(handles.homeWidgets[0].key).toBe('hello');
+    expect(handles.navItems).toHaveLength(1);
+    expect(handles.adminTabs).toHaveLength(1);
+  });
+
+  test('installs window.__ATRIUM_REGISTRY__ pointing at the same fake', () => {
+    expect(window.__ATRIUM_REGISTRY__).toBe(handles.registry);
+  });
+
+  test('exposes window.React so makeWrapperElement resolves', () => {
+    expect((window as unknown as { React?: unknown }).React).toBeDefined();
+  });
+
+  test('cleanup restores the pre-mock window state', () => {
+    handles.cleanup();
+    expect(window.__ATRIUM_REGISTRY__).toBeUndefined();
+  });
+
+  test('reset clears recorded registrations and subscribers', () => {
+    handles.registry.registerHomeWidget({
+      key: 'a',
+      render: () => null as unknown as React.ReactElement,
+    });
+    handles.registry.subscribeEvent('foo', () => {});
+    handles.reset();
+    expect(handles.homeWidgets).toEqual([]);
+    let fired = 0;
+    handles.registry.subscribeEvent('foo', () => {
+      fired += 1;
+    });
+    fireAtriumEvent('foo', {});
+    expect(fired).toBe(1);
+  });
+});
+
+describe('useMe via renderWithAtrium', () => {
+  function MeProbe() {
+    const { data, isLoading } = useMe();
+    if (isLoading) return <span>loading</span>;
+    if (!data) return <span>signed-out</span>;
+    return <span data-testid="email">{data.email}</span>;
+  }
+
+  test('returns the configured me to useMe()', async () => {
+    renderWithAtrium(<MeProbe />);
+    await waitFor(() =>
+      expect(screen.getByTestId('email').textContent).toBe(
+        'alice@example.com',
+      ),
+    );
+  });
+
+  test('per-render me override wins over the registry default', async () => {
+    renderWithAtrium(<MeProbe />, {
+      me: { ...ALICE, email: 'bob@example.com' },
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId('email').textContent).toBe('bob@example.com'),
+    );
+  });
+
+  test('signed-out renders when me=null', async () => {
+    handles.cleanup();
+    handles = mockAtriumRegistry({ me: null });
+    renderWithAtrium(<MeProbe />);
+    await waitFor(() =>
+      expect(screen.getByText('signed-out')).toBeInTheDocument(),
+    );
+  });
+});
+
+describe('usePerm via renderWithAtrium', () => {
+  function PermProbe({ code }: { code: string }) {
+    const hasPerm = usePerm();
+    return (
+      <span data-testid={`perm-${code}`}>{hasPerm(code) ? 'yes' : 'no'}</span>
+    );
+  }
+
+  test('returns true for permissions on the configured me', async () => {
+    renderWithAtrium(<PermProbe code="hello.toggle" />);
+    await waitFor(() =>
+      expect(screen.getByTestId('perm-hello.toggle').textContent).toBe('yes'),
+    );
+  });
+
+  test('returns false for permissions the user lacks', async () => {
+    renderWithAtrium(<PermProbe code="user.manage" />);
+    await waitFor(() =>
+      expect(screen.getByTestId('perm-user.manage').textContent).toBe('no'),
+    );
+  });
+});
+
+describe('fireAtriumEvent', () => {
+  test('dispatches to handlers registered via the fake registry', () => {
+    const seen: Array<{ kind: string; payload: Record<string, unknown> }> = [];
+    handles.registry.subscribeEvent('booking.created', (e) => {
+      seen.push(e);
+    });
+    fireAtriumEvent('booking.created', { booking_id: 42 });
+    expect(seen).toEqual([
+      { kind: 'booking.created', payload: { booking_id: 42 } },
+    ]);
+  });
+
+  test('only fires handlers matching the kind', () => {
+    let aHits = 0;
+    let bHits = 0;
+    handles.registry.subscribeEvent('a', () => {
+      aHits += 1;
+    });
+    handles.registry.subscribeEvent('b', () => {
+      bHits += 1;
+    });
+    fireAtriumEvent('a', {});
+    expect(aHits).toBe(1);
+    expect(bHits).toBe(0);
+  });
+
+  test('unsubscribe stops further dispatches', () => {
+    let hits = 0;
+    const off = handles.registry.subscribeEvent('x', () => {
+      hits += 1;
+    });
+    fireAtriumEvent('x', {});
+    off();
+    fireAtriumEvent('x', {});
+    expect(hits).toBe(1);
+  });
+
+  test('handler that unsubscribes mid-fire does not skip a sibling', () => {
+    let aHits = 0;
+    let bHits = 0;
+    let offA: (() => void) | null = null;
+    offA = handles.registry.subscribeEvent('shared', () => {
+      aHits += 1;
+      offA?.();
+    });
+    handles.registry.subscribeEvent('shared', () => {
+      bHits += 1;
+    });
+    fireAtriumEvent('shared', {});
+    expect(aHits).toBe(1);
+    expect(bHits).toBe(1);
+  });
+
+  test('no-op when called outside a mockAtriumRegistry scope', () => {
+    handles.cleanup();
+    expect(() => fireAtriumEvent('any', {})).not.toThrow();
+  });
+});
+
+describe('window.__atrium_i18n__ + __atrium_t__', () => {
+  test('resolves bundled common.* keys to English by default', () => {
+    expect(__atrium_t__('common.save')).toBe('Save');
+    expect(__atrium_t__('common.cancel')).toBe('Cancel');
+  });
+
+  test('falls back to English when active locale lacks the key', () => {
+    handles.cleanup();
+    handles = mockAtriumRegistry({
+      i18n: {
+        resources: {
+          en: { 'common.save': 'Save' },
+          nl: {},
+        },
+        language: 'nl',
+      },
+    });
+    expect(__atrium_t__('common.save')).toBe('Save');
+  });
+
+  test('returns the literal key when nothing matches', () => {
+    handles.cleanup();
+    handles = mockAtriumRegistry({
+      i18n: { resources: { en: {} } },
+    });
+    expect(__atrium_t__('common.unknownKey')).toBe('common.unknownKey');
+  });
+});

--- a/packages/test-utils/test/setup.ts
+++ b/packages/test-utils/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "verbatimModuleSyntax": false,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["test", "dist", "node_modules"]
+}

--- a/packages/test-utils/vitest.config.ts
+++ b/packages/test-utils/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: false,
+    setupFiles: ['./test/setup.ts'],
+    include: ['test/**/*.test.{ts,tsx}'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,15 +35,27 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
     devDependencies:
+      '@brendan-bank/atrium-test-utils':
+        specifier: workspace:*
+        version: link:../../../packages/test-utils
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
       '@types/react-dom':
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.14)
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.1.0(@noble/hashes@2.2.0)
       otplib:
         specifier: ^13.4.0
         version: 13.4.0
@@ -56,6 +68,9 @@ importers:
       vite-plugin-css-injected-by-js:
         specifier: ^3.5.2
         version: 3.5.2(vite@8.0.10(@types/node@25.6.0))
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.0(@noble/hashes@2.2.0))(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0))
 
   packages/host-bundle-utils:
     dependencies:
@@ -117,6 +132,49 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+
+  packages/test-utils:
+    dependencies:
+      '@brendan-bank/atrium-host-bundle-utils':
+        specifier: workspace:*
+        version: link:../host-bundle-utils
+      '@brendan-bank/atrium-host-types':
+        specifier: workspace:*
+        version: link:../host-types
+    devDependencies:
+      '@tanstack/react-query':
+        specifier: ^5.100.5
+        version: 5.100.6(react@19.2.5)
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.1.0(@noble/hashes@2.2.0)
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.0(@noble/hashes@2.2.0))(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0))
 
 packages:
 


### PR DESCRIPTION
## Summary

Wave 3 of the Host SDK epic, bundled into one PR (matching how Wave 2's #37+#38+#40 shipped together as #53). Two atomic commits, one per issue.

- **`#45` (part b)** — shared i18n keys: `__atrium_t__('common.save')` resolves against atrium's running i18next instance, host-side string literals get the right translation in every locale atrium ships.
- **`#41`** — new `@brendan-bank/atrium-test-utils` package: `mockAtriumRegistry`, `renderWithAtrium`, `fireAtriumEvent`. Replaces the hand-rolled `vi.fn()` mocks every host used to write.

Part (a) of #45 (theme-tokens classification) shipped earlier in #51.

Closes #41.
Closes #45.

## What changed

### `#45 part b` — shared i18n keys (commit `a190d12`)

- `frontend/src/i18n/index.ts` exposes `window.__atrium_i18n__` so host bundles can resolve keys against atrium's bundled resources + admin overrides + host overlays. Reads the active locale dynamically.
- New `common.*` namespace in all four locale JSONs (`en`, `nl`, `de`, `fr`): 16 keys covering verbs (`save`, `cancel`, `delete`, `edit`, `new`, `close`, `confirm`, `back`), structural labels (`loading`, `empty`, `error`, `search`, `required`, `language`), and confirmation patterns (`confirmDelete`, `confirmDiscard`).
- `packages/host-bundle-utils/src/i18n.ts` (new): `__atrium_t__(key, vars?)` helper. Re-exported from package root and `/react`. Resolution path: active locale → English fallback → literal key. Pre-0.14 fallback path returns the key unchanged when `window.__atrium_i18n__` is missing.
- 6 unit tests covering active-locale hits, English fallback, missing-key behaviour, missing i18n global, and var interpolation.
- `examples/hello-world/frontend/src/HelloWidget.tsx` dogfoods `__atrium_t__('common.loading')` and `__atrium_t__('common.error')`.
- New `docs/host-i18n.md` documents the full key catalogue, resolution order, and how to add keys/locales.

### `#41` — `@brendan-bank/atrium-test-utils` (commit `f2acb39`)

- New package at `packages/test-utils/`, version-locked to `0.14.0`. Peer deps: `vitest`, `@testing-library/react`, `react`, `react-dom`, `@tanstack/react-query`.
- `mockAtriumRegistry({ me?, i18n? })` — installs a recording fake on `window.__ATRIUM_REGISTRY__`, exposes React via `window.React`, stubs `window.__atrium_i18n__`. Returns handles with `homeWidgets[]`, `routes[]`, `navItems[]`, `adminTabs[]`, `profileItems[]`, `notificationKinds[]`, `localeOverlays[]` and `cleanup()` to restore pre-mock window state.
- `renderWithAtrium(ui, options?)` — wraps `@testing-library/react`'s `render` with a fresh QueryClient + AtriumProvider pre-wired to the configured `me`.
- `fireAtriumEvent(kind, payload)` — dispatches synthetic SSE events to subscribers; snapshots subscriber list before iterating so a handler that unsubscribes mid-fire doesn't skip a sibling.
- 18 unit tests for the package itself.
- `examples/hello-world/frontend` dogfoods the package via a new `src/test/HelloWidget.test.tsx` that gates `usePerm('hello.toggle')` for two users without standing up the SPA. Adds vitest config + setup; the matchMedia stub unblocks Mantine on jsdom.
- Workspace `test` script extended to also run `./examples/*/frontend` tests.
- `docs/published-images.md` bumps "two packages" to "three packages" with a test-utils description.

## Test plan

- [x] `pnpm typecheck` — all four targets clean (host-types, host-bundle-utils, test-utils, hello-world).
- [x] `pnpm test` — 26 + 18 + 2 = 46 tests pass across `packages/*` and the hello-world dogfood.
- [x] `frontend && pnpm typecheck && pnpm test` — atrium SPA still typechecks; 49 unit tests pass with the i18next change.
- [ ] CI passes (typecheck + lint + atrium frontend tests + e2e + hello-world e2e). The host SDK packages aren't gated in CI today (existing gap from Wave 2); follow-up suggested.