### PR TITLE
Release v0.14.0: backend version bump + doc sweep

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,7 +10,7 @@ name = "atrium-backend"
 # ``window.__ATRIUM_VERSION__`` for host-bundle feature detection.
 # Until the next release-bump lands, ``__ATRIUM_VERSION__`` reports
 # this value verbatim — i.e. the *previous* released version.
-version = "0.1.0"
+version = "0.14.0"
 description = "Atrium — auth/RBAC/notifications/audit starter (backend)"
 readme = "../README.md"
 requires-python = ">=3.12"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -129,7 +129,7 @@ wheels = [
 
 [[package]]
 name = "atrium-backend"
-version = "0.1.0"
+version = "0.14.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiomysql" },

--- a/docs/compat-matrix.md
+++ b/docs/compat-matrix.md
@@ -23,6 +23,7 @@ then read forward to plan the upgrade path.
 | [0.11.2](https://github.com/Brendan-Bank/atrium/releases/tag/v0.11.2) | unchanged | `registerNotificationKind` | — | — |
 | [0.11.3](https://github.com/Brendan-Bank/atrium/releases/tag/v0.11.3) | unchanged | `subscribeEvent`. **SSE wire-format change**: `/notifications/stream` events now carry the row's actual `{kind, payload}` instead of the literal `{kind: 'refresh'}` | — | — |
 | [0.12.0](https://github.com/Brendan-Bank/atrium/releases/tag/v0.12.0) | unchanged | `registerLocale`; `render()` form on `registerRoute` and `registerAdminTab`; `roles[]` (role codes) added to `/admin/users` responses | `element:` shape on `registerRoute` / `registerAdminTab` is soft-deprecated — keep working via fallback, but new code should pass `render: () => …` | — |
+| [0.14.0](https://github.com/Brendan-Bank/atrium/releases/tag/v0.14.0) | unchanged | `__ATRIUM_VERSION__` on `window` for runtime feature detection; `HostForeignKey()` + `emit_host_foreign_keys` for cross-base FKs; typed `HostWorkerCtx.register_job_handler()` for `init_worker(host)`; published host SDK packages (`@brendan-bank/atrium-host-{types,bundle-utils,test-utils}`); `__atrium_t__('common.*')` shared i18n keys; `npx @brendan-bank/create-atrium-host` scaffolder | — | — |
 
 A blank cell means "no change in this release on that axis". Schema rows
 list the alembic head a host can rely on coexisting with — atrium owns

--- a/docs/new-project/README.md
+++ b/docs/new-project/README.md
@@ -771,7 +771,7 @@ into the wrapper).
 ## Step 5 - Dockerfile
 
 ```dockerfile
-ARG ATRIUM_IMAGE=ghcr.io/<org>/atrium:1
+ARG ATRIUM_IMAGE=ghcr.io/<org>/atrium:0.14
 
 # ---- frontend-builder ----
 FROM node:25-alpine AS frontend-builder
@@ -924,7 +924,7 @@ MAIL_FROM=no-reply@example.com
 
 # Pin the atrium base image. X.Y for patch uptake; X.Y.Z for fully
 # deterministic deploys.
-ATRIUM_IMAGE=ghcr.io/<org>/atrium:1
+ATRIUM_IMAGE=ghcr.io/<org>/atrium:0.14
 ```
 
 For the full env-var surface (CAPTCHA secret, SMTP host/port/user, etc.)

--- a/docs/new-project/SKILL.md
+++ b/docs/new-project/SKILL.md
@@ -202,7 +202,7 @@ Two-stage build: node-builder for the SPA, then `FROM ${ATRIUM_IMAGE}`
 to install the host package and copy the bundle into the static dir:
 
 ```dockerfile
-ARG ATRIUM_IMAGE=ghcr.io/<org>/atrium:1
+ARG ATRIUM_IMAGE=ghcr.io/<org>/atrium:0.14
 FROM node:25-alpine AS frontend-builder
 WORKDIR /app
 RUN npm install -g pnpm@10.33.1


### PR DESCRIPTION
## Summary

- Bumps `backend/pyproject.toml` from `0.1.0` to `0.14.0` to match the host SDK packages already at `0.14.0` (waves 2/3/4 landed at that version).
- Without this, `/app-config` would report `0.1.0` and `window.__ATRIUM_VERSION__` (the new feature-detection surface) would lie about every host running the new image.
- Closes the Host SDK epic. The next \`v0.14.0\` tag pushes:
  - the runtime image (publish-images.yml)
  - `@brendan-bank/atrium-host-{types,bundle-utils,test-utils}@0.14.0` (publish-npm.yml)
  - `@brendan-bank/create-atrium-host@0.14.0` (publish-npm.yml — newly included via the workspace)

## Doc sweep (RELEASING.md step 1.5)

- `docs/compat-matrix.md` — new row for 0.14.0 enumerating every wave's contribution: `__ATRIUM_VERSION__`, `HostForeignKey`, typed `HostWorkerCtx`, the published host SDK packages, the `common.*` shared i18n keys, and the `create-atrium-host` scaffolder.
- `docs/new-project/{README.md,SKILL.md}` — example Dockerfiles + `.env.example` lines now pin to `ghcr.io/<org>/atrium:0.14` rather than the placeholder `:1` (atrium is on 0.x; a major-pin of `1` doesn't exist yet).

## Test plan

- [x] `make test-backend` — 200 passed
- [x] `make test-frontend` — 49 passed
- [x] `(cd frontend && pnpm typecheck)` — clean
- [x] `make lint` — clean (1 pre-existing react-hooks warning, per RELEASING.md note)
- [x] `make smoke` — 9/9 passed