### PR TITLE
Extend CodeQL coverage to actions; ignore e2e test paths

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -17,8 +17,14 @@ paths-ignore:
   # code and not meaningful for runtime risk.
   - backend/alembic/versions/**
   # Test fixtures + scaffolding — out of scope for product security
-  # review; their findings rarely correspond to real risk.
+  # review; their findings rarely correspond to real risk. The threat
+  # model for e2e fixtures (developer- / CI-controlled env vars
+  # feeding ``execSync``, fixture data flowing into HTTP calls) is
+  # the same as for backend tests: there is no attacker, the inputs
+  # come from the test runner.
   - backend/tests/**
+  - frontend/tests-e2e/**
+  - examples/hello-world/frontend/tests-e2e/**
 
 query-filters:
   - exclude:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,11 @@ jobs:
             build-mode: none
           - language: javascript-typescript
             build-mode: none
+          # ``actions`` re-uses the CodeQL pipeline to lint workflow
+          # files (missing GITHUB_TOKEN permissions, untrusted inputs
+          # in run blocks, etc.). Cheap, no build step.
+          - language: actions
+            build-mode: none
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
Follow-up to #61 to close the remaining open code-scanning alerts.

- `codeql.yml`: add `actions` to the language matrix so
  `actions/missing-workflow-permissions` re-evaluates against the
  fixed `ci.yml` from #61. Closes alerts #7–#12.
- `codeql-config.yml`: extend `paths-ignore` to the two e2e test
  trees (`frontend/tests-e2e/**`,
  `examples/hello-world/frontend/tests-e2e/**`), matching the
  existing carve-out for `backend/tests/**`. Closes alerts #33–#38
  (`js/indirect-command-line-injection` from `execSync` taking
  `process.env.E2E_*` values — developer / CI input, no attacker).

## Test plan
- [ ] CI green
- [ ] Code-scanning alerts on master drop from 20 to ~8 (only
      pre-existing low-severity quality alerts remain)