### PR TITLE
Split uv-lock workflow into untrusted+privileged pair

### DIFF
--- a/.github/workflows/uv-lock-commit.yml
+++ b/.github/workflows/uv-lock-commit.yml
@@ -7,18 +7,17 @@ name: uv-lock-commit
 # context). Triggered by the unprivileged workflow finishing
 # successfully on a Dependabot PR; this one runs in the base-repo
 # context (default branch's YAML), holds ``contents: write``, and
-# does only git plumbing — it never executes a script from the PR.
+# never checks out the PR branch — the lockfile is written via the
+# GitHub Contents API directly. That keeps every "untrusted-checkout"
+# anti-pattern out of the privileged path: no ``actions/checkout`` of
+# a PR ref, no ``run:`` block executing a script from PR content.
 #
 # The flow:
 #   1. Validate the originating workflow_run was a successful
 #      Dependabot ``pull_request`` event.
 #   2. Download the uv-lock + pr-meta artifacts from that run.
-#   3. Sanity-check the metadata before it touches git plumbing.
-#   4. Check out the PR head ref (no code execution from PR — just
-#      ``git fetch`` + ``git checkout``).
-#   5. Verify the head SHA still matches what the artifact was built
-#      against — abort if the branch moved.
-#   6. Copy uv.lock from artifact, commit, push.
+#   3. Sanity-check the metadata before any of it touches gh.
+#   4. PUT the new uv.lock to the PR branch via the Contents API.
 
 on:
   workflow_run:
@@ -54,55 +53,60 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Validate PR metadata
-        id: pr
-        # Refs from the PR are attacker-influenced (Dependabot is the
-        # actor but the branch name on a Dependabot PR is well-formed
-        # by convention; we still pin the shape before letting it
-        # near git). Each value goes through a regex; an invalid
-        # value fails the workflow loudly.
+      - name: Validate PR metadata and apply uv.lock
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        # Whole step is bash with ``set -euo pipefail`` and explicit
+        # env vars — nothing comes from ``${{ ... }}`` interpolation,
+        # and nothing from the artifact is fed to a shell unquoted.
+        # Fails closed on any unexpected metadata shape.
         run: |
-          set -e
+          set -euo pipefail
+
           NUMBER=$(cat artifact-pr-meta/number)
           HEAD_REF=$(cat artifact-pr-meta/head_ref)
           HEAD_SHA=$(cat artifact-pr-meta/head_sha)
-          [[ "$NUMBER"  =~ ^[0-9]+$ ]]              || { echo "bad PR number: $NUMBER" >&2; exit 1; }
-          [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]       || { echo "bad SHA: $HEAD_SHA"     >&2; exit 1; }
-          [[ "$HEAD_REF" =~ ^[A-Za-z0-9._/-]+$ ]]   || { echo "bad ref: $HEAD_REF"     >&2; exit 1; }
-          {
-            echo "number=$NUMBER"
-            echo "head_ref=$HEAD_REF"
-            echo "head_sha=$HEAD_SHA"
-          } >> "$GITHUB_OUTPUT"
 
-      - name: Checkout PR branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          ref: ${{ steps.pr.outputs.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          [[ "$NUMBER"   =~ ^[0-9]+$ ]]            || { echo "bad PR number"  >&2; exit 1; }
+          [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]      || { echo "bad SHA"        >&2; exit 1; }
+          [[ "$HEAD_REF" =~ ^[A-Za-z0-9._/-]+$ ]]  || { echo "bad ref"        >&2; exit 1; }
 
-      - name: Apply uv.lock and commit
-        env:
-          EXPECTED_SHA: ${{ steps.pr.outputs.head_sha }}
-        run: |
-          set -e
-          ACTUAL_SHA=$(git rev-parse HEAD)
-          if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
-            echo "Branch moved since uv.lock was regenerated"
-            echo "  expected: $EXPECTED_SHA"
-            echo "  actual:   $ACTUAL_SHA"
-            echo "Skipping push; Dependabot will re-trigger if needed."
-            exit 0
-          fi
+          # Fetch the current uv.lock blob SHA on the PR branch via
+          # the Contents API — needed for the conditional update.
+          CURRENT_JSON=$(gh api -H "Accept: application/vnd.github+json" \
+            "repos/$REPO/contents/backend/uv.lock?ref=$HEAD_REF")
+          CURRENT_BLOB_SHA=$(echo "$CURRENT_JSON" | jq -r '.sha')
+          CURRENT_CONTENT=$(echo "$CURRENT_JSON" | jq -r '.content' | tr -d '\n' | base64 -d)
 
-          cp artifact-uv-lock/uv.lock backend/uv.lock
-          if [ -z "$(git status --porcelain backend/uv.lock)" ]; then
+          NEW_CONTENT=$(cat artifact-uv-lock/uv.lock)
+          if [ "$NEW_CONTENT" = "$CURRENT_CONTENT" ]; then
             echo "uv.lock unchanged — nothing to commit"
             exit 0
           fi
 
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add backend/uv.lock
-          git commit -m "chore(deps): refresh uv.lock after Dependabot bump"
-          git push
+          # Verify the branch tip still matches the SHA the artifact
+          # was generated against. If the branch moved, abort and let
+          # Dependabot re-trigger; we don't want to clobber a newer
+          # human commit with a stale lockfile.
+          BRANCH_HEAD_SHA=$(gh api -H "Accept: application/vnd.github+json" \
+            "repos/$REPO/branches/$HEAD_REF" --jq '.commit.sha')
+          if [ "$BRANCH_HEAD_SHA" != "$HEAD_SHA" ]; then
+            echo "Branch moved: artifact SHA=$HEAD_SHA, branch=$BRANCH_HEAD_SHA"
+            echo "Skipping push; Dependabot will re-trigger if needed."
+            exit 0
+          fi
+
+          # PUT the new file. base64-encoded content + the existing
+          # blob SHA make this a conditional update — if anything has
+          # changed under us, GitHub returns 409 and we fail rather
+          # than overwrite.
+          NEW_CONTENT_B64=$(base64 < artifact-uv-lock/uv.lock | tr -d '\n')
+          gh api -X PUT -H "Accept: application/vnd.github+json" \
+            "repos/$REPO/contents/backend/uv.lock" \
+            -f message="chore(deps): refresh uv.lock after Dependabot bump" \
+            -f content="$NEW_CONTENT_B64" \
+            -f sha="$CURRENT_BLOB_SHA" \
+            -f branch="$HEAD_REF" \
+            > /dev/null
+          echo "uv.lock committed to $HEAD_REF on PR #$NUMBER"

--- a/.github/workflows/uv-lock-commit.yml
+++ b/.github/workflows/uv-lock-commit.yml
@@ -1,0 +1,108 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: uv-lock-commit
+
+# Privileged half of the uv-lock-refresh split (see that file for
+# context). Triggered by the unprivileged workflow finishing
+# successfully on a Dependabot PR; this one runs in the base-repo
+# context (default branch's YAML), holds ``contents: write``, and
+# does only git plumbing — it never executes a script from the PR.
+#
+# The flow:
+#   1. Validate the originating workflow_run was a successful
+#      Dependabot ``pull_request`` event.
+#   2. Download the uv-lock + pr-meta artifacts from that run.
+#   3. Sanity-check the metadata before it touches git plumbing.
+#   4. Check out the PR head ref (no code execution from PR — just
+#      ``git fetch`` + ``git checkout``).
+#   5. Verify the head SHA still matches what the artifact was built
+#      against — abort if the branch moved.
+#   6. Copy uv.lock from artifact, commit, push.
+
+on:
+  workflow_run:
+    workflows: ["uv-lock-refresh"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  push-uv-lock:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download uv.lock artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          name: uv-lock
+          path: artifact-uv-lock
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download PR metadata
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          name: pr-meta
+          path: artifact-pr-meta
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate PR metadata
+        id: pr
+        # Refs from the PR are attacker-influenced (Dependabot is the
+        # actor but the branch name on a Dependabot PR is well-formed
+        # by convention; we still pin the shape before letting it
+        # near git). Each value goes through a regex; an invalid
+        # value fails the workflow loudly.
+        run: |
+          set -e
+          NUMBER=$(cat artifact-pr-meta/number)
+          HEAD_REF=$(cat artifact-pr-meta/head_ref)
+          HEAD_SHA=$(cat artifact-pr-meta/head_sha)
+          [[ "$NUMBER"  =~ ^[0-9]+$ ]]              || { echo "bad PR number: $NUMBER" >&2; exit 1; }
+          [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]       || { echo "bad SHA: $HEAD_SHA"     >&2; exit 1; }
+          [[ "$HEAD_REF" =~ ^[A-Za-z0-9._/-]+$ ]]   || { echo "bad ref: $HEAD_REF"     >&2; exit 1; }
+          {
+            echo "number=$NUMBER"
+            echo "head_ref=$HEAD_REF"
+            echo "head_sha=$HEAD_SHA"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Checkout PR branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ steps.pr.outputs.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Apply uv.lock and commit
+        env:
+          EXPECTED_SHA: ${{ steps.pr.outputs.head_sha }}
+        run: |
+          set -e
+          ACTUAL_SHA=$(git rev-parse HEAD)
+          if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+            echo "Branch moved since uv.lock was regenerated"
+            echo "  expected: $EXPECTED_SHA"
+            echo "  actual:   $ACTUAL_SHA"
+            echo "Skipping push; Dependabot will re-trigger if needed."
+            exit 0
+          fi
+
+          cp artifact-uv-lock/uv.lock backend/uv.lock
+          if [ -z "$(git status --porcelain backend/uv.lock)" ]; then
+            echo "uv.lock unchanged — nothing to commit"
+            exit 0
+          fi
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add backend/uv.lock
+          git commit -m "chore(deps): refresh uv.lock after Dependabot bump"
+          git push

--- a/.github/workflows/uv-lock-refresh.yml
+++ b/.github/workflows/uv-lock-refresh.yml
@@ -48,11 +48,20 @@ jobs:
         # the workflow_run consumer doesn't have to trust anything
         # from the PR head — it reads files we wrote, validates
         # their shape, and fails closed.
+        #
+        # Pass the values via env, NOT through ``${{ ... }}`` template
+        # interpolation in the run script, so a maliciously-named
+        # branch (``foo'; rm -rf /; echo '``) can't break out of the
+        # shell quoting (``actions/code-injection``).
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           mkdir -p pr-meta
-          printf '%s' '${{ github.event.pull_request.number }}'  > pr-meta/number
-          printf '%s' '${{ github.event.pull_request.head.ref }}' > pr-meta/head_ref
-          printf '%s' '${{ github.event.pull_request.head.sha }}' > pr-meta/head_sha
+          printf '%s' "$PR_NUMBER"   > pr-meta/number
+          printf '%s' "$PR_HEAD_REF" > pr-meta/head_ref
+          printf '%s' "$PR_HEAD_SHA" > pr-meta/head_sha
 
       - name: Upload uv.lock
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4.6.2

--- a/.github/workflows/uv-lock-refresh.yml
+++ b/.github/workflows/uv-lock-refresh.yml
@@ -4,14 +4,18 @@
 name: uv-lock-refresh
 
 # Dependabot reads ``backend/pyproject.toml`` and opens PRs bumping
-# the pinned version constraints, but it has no uv.lock support —
-# so ``uv sync --frozen`` in CI fails on those PRs until someone
-# runs ``uv lock`` manually.
+# the pinned version constraints, but it has no uv.lock support — so
+# ``uv sync --frozen`` in CI fails on those PRs until someone runs
+# ``uv lock`` manually.
 #
-# This workflow runs on every Dependabot-authored PR targeting a
-# ``backend/`` file, regenerates the lockfile, and commits the
-# refreshed file back to the same PR branch. Non-Dependabot PRs
-# are ignored.
+# This workflow regenerates the lockfile and uploads it as an
+# artifact. ``uv-lock-commit.yml`` then picks the artifact up via a
+# ``workflow_run`` trigger and pushes it back to the PR branch with
+# elevated permissions. The split — recommended by the GitHub
+# Security Lab "preventing pwn requests" research — keeps the step
+# that may execute PR-supplied build hooks (``uv lock`` resolves
+# build backends declared in ``pyproject.toml``) on a token with no
+# write scope. Closing alert #39 / ``actions/untrusted-checkout``.
 
 on:
   pull_request:
@@ -20,37 +24,48 @@ on:
       - "backend/uv.lock"
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   relock:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout PR branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          # Check out the PR head (not the merge ref) so we can
-          # push back; GITHUB_TOKEN's default perms cover this
-          # thanks to ``permissions: contents: write`` above.
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+      # Implicit checkout of PR head — fine, this job's token is
+      # read-only so a malicious build hook can't do anything
+      # repo-relevant if uv ever resolves one.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
 
       - name: Regenerate uv.lock
         working-directory: backend
         run: uv lock
 
-      - name: Commit lockfile if changed
+      - name: Capture PR metadata
+        # The privileged downstream workflow needs to know which
+        # branch to push back to. Carry the values via artifact so
+        # the workflow_run consumer doesn't have to trust anything
+        # from the PR head — it reads files we wrote, validates
+        # their shape, and fails closed.
         run: |
-          if [ -n "$(git status --porcelain backend/uv.lock)" ]; then
-            git config user.name  "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add backend/uv.lock
-            git commit -m "chore(deps): refresh uv.lock after Dependabot bump"
-            git push
-          fi
+          mkdir -p pr-meta
+          printf '%s' '${{ github.event.pull_request.number }}'  > pr-meta/number
+          printf '%s' '${{ github.event.pull_request.head.ref }}' > pr-meta/head_ref
+          printf '%s' '${{ github.event.pull_request.head.sha }}' > pr-meta/head_sha
+
+      - name: Upload uv.lock
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4.6.2
+        with:
+          name: uv-lock
+          path: backend/uv.lock
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Upload PR metadata
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4.6.2
+        with:
+          name: pr-meta
+          path: pr-meta/
+          retention-days: 1
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
Closes the last security alert from the original 22 — alert #39
(\`actions/untrusted-checkout/medium\`) on \`uv-lock-refresh.yml\`.

The single \`uv-lock-refresh.yml\` workflow combined two things that
shouldn't share a context: it ran \`uv lock\` against the PR's
\`pyproject.toml\` (which resolves and may execute build backends —
PR-supplied code) AND it held \`contents: write\` to push the
regenerated lockfile back.

Split per the [GitHub Security Lab "preventing pwn requests"](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)
recommendation:

- **\`uv-lock-refresh.yml\`** (unprivileged, \`pull_request\` trigger,
  \`contents: read\`) — checks out the PR head, runs \`uv lock\`,
  uploads the regenerated lockfile + PR metadata as artifacts. If a
  malicious build backend ever resolves during the lock, it can't do
  anything repo-relevant from a read-only token.
- **\`uv-lock-commit.yml\`** (privileged, \`workflow_run\` trigger,
  \`contents: write\`) — runs from the base repo's YAML, gates on the
  originating run being a successful Dependabot \`pull_request\`,
  downloads the artifacts, validates the PR metadata shape with
  regexes, checks out the PR branch (git plumbing only — no code
  execution), verifies the head SHA hasn't moved since the lockfile
  was regenerated, then commits and pushes.

## Test plan
- [ ] CI green
- [ ] CodeQL re-scan confirms #39 closes
- [ ] Next Dependabot PR landing on \`backend/pyproject.toml\` triggers
      both workflows in sequence and the lockfile commit appears