### PR TITLE
Clean up 8 CodeQL quality alerts

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -11,12 +11,16 @@ from sqlalchemy import pool
 from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
-# Importing the models package ensures every model class is registered on
-# Base.metadata before autogenerate runs. Empty until task #3 lands.
-import app.models  # noqa: F401
+import app.models
 from alembic import context
 from app.db import Base
 from app.settings import get_settings
+
+# Acknowledge the side-effect import. ``app.models.__init__`` pulls
+# every model class into scope so it registers on ``Base.metadata``
+# before autogenerate inspects it; without the reference below
+# CodeQL flags ``app.models`` as unused.
+_ = app.models
 
 config = context.config
 

--- a/backend/app/auth/users.py
+++ b/backend/app/auth/users.py
@@ -141,6 +141,11 @@ async def current_user(
     except HTTPException:
         raise
     except Exception:
+        # Defensive: an auth-config read failure here must not turn
+        # an authenticated request into a 500. The 2FA-enforcement
+        # check is best-effort — when we can't read the config we
+        # let the user through with their existing factors and the
+        # next request will retry.
         pass
     return user
 

--- a/backend/app/email/backend.py
+++ b/backend/app/email/backend.py
@@ -44,7 +44,8 @@ class EmailMessage:
 class MailBackend(Protocol):
     name: str
 
-    async def send(self, message: EmailMessage) -> None: ...
+    async def send(self, message: EmailMessage) -> None:
+        """Deliver ``message`` via this backend's transport."""
 
 
 # -----------------------------------------------------------------------------

--- a/backend/app/services/app_config.py
+++ b/backend/app/services/app_config.py
@@ -51,6 +51,9 @@ def _atrium_version() -> str:
     try:
         return _metadata.version("atrium-backend")
     except _metadata.PackageNotFoundError:
+        # The package isn't installed in editable mode (typical for
+        # the dev container) — fall through to reading pyproject.toml
+        # directly so we still surface a real version string.
         pass
     try:
         pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
@@ -59,6 +62,9 @@ def _atrium_version() -> str:
         if isinstance(version, str) and version:
             return version
     except (OSError, KeyError, tomllib.TOMLDecodeError):
+        # pyproject.toml may not exist in the runtime image (it's
+        # only in source checkouts). Both branches failing is fine —
+        # ``unknown`` is the documented sentinel.
         pass
     return "unknown"
 

--- a/examples/hello-world/backend/alembic/env.py
+++ b/examples/hello-world/backend/alembic/env.py
@@ -26,12 +26,14 @@ from sqlalchemy import pool
 from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
-# Imports the model module so HostBase.metadata is populated before
-# autogenerate runs.
-import atrium_hello_world.models  # noqa: F401
 from alembic import context
 from app.host_sdk.alembic import emit_host_foreign_keys
 from app.settings import get_settings
+
+# ``HostBase`` is the metadata target; importing it from
+# ``atrium_hello_world.models`` also runs the package's ``__init__``,
+# which registers every model class on ``HostBase.metadata`` before
+# autogenerate inspects it.
 from atrium_hello_world.models import HostBase
 
 VERSION_TABLE = "alembic_version_app"

--- a/packages/create-atrium-host/src/cli.js
+++ b/packages/create-atrium-host/src/cli.js
@@ -12,7 +12,7 @@
 // the baseline).
 
 import { fileURLToPath } from 'node:url';
-import { dirname, join, resolve, isAbsolute } from 'node:path';
+import { dirname, resolve, isAbsolute } from 'node:path';
 import { stat } from 'node:fs/promises';
 
 import kleur from 'kleur';

--- a/packages/create-atrium-host/template/backend/alembic/env.py
+++ b/packages/create-atrium-host/template/backend/alembic/env.py
@@ -22,12 +22,14 @@ from sqlalchemy import pool
 from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
-# Import the model module so HostBase.metadata is populated before
-# autogenerate runs.
-import __HOST_PKG__.models  # noqa: F401
 from alembic import context
 from app.host_sdk.alembic import emit_host_foreign_keys
 from app.settings import get_settings
+
+# ``HostBase`` is the metadata target; importing it from
+# ``__HOST_PKG__.models`` also runs the package's ``__init__``, which
+# registers every model class on ``HostBase.metadata`` before
+# autogenerate inspects it.
 from __HOST_PKG__.models import HostBase
 
 VERSION_TABLE = "alembic_version_app"


### PR DESCRIPTION
## Summary
Closes the eight low-severity ``security-and-quality`` findings on
master that aren't security alerts but cleaning them up gets the
code-scanning surface to zero.

- ``backend/app/auth/users.py`` + ``backend/app/services/app_config.py``:
  document two ``except: pass`` clauses with their fail-open rationale
  (alerts #6, #32).
- ``backend/app/email/backend.py``: replace the ``...`` Protocol body
  with a one-line docstring — CodeQL doesn't model ``...`` as a valid
  Protocol method body (alert #28).
- Alembic ``env.py`` files: collapse the duplicate ``import X`` +
  ``from X import Y`` pattern into a single ``from`` import; the
  ``__init__`` side-effect runs either way (alerts #4, #29, #31).
- ``backend/alembic/env.py``: keep the ``import app.models``
  side-effect (its ``__init__`` registers every model on
  ``Base.metadata``) and reference it explicitly with ``_ = app.models``
  so ``py/unused-import`` understands the intent (alert #30).
- ``packages/create-atrium-host/src/cli.js``: drop the unused ``join``
  import — line 196's ``.join(' ')`` is ``Array.prototype.join``, not
  ``node:path``'s ``join`` (alert #5).

## Test plan
- [x] ``ruff check`` clean
- [x] Backend modules import cleanly
- [x] ``node --test`` passes for the scaffolder
- [ ] CI green
- [ ] CodeQL re-scan reports the eight alerts as fixed