### PR TITLE
Release v0.15.2: fix host-bundle-utils useMe() default 404 (#72)

### DIFF
--- a/docs/published-images.md
+++ b/docs/published-images.md
@@ -512,7 +512,7 @@ function CommissionsPage() {
 function App() {
   return (
     <QueryClientProvider client={hostQueryClient}>
-      <AtriumProvider apiBase="/api">
+      <AtriumProvider>
         <CommissionsPage />
       </AtriumProvider>
     </QueryClientProvider>

--- a/packages/host-bundle-utils/README.md
+++ b/packages/host-bundle-utils/README.md
@@ -79,7 +79,7 @@ function CommissionsPage() {
 function App() {
   return (
     <QueryClientProvider client={hostQueryClient}>
-      <AtriumProvider apiBase="/api">
+      <AtriumProvider>
         <CommissionsPage />
       </AtriumProvider>
     </QueryClientProvider>
@@ -87,10 +87,13 @@ function App() {
 }
 ```
 
-`<AtriumProvider>` reads from your existing `<QueryClientProvider>`
-by default — no second QueryClient. Pass `client={hostQueryClient}`
-to wrap one inline; pass `fetchUserContext={...}` to inject a custom
-fetcher (useful for tests or hosts that want axios-shaped retry).
+The hooks fetch atrium's fixed same-origin `/users/me/context`
+endpoint — no path is configurable, since a host bundle loads inside
+atrium's SPA and hits the same origin. `<AtriumProvider>` reads from
+your existing `<QueryClientProvider>` by default — no second
+QueryClient. Pass `client={hostQueryClient}` to wrap one inline; pass
+`fetchUserContext={...}` to inject a custom fetcher (useful for tests
+or hosts that want axios-shaped retry).
 
 ## Versioning
 

--- a/packages/host-bundle-utils/src/react/index.ts
+++ b/packages/host-bundle-utils/src/react/index.ts
@@ -7,9 +7,13 @@
  * One TanStack Query subscription serves the whole host tree:
  * `useMe()` fetches `/users/me/context` once and shares the result
  * with every `usePerm()`, `useRole()`, and `useUserContext()` caller.
- * The hooks read the API base URL from `<AtriumProvider>` (default
- * `'/api'`) so a host serving its bundle on a different prefix can
- * point them at the right origin without forking the package.
+ *
+ * The endpoint path is fixed by atrium — it's mounted at the SPA root
+ * by `app.include_router(me_context_router)` and served from the same
+ * origin as the bundle. There's no `apiBase` prop because there's
+ * nothing for the host to configure: a host bundle that loads inside
+ * atrium's SPA fetches a same-origin relative path. Hosts that want
+ * to layer their own retry / headers / mock can pass `fetchUserContext`.
  *
  * The hooks reuse the host's enclosing `<QueryClientProvider>` if one
  * is already mounted; pass `client={hostQueryClient}` to
@@ -39,23 +43,20 @@ export type { UserContext } from '@brendanbank/atrium-host-types';
 export { __atrium_t__ } from '../i18n';
 
 interface AtriumContextValue {
-  apiBase: string;
   fetchUserContext: () => Promise<UserContext | null>;
 }
 
-const DEFAULT_API_BASE = '/api';
+const ME_CONTEXT_PATH = '/users/me/context';
 
-async function defaultFetchUserContext(
-  apiBase: string,
-): Promise<UserContext | null> {
-  const res = await fetch(`${apiBase}/users/me/context`, {
+async function defaultFetchUserContext(): Promise<UserContext | null> {
+  const res = await fetch(ME_CONTEXT_PATH, {
     credentials: 'include',
     headers: { Accept: 'application/json' },
   });
   if (res.status === 401 || res.status === 403) return null;
   if (!res.ok) {
     const body = await res.text().catch(() => '');
-    throw new Error(`/users/me/context: ${res.status} ${body}`.trim());
+    throw new Error(`${ME_CONTEXT_PATH}: ${res.status} ${body}`.trim());
   }
   return (await res.json()) as UserContext;
 }
@@ -63,10 +64,6 @@ async function defaultFetchUserContext(
 const AtriumContext = createContext<AtriumContextValue | null>(null);
 
 export interface AtriumProviderProps {
-  /** API base URL the hooks prefix on every fetch. Default `'/api'` —
-   *  matches atrium's convention of mounting the API behind `/api/*`
-   *  on the same origin as the SPA. */
-  apiBase?: string;
   /** Optional TanStack QueryClient. When supplied the provider wraps
    *  children in a `<QueryClientProvider>`; otherwise the hooks
    *  inherit the caller's enclosing one. Use this only when the host
@@ -80,20 +77,19 @@ export interface AtriumProviderProps {
   children: ReactNode;
 }
 
-/** Provider that supplies `apiBase` and (optionally) a QueryClient
- *  to the atrium hooks below. Hosts that already wrap their tree in
- *  `<QueryClientProvider>` can omit `client` — the hooks use the
+/** Provider that supplies the atrium hooks below with their fetcher
+ *  and (optionally) a QueryClient. Hosts that already wrap their tree
+ *  in `<QueryClientProvider>` can omit `client` — the hooks use the
  *  caller's existing QueryClient. */
 export function AtriumProvider({
-  apiBase = DEFAULT_API_BASE,
   client,
   fetchUserContext,
   children,
 }: AtriumProviderProps) {
-  const value = useMemo<AtriumContextValue>(() => {
-    const fetcher = fetchUserContext ?? (() => defaultFetchUserContext(apiBase));
-    return { apiBase, fetchUserContext: fetcher };
-  }, [apiBase, fetchUserContext]);
+  const value = useMemo<AtriumContextValue>(
+    () => ({ fetchUserContext: fetchUserContext ?? defaultFetchUserContext }),
+    [fetchUserContext],
+  );
 
   const inner = createElement(AtriumContext.Provider, { value }, children);
 
@@ -110,15 +106,12 @@ export const ME_QUERY_KEY = ['atrium', 'me'] as const;
 
 // Module-level fallback so hooks work without an explicit
 // `<AtriumProvider>` — convenient for hosts that don't need to
-// override the API base or the fetcher. Lazily-allocated so the
-// import has no side effects.
+// override the fetcher. Lazily-allocated so the import has no side
+// effects.
 let DEFAULT_CTX: AtriumContextValue | null = null;
 function defaultCtx(): AtriumContextValue {
   if (!DEFAULT_CTX) {
-    DEFAULT_CTX = {
-      apiBase: DEFAULT_API_BASE,
-      fetchUserContext: () => defaultFetchUserContext(DEFAULT_API_BASE),
-    };
+    DEFAULT_CTX = { fetchUserContext: defaultFetchUserContext };
   }
   return DEFAULT_CTX;
 }

--- a/packages/host-bundle-utils/test/useMe.test.tsx
+++ b/packages/host-bundle-utils/test/useMe.test.tsx
@@ -29,7 +29,7 @@ const ALICE: UserContext = {
 };
 
 const server = setupServer(
-  http.get('/api/users/me/context', () => HttpResponse.json(ALICE)),
+  http.get('/users/me/context', () => HttpResponse.json(ALICE)),
 );
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
@@ -102,7 +102,7 @@ describe('useMe', () => {
 
   test('returns null when atrium responds 401', async () => {
     server.use(
-      http.get('/api/users/me/context', () => new HttpResponse(null, { status: 401 })),
+      http.get('/users/me/context', () => new HttpResponse(null, { status: 401 })),
     );
     render(withProviders(<MeProbe />));
     await waitFor(() =>
@@ -113,7 +113,7 @@ describe('useMe', () => {
   test('shares one query subscription across hooks', async () => {
     let calls = 0;
     server.use(
-      http.get('/api/users/me/context', () => {
+      http.get('/users/me/context', () => {
         calls += 1;
         return HttpResponse.json(ALICE);
       }),
@@ -183,24 +183,26 @@ describe('useRole', () => {
 });
 
 describe('AtriumProvider', () => {
-  test('apiBase override changes the fetch URL', async () => {
+  test('fetches the same-origin /users/me/context (no /api prefix)', async () => {
+    // Atrium mounts /users/me/context at the SPA root — hosts loaded
+    // inside atrium's SPA fetch a same-origin relative path. The
+    // package must not prefix it (issue #72).
     let hit = false;
     server.use(
-      http.get('/v2/users/me/context', () => {
+      http.get('/users/me/context', () => {
         hit = true;
-        return HttpResponse.json({ ...ALICE, email: 'v2@example.com' });
+        return HttpResponse.json(ALICE);
       }),
+      http.get('/api/users/me/context', () =>
+        HttpResponse.json(
+          { detail: 'wrong path — apiBase prefix should not be applied' },
+          { status: 404 },
+        ),
+      ),
     );
-    const client = makeClient();
-    render(
-      <QueryClientProvider client={client}>
-        <AtriumProvider apiBase="/v2">
-          <MeProbe />
-        </AtriumProvider>
-      </QueryClientProvider>,
-    );
+    render(withProviders(<MeProbe />));
     await waitFor(() =>
-      expect(screen.getByTestId('email').textContent).toBe('v2@example.com'),
+      expect(screen.getByTestId('email').textContent).toBe('alice@example.com'),
     );
     expect(hit).toBe(true);
   });


### PR DESCRIPTION
Closes #72. Cuts atrium v0.15.2 — a single-fix patch release.

## Summary

- **Fix the bug**: drop `apiBase` from `<AtriumProvider>` and hard-code `/users/me/context` as a same-origin relative path. Atrium mounts `me_context_router` at the SPA root with no app-level prefix, and the merged backend+frontend image serves both from one origin — the `'/api'` default produced `GET /api/users/me/context` → 404, which made `useMe()` throw and `usePerm()` silently default-deny every code.
- **`fetchUserContext` override stays** as the real escape hatch for tests and axios-shaped retry. `apiBase` was a knob with no legitimate value to set: the path is fixed by atrium, not by the host.
- **Test coverage**: replace the "apiBase override changes the fetch URL" test with a regression test that 404s `/api/users/me/context` and asserts the unprefixed path is hit.
- **Docs**: drop `apiBase="/api"` from README + `docs/published-images.md` and explain why the path is fixed. New row in `docs/compat-matrix.md` captures the fix and flags the breaking prop removal.
- **Version bump (RELEASING.md step 1.5)**: `backend/pyproject.toml`, `host-types`, `host-bundle-utils`, `test-utils`, `create-atrium-host` all to 0.15.2 in lockstep. `uv.lock` + `pnpm-lock.yaml` refreshed. `DEFAULT_ATRIUM_VERSION` stays at `0.15` (still major.minor).

This is a TypeScript-breaking change to `<AtriumProvider>`'s prop surface (removes `apiBase`), but the only known consumer is `atrium-casa-bookings#9 phase 2`, which deferred adoption pending this fix.

## Test plan

- [x] `pnpm -r build` — all packages
- [x] `pnpm -r typecheck` — host-bundle-utils + hello-world + others
- [x] `pnpm -r test` — host-bundle-utils 26/26, hello-world frontend 2/2, test-utils 18/18, create-atrium-host 16/16
- [ ] `make test-backend` — version bump only, but RELEASING.md asks for full pre-flight
- [ ] `make test-frontend`
- [ ] `make smoke`