### PR TITLE
ci: skip hello-world-e2e when PR does not touch the published-image surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,44 @@ permissions:
   contents: read
 
 jobs:
+  # Detects whether the PR touches the published-image extension
+  # surface that ``hello-world-e2e`` exercises. Conservative scope:
+  # anything baked into the runtime image (``Dockerfile`` lines
+  # 86-111 — backend source, uv venv, the SPA bundle) plus the
+  # example itself. Excludes test directories, the scaffolder, infra
+  # configs not in the image, and sibling workflow files. The
+  # workflow-level ``paths-ignore`` already handles doc-only PRs at
+  # trigger time; this filter is the per-job complement.
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      hello-world: ${{ steps.filter.outputs.hello-world }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
+        id: filter
+        with:
+          filters: |
+            hello-world:
+              - 'backend/app/**'
+              - 'backend/alembic/**'
+              - 'backend/pyproject.toml'
+              - 'backend/uv.lock'
+              - 'frontend/src/**'
+              - 'frontend/package.json'
+              - 'frontend/pnpm-lock.yaml'
+              - 'frontend/vite.config.ts'
+              - 'frontend/tsconfig*.json'
+              - 'frontend/index.html'
+              - 'examples/hello-world/**'
+              - 'Dockerfile'
+              - 'docker-compose.yml'
+              - '.github/workflows/ci.yml'
+
   # Backend pytest is sharded for parallel CI. ``backend-core`` runs
   # unit + integration + healthz (~41 tests) and ruff. ``backend-api``
   # runs the HTTP / fastapi-users flows (~154 tests) split across an
@@ -358,6 +396,15 @@ jobs:
     #
     # Uses the example's self-contained compose.yaml (atrium image +
     # host extension built locally on top, plain HTTP on :8000).
+    #
+    # Skipped via the ``changes`` job's path filter when the PR
+    # doesn't touch the runtime image or the example. master is not
+    # a protected branch with required checks today, so a skipped
+    # job is a clean "neutral" — no aggregator-job dance needed. If
+    # branch protection is added later, gate ``hello-world-e2e`` via
+    # an always-runs aggregator instead of marking this job required.
+    needs: changes
+    if: needs.changes.outputs.hello-world == 'true'
     runs-on: ubuntu-latest
     env:
       E2E_BASE_URL: http://localhost:8000


### PR DESCRIPTION
## Summary

- Adds a `changes` job using `dorny/paths-filter@v4.0.1` (SHA-pinned) that detects whether a PR touches the published-image extension surface.
- Gates `hello-world-e2e` on that output: skipped on test-only / scaffolder-only / infra-only / sibling-workflow-only PRs (~10 min wallclock saved on those).
- The workflow-level `paths-ignore` (`**.md`, `docs/**`, `LICENCE.md`) is unchanged — it still gates the entire workflow at trigger time. The new filter is the per-job complement for code-only PRs.

## Filter scope

Conservative — anything baked into the runtime image (per `Dockerfile` lines 86-111) or the example itself triggers the job:

- `backend/app/**`, `backend/alembic/**`, `backend/pyproject.toml`, `backend/uv.lock`
- `frontend/src/**`, `frontend/package.json`, `frontend/pnpm-lock.yaml`, `frontend/vite.config.ts`, `frontend/tsconfig*.json`, `frontend/index.html`
- `examples/hello-world/**`
- `Dockerfile`, `docker-compose.yml`, `.github/workflows/ci.yml`

What's *excluded* (the savings): `backend/tests/**`, `frontend/tests-e2e/**`, `packages/create-atrium-host/**`, `infra/**`, `.github/workflows/{codeql,security,publish-images,release}.yml`.

## Branch protection note

`master` is not protected today, so a skipped job is a clean neutral and no aggregator-job dance is needed. The new comment in the file flags the standard always-runs aggregator pattern to apply if branch protection with required checks is added later.

## Test plan

- [x] Self-test on this PR: it touches `.github/workflows/ci.yml`, which IS in the filter, so `hello-world-e2e` should run to completion (the positive case).
- [ ] Follow-up validation: open a draft PR that only touches `backend/tests/test_healthz.py` (or similar test-only file). Expected: `changes` job runs, outputs `hello-world: false`, `hello-world-e2e` is skipped while every other job runs.
- [x] `actionlint` passes for the new job. (Two pre-existing SC2034 warnings on unchanged wait-for-API loops are not introduced by this change.)