### PR TITLE
test: validate hello-world-e2e path-filter skip path

### DIFF
--- a/backend/tests/test_healthz.py
+++ b/backend/tests/test_healthz.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 async def test_healthz_ok(client):
+    """Smoke check for the /healthz liveness probe."""
     r = await client.get("/healthz")
     assert r.status_code == 200
     assert r.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary

Validation-only PR for #75. Targets the **`gate-hello-world-e2e`** branch (not `master`) so the diff is just the test docstring change — no workflow file in the diff.

Expected CI behaviour on this PR (using the workflow from `gate-hello-world-e2e`, which has the path filter):

- `changes` job runs and outputs `hello-world: false`.
- `hello-world-e2e` is **skipped**.
- `backend-core`, `backend-api`, `frontend`, `scaffolder`, `e2e` all run as normal.

If that's what we see, the filter is working — close this PR without merging (it's just a probe). If `hello-world-e2e` *does* run on this PR, the filter is misconfigured and we need to fix #75 before merging.

## Test plan

- [ ] On the GitHub Actions tab for this PR, confirm `hello-world-e2e` shows as "Skipped".
- [ ] Confirm `changes` ran and shows `hello-world: false` in its output.
- [ ] Confirm every other job ran normally (no false-skip elsewhere).