### PR TITLE
ci(publish-images): fix SPA verify path

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -103,18 +103,28 @@ jobs:
       - name: Verify SPA bundle bakes /api prefix
         if: matrix.platform == 'linux/amd64'
         run: |
+          # ``--output type=local`` exports the full filesystem of the
+          # target stage, so the bundle lands at ``app/dist/assets/...``
+          # (mirroring the Dockerfile's ``WORKDIR /app``), not
+          # ``dist/assets/...``. ``find`` keeps the check robust to
+          # future workdir changes.
           docker buildx build \
             --target frontend-builder \
             --build-arg VITE_API_BASE_URL=/api \
             --output type=local,dest=/tmp/spa-check \
             --cache-from type=gha,scope=runtime-${{ env.PLATFORM_PAIR }} \
             .
-          bundle=$(ls /tmp/spa-check/dist/assets/index-*.js | head -1)
+          bundle=$(find /tmp/spa-check -path '*/dist/assets/index-*.js' -type f | head -1)
+          if [ -z "$bundle" ]; then
+            echo "::error::SPA bundle file not found in /tmp/spa-check — exporter layout changed?" >&2
+            find /tmp/spa-check -maxdepth 4 -type d | head -20 >&2
+            exit 1
+          fi
           if ! grep -q '/api' "$bundle"; then
             echo "::error::SPA bundle does not contain /api — VITE_API_BASE_URL build arg lost (issue #91)" >&2
             exit 1
           fi
-          echo "SPA bundle contains /api prefix ($(basename "$bundle"))"
+          echo "SPA bundle contains /api prefix ($bundle)"
 
       - name: Build and push by digest
         id: build


### PR DESCRIPTION
## Summary

The verification step added in v0.19.1's publish workflow used `--output type=local`, which exports the full stage filesystem rooted at the Dockerfile's `/` — so the SPA bundle lands at `/tmp/spa-check/app/dist/assets/...` (matching `WORKDIR /app` in frontend-builder), not `/tmp/spa-check/dist/assets/...`.

The v0.19.1 publish job self-failed on its own guard:
```
ls: cannot access '/tmp/spa-check/dist/assets/index-*.js': No such file or directory
SPA bundle does not contain /api — VITE_API_BASE_URL build arg lost (issue #91)
```

The fix swaps `ls` for `find -path '*/dist/assets/index-*.js'` so the check is robust to the workdir layout. The `if -z` early-exit also prints the export's directory structure so a future structural change is diagnosable from the failure log.

After this lands I'll re-dispatch publish-images against the existing `v0.19.1` tag — `workflow_dispatch` always runs from master's workflow file but checks out the input ref, so the fixed verify step will guard the v0.19.1 source.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: dispatch publish-images.yml with `ref=v0.19.1`, confirm verify step passes and digests push
- [ ] After publish: pull `ghcr.io/brendanbank/atrium:0.19.1`, grep bundle for `/api`, run the stack, hard-reload `/admin/audit`