### PR TITLE
test(smoke-extended): cover every admin tab + 3 product fixes

### DIFF
--- a/backend/alembic/versions/2026_04_30_0007-0007_password_reset_fallback_url.py
+++ b/backend/alembic/versions/2026_04_30_0007-0007_password_reset_fallback_url.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Add a paste-able fallback URL line to the password_reset template.
+
+Revision ID: 0007_password_reset_fallback_url
+Revises: 0006_email_outbox_perm
+Create Date: 2026-04-30
+
+The default ``password_reset`` template's body_html embedded the
+reset URL only inside an ``<a href="{{ reset_url }}">…</a>`` anchor.
+``send_and_log`` derives the plain-text alternative by stripping
+tags, so the URL never reached the plaintext body — readers on
+text-only mail clients saw "Click here to set a new password" with
+no destination, and the e2e suite couldn't scrape the token from
+the console mail backend's stdout capture.
+
+This mirrors the ``email_verify`` template (added in 0004) which
+already carries a small "Or paste this link" fallback line outside
+the anchor for the same reasons.
+
+Updates all four seeded locales (en / nl / de / fr).
+
+Idempotent via ``UPDATE ... WHERE body_html LIKE ...``: re-running on
+an already-patched DB is a no-op because the LIKE clause won't match
+the patched rows. Downgrade restores the original anchor-only body.
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0007_password_reset_fallback_url"
+down_revision = "0006_email_outbox_perm"
+branch_labels = None
+depends_on = None
+
+
+# (locale, original anchor-only body, patched body with fallback)
+_LOCALES = (
+    (
+        "en",
+        (
+            "<p>Hello {{ recipient.full_name }},</p>"
+            "<p>You requested a password reset. "
+            "<a href=\"{{ reset_url }}\">Click here to set a new password</a>.</p>"
+            "<p>If you didn't request this, you can ignore this email.</p>"
+        ),
+        (
+            "<p>Hello {{ recipient.full_name }},</p>"
+            "<p>You requested a password reset. "
+            "<a href=\"{{ reset_url }}\">Click here to set a new password</a>.</p>"
+            "<p style=\"font-size:12px;color:#666\">"
+            "Or paste this link: {{ reset_url }}"
+            "</p>"
+            "<p>If you didn't request this, you can ignore this email.</p>"
+        ),
+    ),
+    (
+        "nl",
+        (
+            "<p>Hallo {{ recipient.full_name }},</p>"
+            "<p>Je hebt een wachtwoordreset aangevraagd. "
+            "<a href=\"{{ reset_url }}\">Klik hier om een nieuw wachtwoord "
+            "in te stellen</a>.</p>"
+            "<p>Als je dit niet hebt aangevraagd, kun je deze e-mail negeren.</p>"
+        ),
+        (
+            "<p>Hallo {{ recipient.full_name }},</p>"
+            "<p>Je hebt een wachtwoordreset aangevraagd. "
+            "<a href=\"{{ reset_url }}\">Klik hier om een nieuw wachtwoord "
+            "in te stellen</a>.</p>"
+            "<p style=\"font-size:12px;color:#666\">"
+            "Of plak deze link: {{ reset_url }}"
+            "</p>"
+            "<p>Als je dit niet hebt aangevraagd, kun je deze e-mail negeren.</p>"
+        ),
+    ),
+    (
+        "de",
+        (
+            "<p>Hallo {{ recipient.full_name }},</p>"
+            "<p>Du hast eine Passwortzurucksetzung angefordert. "
+            "<a href=\"{{ reset_url }}\">Hier klicken, um ein neues Passwort "
+            "festzulegen</a>.</p>"
+            "<p>Falls du das nicht angefordert hast, kannst du diese E-Mail "
+            "ignorieren.</p>"
+        ),
+        (
+            "<p>Hallo {{ recipient.full_name }},</p>"
+            "<p>Du hast eine Passwortzurucksetzung angefordert. "
+            "<a href=\"{{ reset_url }}\">Hier klicken, um ein neues Passwort "
+            "festzulegen</a>.</p>"
+            "<p style=\"font-size:12px;color:#666\">"
+            "Oder diesen Link einfugen: {{ reset_url }}"
+            "</p>"
+            "<p>Falls du das nicht angefordert hast, kannst du diese E-Mail "
+            "ignorieren.</p>"
+        ),
+    ),
+    (
+        "fr",
+        (
+            "<p>Bonjour {{ recipient.full_name }},</p>"
+            "<p>Vous avez demande la reinitialisation de votre mot de passe. "
+            "<a href=\"{{ reset_url }}\">Cliquez ici pour definir un nouveau "
+            "mot de passe</a>.</p>"
+            "<p>Si vous n'avez pas fait cette demande, ignorez cet e-mail.</p>"
+        ),
+        (
+            "<p>Bonjour {{ recipient.full_name }},</p>"
+            "<p>Vous avez demande la reinitialisation de votre mot de passe. "
+            "<a href=\"{{ reset_url }}\">Cliquez ici pour definir un nouveau "
+            "mot de passe</a>.</p>"
+            "<p style=\"font-size:12px;color:#666\">"
+            "Ou copiez ce lien : {{ reset_url }}"
+            "</p>"
+            "<p>Si vous n'avez pas fait cette demande, ignorez cet e-mail.</p>"
+        ),
+    ),
+)
+
+
+def upgrade() -> None:
+    for locale, original, patched in _LOCALES:
+        op.execute(
+            """
+            UPDATE email_templates
+            SET body_html = :patched
+            WHERE `key` = 'password_reset'
+              AND locale = :locale
+              AND body_html = :original
+            """.replace(":patched", _q(patched))
+                .replace(":locale", _q(locale))
+                .replace(":original", _q(original))
+        )
+
+
+def downgrade() -> None:
+    for locale, original, patched in _LOCALES:
+        op.execute(
+            """
+            UPDATE email_templates
+            SET body_html = :original
+            WHERE `key` = 'password_reset'
+              AND locale = :locale
+              AND body_html = :patched
+            """.replace(":original", _q(original))
+                .replace(":locale", _q(locale))
+                .replace(":patched", _q(patched))
+        )
+
+
+def _q(value: str) -> str:
+    """Inline a string literal for op.execute. MySQL backslash + single
+    quote are the only escapes we need; the bodies don't carry either
+    in their raw form."""
+    return "'" + value.replace("\\", "\\\\").replace("'", "''") + "'"

--- a/backend/app/api/reminder_rules.py
+++ b/backend/app/api/reminder_rules.py
@@ -35,7 +35,16 @@ async def list_rules(
 
 
 async def _check_template_exists(session: AsyncSession, key: str) -> None:
-    if (await session.get(EmailTemplate, key)) is None:
+    # ``email_templates`` has a composite primary key ``(key, locale)``
+    # since 0005, so ``session.get(EmailTemplate, key)`` raises. Probe
+    # for any locale variant — the reminder rule references the key
+    # only; the per-locale resolution happens at render time.
+    row = await session.execute(
+        select(EmailTemplate.key)
+        .where(EmailTemplate.key == key)
+        .limit(1)
+    )
+    if row.scalar_one_or_none() is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"email template '{key}' does not exist",

--- a/backend/app/email/sender.py
+++ b/backend/app/email/sender.py
@@ -54,7 +54,16 @@ _FALLBACK_LOCALE = "en"
 
 
 def _html_to_text(html: str) -> str:
-    """Coarse HTML to text for the plain-text alternative."""
+    """Coarse HTML to text for the plain-text alternative.
+
+    Tag-stripping is destructive — an ``<a href="X">Y</a>`` becomes
+    ``Y`` with the URL gone. Templates whose plaintext alternative
+    needs the URL surfaced should follow the ``email_verify`` pattern
+    and include a paste-able ``{{ url }}`` line outside the anchor:
+
+        <a href="{{ url }}">Click here</a>
+        <p>Or paste this link: {{ url }}</p>
+    """
     text = _BREAK_RE.sub("\n", html)
     text = _TAG_RE.sub("", text)
     text = unescape(text)

--- a/backend/app/schemas/reminder_rule.py
+++ b/backend/app/schemas/reminder_rule.py
@@ -2,25 +2,26 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from datetime import datetime
-from typing import Literal
 
 from pydantic import BaseModel, Field
 
-ReminderKind = Literal["down_payment", "final_payment", "option_expiry", "other"]
-ReminderAnchor = Literal[
-    "booking_creation",
-    "booking_arrival",
-    "booking_departure",
-    "option_expiry",
-]
+# ``kind`` and ``anchor`` are free-form strings: atrium ships only the
+# storage + admin UI; the host app decides what valid anchors / kinds
+# are and writes the logic that turns a rule into a scheduled job.
+# (CLAUDE.md, "Scheduled jobs" section.)
+#
+# Earlier revisions of this file constrained both fields with
+# ``Literal[...]`` enums baked from one specific host app's domain
+# (booking_arrival / down_payment / etc.). That broke the documented
+# free-form contract and 422'd every create from the admin UI.
 
 
 class ReminderRuleRead(BaseModel):
     id: int
     name: str
     template_key: str
-    kind: ReminderKind
-    anchor: ReminderAnchor
+    kind: str
+    anchor: str
     days_offset: int
     active: bool
     created_at: datetime
@@ -32,8 +33,8 @@ class ReminderRuleRead(BaseModel):
 class ReminderRuleCreate(BaseModel):
     name: str = Field(min_length=1, max_length=100)
     template_key: str
-    kind: ReminderKind
-    anchor: ReminderAnchor
+    kind: str = Field(default="", max_length=50)
+    anchor: str = Field(min_length=1, max_length=50)
     days_offset: int = Field(ge=-365, le=365)
     active: bool = True
 
@@ -41,7 +42,7 @@ class ReminderRuleCreate(BaseModel):
 class ReminderRuleUpdate(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=100)
     template_key: str | None = None
-    kind: ReminderKind | None = None
-    anchor: ReminderAnchor | None = None
+    kind: str | None = Field(default=None, max_length=50)
+    anchor: str | None = Field(default=None, min_length=1, max_length=50)
     days_offset: int | None = Field(default=None, ge=-365, le=365)
     active: bool | None = None

--- a/frontend/src/components/admin/RemindersAdmin.tsx
+++ b/frontend/src/components/admin/RemindersAdmin.tsx
@@ -88,11 +88,20 @@ function RuleFormModal({
       notifications.show({ color: 'teal', message: t('reminders.saved') });
       onClose();
     } catch (err) {
-      const resp = (err as { response?: { data?: { detail?: string } } }).response;
-      notifications.show({
-        color: 'red',
-        message: resp?.data?.detail ?? t('admin.saveFailed'),
-      });
+      const resp = (err as { response?: { data?: { detail?: unknown } } }).response;
+      // ``detail`` is a string for app-raised HTTPException (the common
+      // case) but a list of validation-error objects on a 422 from
+      // FastAPI / Pydantic. Mantine's Notification renders ``message``
+      // as a React child, so passing a non-string crashes the page
+      // (React error #31). Coerce to a string.
+      const detail = resp?.data?.detail;
+      const message =
+        typeof detail === 'string'
+          ? detail
+          : Array.isArray(detail)
+            ? detail.map((d) => (typeof d === 'object' && d !== null && 'msg' in d ? String((d as { msg: unknown }).msg) : String(d))).join('; ')
+            : t('admin.saveFailed');
+      notifications.show({ color: 'red', message });
     }
   });
 
@@ -113,7 +122,14 @@ function RuleFormModal({
           <Select
             label={t('reminders.template')}
             required
-            data={templates.map((t_) => ({ value: t_.key, label: t_.key }))}
+            // ``email_templates`` carries one row per (key, locale)
+            // since 0005 — the Select keys on ``template_key`` only, so
+            // collapse duplicates here. Mantine v9 throws "Duplicate
+            // options are not supported" if the same value appears
+            // twice in ``data``, which would page-error the modal.
+            data={Array.from(new Set(templates.map((t_) => t_.key)))
+              .sort()
+              .map((key) => ({ value: key, label: key }))}
             searchable
             {...form.getInputProps('template_key')}
           />

--- a/frontend/tests-e2e/audit-admin.spec.ts
+++ b/frontend/tests-e2e/audit-admin.spec.ts
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+import { expect, test } from '@playwright/test';
+
+import {
+  API_URL,
+  createAndEnrolUserViaApi,
+  loginAsSuperAdmin,
+} from './helpers';
+
+/**
+ * AuditAdmin (`/admin/audit`) coverage. The audit *write* paths are
+ * exercised everywhere — every admin mutation lands a row. This spec
+ * proves the read UI: rows render, the entity filter narrows the
+ * query, and clicking a row with a diff expands the JSON.
+ */
+
+const adminEmail = process.env.E2E_ADMIN_EMAIL;
+const adminPassword = process.env.E2E_ADMIN_PASSWORD;
+const adminTotpSecret = process.env.E2E_ADMIN_TOTP_SECRET;
+
+const haveSmokeEnv = Boolean(adminEmail && adminPassword && adminTotpSecret);
+
+test.skip(
+  !haveSmokeEnv,
+  'E2E_ADMIN_EMAIL / E2E_ADMIN_PASSWORD / E2E_ADMIN_TOTP_SECRET must be set (run via `make smoke`).',
+);
+
+test.describe('Audit admin', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('admin can view + filter the activity log', async ({ browser }) => {
+    const adminContext = await browser.newContext();
+    const adminPage = await adminContext.newPage();
+    await loginAsSuperAdmin(adminPage);
+
+    // Generate a known audit row: provisioning a fresh user via the
+    // invite flow writes ``user`` + ``invite`` rows we can grep for.
+    const userContext = await browser.newContext();
+    await createAndEnrolUserViaApi(adminPage.request, userContext.request);
+    await userContext.close();
+
+    try {
+      await adminPage.goto('/admin/audit');
+      await expect(
+        adminPage.getByRole('heading', { name: /activity log/i }),
+      ).toBeVisible();
+
+      // Fresh deployment has at least the seed rows (e.g. role
+      // assignments, invite creates) plus the user we just provisioned
+      // — the empty-state copy should not be visible.
+      await expect(adminPage.getByText(/no activity recorded/i)).toHaveCount(
+        0,
+      );
+
+      // Filter to ``user`` entity. The endpoint hits
+      // /admin/audit?entity=user; assert via the API that the
+      // result set is non-empty and every entry's entity matches.
+      await adminPage
+        .getByPlaceholder(/filter by entity/i)
+        .fill('user');
+
+      await expect
+        .poll(async () => {
+          const resp = await adminPage.request.get(
+            `${API_URL}/admin/audit?entity=user&limit=10`,
+          );
+          if (!resp.ok()) return null;
+          const body = (await resp.json()) as {
+            items: Array<{ entity: string }>;
+          };
+          return body.items.length > 0 &&
+            body.items.every((it) => it.entity === 'user');
+        })
+        .toBe(true);
+
+      // The visible table now only contains ``user`` rows. Pick any
+      // visible row and verify the entity column carries the prefix.
+      const firstRow = adminPage.locator('tbody tr').first();
+      await expect(firstRow).toContainText(/user #\d+/);
+    } finally {
+      await adminContext.close();
+    }
+  });
+
+  test('admin can expand a row to inspect the JSON diff', async ({
+    browser,
+  }) => {
+    const adminContext = await browser.newContext();
+    const adminPage = await adminContext.newPage();
+    await loginAsSuperAdmin(adminPage);
+
+    // Trigger an admin write that lands an audit row with a non-null
+    // diff: PUT brand config with a known field.
+    const probe = `audit-spec-${Date.now()}`;
+    const cur = await adminPage.request.get(`${API_URL}/admin/app-config`);
+    const curBody = (await cur.json()) as { brand?: Record<string, unknown> };
+    await adminPage.request.put(`${API_URL}/admin/app-config/brand`, {
+      data: { ...(curBody.brand ?? {}), name: probe },
+    });
+
+    try {
+      await adminPage.goto('/admin/audit');
+      // Filter to app_setting so the freshly-written row floats up.
+      await adminPage
+        .getByPlaceholder(/filter by entity/i)
+        .fill('app_setting');
+
+      // Wait for at least one row to land in the filtered view.
+      const firstRow = adminPage.locator('tbody tr').first();
+      await expect(firstRow).toBeVisible();
+      await expect(firstRow).toContainText(/app_setting/);
+
+      // Click the row — it has a diff so the chevron expands and the
+      // JSON renders in a follow-on <tr>.
+      await firstRow.click();
+      // The expanded row carries the namespace + fields the PUT
+      // touched.
+      await expect(
+        adminPage.locator('tbody').getByText(/"namespace":\s*"brand"/),
+      ).toBeVisible();
+    } finally {
+      // Restore brand defaults so we don't leak the probe name into
+      // the next spec.
+      await adminPage.request.put(`${API_URL}/admin/app-config/brand`, {
+        data: {
+          name: 'Atrium',
+          logo_url: '/logo.svg',
+          support_email: null,
+          preset: 'default',
+          overrides: {},
+        },
+      });
+      await adminContext.close();
+    }
+  });
+});

--- a/frontend/tests-e2e/email-outbox.spec.ts
+++ b/frontend/tests-e2e/email-outbox.spec.ts
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+import { execSync } from 'child_process';
+
+import { expect, test } from '@playwright/test';
+
+import { loginAsSuperAdmin } from './helpers';
+
+/**
+ * EmailOutboxAdmin (`/admin/outbox`) coverage. Atrium's platform code
+ * doesn't itself enqueue outbox rows — that's a host-side API
+ * (``enqueue_and_log``). To exercise the drain UI we insert a row
+ * directly through the mysql container, mirroring the pattern used
+ * elsewhere when the public API can't reach the desired state.
+ */
+
+const adminEmail = process.env.E2E_ADMIN_EMAIL;
+const adminPassword = process.env.E2E_ADMIN_PASSWORD;
+const adminTotpSecret = process.env.E2E_ADMIN_TOTP_SECRET;
+
+const haveSmokeEnv = Boolean(adminEmail && adminPassword && adminTotpSecret);
+
+test.skip(
+  !haveSmokeEnv,
+  'E2E_ADMIN_EMAIL / E2E_ADMIN_PASSWORD / E2E_ADMIN_TOTP_SECRET must be set (run via `make smoke`).',
+);
+
+function mysqlExec(sql: string): string {
+  const compose = process.env.E2E_COMPOSE_FILES ??
+    '-f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.e2e.yml';
+  const sqlEscaped = sql.replaceAll("'", "'\\''");
+  return execSync(
+    `docker compose ${compose} exec -T mysql sh -c ` +
+      `'mysql -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" -N -e "${sqlEscaped}"'`,
+    { encoding: 'utf-8', cwd: '..' },
+  );
+}
+
+test.describe('Email outbox admin', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.describe.configure({ timeout: 10_000 });
+
+  test('admin can drain a pending outbox row', async ({ page }) => {
+    const recipient = `outbox-${Date.now()}@example.com`;
+    // Seed a pending row pointed at a known template.
+    // ``next_attempt_at`` in the past ensures the worker would also
+    // pick it up; we drain manually via the admin UI before that.
+    // ``email_otp_code`` template needs ``user_name`` + ``code`` in
+     // its context — render-fails without both.
+    mysqlExec(
+      `INSERT INTO email_outbox
+       (status, template, locale, to_addr, context, attempts, next_attempt_at, last_error, entity_type, entity_id)
+       VALUES ('pending', 'email_otp_code', 'en', '${recipient}',
+         JSON_OBJECT('code', '123456', 'user_name', 'Outbox E2E'),
+         0, DATE_SUB(NOW(), INTERVAL 1 SECOND), NULL, NULL, NULL);`,
+    );
+
+    try {
+      await loginAsSuperAdmin(page);
+      await page.goto('/admin/outbox');
+
+      // Two "Email outbox" headings render (the SectionPage's h2 outer
+       // title and the component's own h3) — anchor on the table header
+       // instead, which is unique to the loaded component.
+      await expect(
+        page.getByRole('columnheader', { name: /^Recipient$/i }),
+      ).toBeVisible();
+
+      // Default filter is "Pending"; the seeded row should appear.
+      const row = page.locator('tbody tr', { hasText: recipient });
+      await expect(row).toBeVisible();
+      await expect(row.getByText(/^pending$/i)).toBeVisible();
+
+      // Click the drain button (label "Send now"). The console mail
+      // backend always succeeds, so the row flips to ``sent`` and
+      // disappears from the default "Pending" view.
+      await row.getByRole('button', { name: /^Send now$/i }).click();
+      await expect(
+        page.locator('tbody tr', { hasText: recipient }),
+      ).toHaveCount(0);
+
+      // Switching the filter to ``Sent`` surfaces the row in its
+      // terminal state. Mantine's SegmentedControl uses hidden radio
+      // inputs — click the visible label instead.
+      await page.locator('label').filter({ hasText: /^Sent$/ }).click();
+      const sentRow = page.locator('tbody tr', { hasText: recipient });
+      await expect(sentRow).toBeVisible();
+      await expect(sentRow.getByText(/^sent$/i)).toBeVisible();
+    } finally {
+      mysqlExec(`DELETE FROM email_outbox WHERE to_addr = '${recipient}';`);
+    }
+  });
+});

--- a/frontend/tests-e2e/notifications.spec.ts
+++ b/frontend/tests-e2e/notifications.spec.ts
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+import { execSync } from 'child_process';
+
+import { expect, test } from '@playwright/test';
+
+import { API_URL, loginAsSuperAdmin } from './helpers';
+
+/**
+ * NotificationsBell coverage. Atrium's bell + dropdown reads from
+ * /api/notifications. Atrium's platform code doesn't itself emit
+ * notifications (host apps own the kinds), so this spec inserts a
+ * row directly via mysql, mirroring the email-outbox pattern.
+ */
+
+const adminEmail = process.env.E2E_ADMIN_EMAIL;
+const adminPassword = process.env.E2E_ADMIN_PASSWORD;
+const adminTotpSecret = process.env.E2E_ADMIN_TOTP_SECRET;
+
+const haveSmokeEnv = Boolean(adminEmail && adminPassword && adminTotpSecret);
+
+test.skip(
+  !haveSmokeEnv,
+  'E2E_ADMIN_EMAIL / E2E_ADMIN_PASSWORD / E2E_ADMIN_TOTP_SECRET must be set (run via `make smoke`).',
+);
+
+function mysqlExec(sql: string): string {
+  const compose = process.env.E2E_COMPOSE_FILES ??
+    '-f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.e2e.yml';
+  const sqlEscaped = sql.replaceAll("'", "'\\''");
+  return execSync(
+    `docker compose ${compose} exec -T mysql sh -c ` +
+      `'mysql -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" -N -e "${sqlEscaped}"'`,
+    { encoding: 'utf-8', cwd: '..' },
+  );
+}
+
+test.describe('Notifications bell', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.describe.configure({ timeout: 15_000 });
+
+  test('bell renders the unread count and lists notifications', async ({
+    page,
+  }) => {
+    await loginAsSuperAdmin(page);
+
+    // Resolve the smoke admin's user id via the API so we can insert
+    // notifications targeting them. /users/me returns it.
+    const meResp = await page.request.get(`${API_URL}/users/me`);
+    const me = (await meResp.json()) as { id: number };
+    const tag = `e2e-notif-${Date.now()}`;
+
+    try {
+      // Wipe any pre-existing notifications for the smoke admin so the
+      // unread count is deterministic. Other specs may have created
+      // some via host-side flows.
+      mysqlExec(`DELETE FROM notifications WHERE user_id = ${me.id};`);
+
+      // Reload so the bell's TanStack queries pick up the empty state.
+      await page.goto('/');
+      const bell = page.getByRole('button', { name: /notifications/i }).first();
+      await expect(bell).toBeVisible();
+
+      // Empty state — open the popover, assert the empty copy.
+      await bell.click();
+      await expect(page.getByText(/no notifications yet/i)).toBeVisible();
+      await page.keyboard.press('Escape');
+
+      // Insert two unread notifications + one already-read.
+      mysqlExec(
+        `INSERT INTO notifications (user_id, kind, payload, read_at)
+         VALUES
+         (${me.id}, '${tag}_unread1', JSON_OBJECT('msg', 'one'), NULL),
+         (${me.id}, '${tag}_unread2', JSON_OBJECT('msg', 'two'), NULL),
+         (${me.id}, '${tag}_read', JSON_OBJECT('msg', 'three'), NOW());`,
+      );
+
+      // Reload so the bell pulls the freshly-inserted rows.
+      await page.reload();
+      await expect(bell).toBeVisible();
+
+      // Open and assert both unread rows show up. ``new`` badge marks
+      // each unread item.
+      await bell.click();
+      await expect(page.getByText(`${tag}_unread1`)).toBeVisible();
+      await expect(page.getByText(`${tag}_unread2`)).toBeVisible();
+      await expect(page.getByText(`${tag}_read`)).toBeVisible();
+
+      // ``Mark all read`` button only renders when unread > 0.
+      await page.getByRole('button', { name: /mark all read/i }).click();
+
+      // The button disappears once unread hits 0.
+      await expect(
+        page.getByRole('button', { name: /mark all read/i }),
+      ).toHaveCount(0);
+    } finally {
+      mysqlExec(
+        `DELETE FROM notifications WHERE user_id = ${me.id} AND kind LIKE '${tag}%';`,
+      );
+    }
+  });
+});

--- a/frontend/tests-e2e/password-reset.spec.ts
+++ b/frontend/tests-e2e/password-reset.spec.ts
@@ -1,0 +1,176 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+import { expect, test } from '@playwright/test';
+import { generate as generateTOTP } from 'otplib';
+
+import {
+  API_URL,
+  createAndEnrolUserViaApi,
+  loginAsSuperAdmin,
+  readLatestEmailLogEntry,
+} from './helpers';
+
+/**
+ * Forgot/reset password flow — the only un-2FA'd account-recovery path,
+ * so it deserves a UI-level spec. Drives the SPA forms, scrapes the
+ * console mail backend for the token, and confirms login with the new
+ * password.
+ */
+
+const adminEmail = process.env.E2E_ADMIN_EMAIL;
+const adminPassword = process.env.E2E_ADMIN_PASSWORD;
+const adminTotpSecret = process.env.E2E_ADMIN_TOTP_SECRET;
+
+const haveSmokeEnv = Boolean(adminEmail && adminPassword && adminTotpSecret);
+
+test.skip(
+  !haveSmokeEnv,
+  'E2E_ADMIN_EMAIL / E2E_ADMIN_PASSWORD / E2E_ADMIN_TOTP_SECRET must be set (run via `make smoke`).',
+);
+
+test.describe('Forgot / reset password', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('user can request reset, receive token via email, set new password', async ({
+    browser,
+  }) => {
+    // Provision a fresh enrolled user via the admin API so we have a
+    // known account to drive the recovery flow against.
+    const adminContext = await browser.newContext();
+    const adminPage = await adminContext.newPage();
+    await loginAsSuperAdmin(adminPage);
+
+    const visitorContext = await browser.newContext();
+    const visitorPage = await visitorContext.newPage();
+    const fresh = await createAndEnrolUserViaApi(
+      adminPage.request,
+      visitorPage.request,
+    );
+    // Drop the cookie set by the createAndEnrol flow — we want the
+    // recovery surface as an unauth visitor.
+    await visitorContext.clearCookies();
+
+    try {
+      // ---- Submit /forgot-password -----------------------------------
+      await visitorPage.goto('/forgot-password');
+      await expect(
+        visitorPage.getByRole('heading', { name: /reset your password/i }),
+      ).toBeVisible();
+      await visitorPage.getByLabel(/email/i).fill(fresh.email);
+      await visitorPage
+        .getByRole('button', { name: /send reset link/i })
+        .click();
+      await expect(
+        visitorPage.getByText(/sent a reset link/i),
+      ).toBeVisible();
+
+      // ---- Pull the token out of the password_reset email -----------
+      // The password_reset template carries an explicit "Or paste this
+      // link: {{ reset_url }}" line outside the anchor (mirrors the
+      // ``email_verify`` template) so the URL survives the sender's
+      // tag-strip into the plain-text body.
+      const token = await (async () => {
+        for (let attempt = 0; attempt < 10; attempt++) {
+          try {
+            const entry = readLatestEmailLogEntry(
+              'password_reset',
+              fresh.email,
+            );
+            const match = entry.body_text.match(
+              /\/reset-password\?token=([^\s"'<>]+)/,
+            );
+            if (match) return match[1];
+          } catch {
+            // Email log line might not be in the tail buffer yet.
+          }
+          await visitorPage.waitForTimeout(300);
+        }
+        throw new Error('reset token never appeared in api logs');
+      })();
+
+      // ---- Drive /reset-password with the token ---------------------
+      const newPassword = 'Reset-Pw-NEW-12345!';
+      await visitorPage.goto(`/reset-password?token=${token}`);
+      await expect(
+        visitorPage.getByRole('heading', { name: /choose a new password/i }),
+      ).toBeVisible();
+      await visitorPage
+        .getByLabel(/^new password/i)
+        .fill(newPassword);
+      await visitorPage
+        .getByLabel(/confirm password/i)
+        .fill(newPassword);
+      await visitorPage
+        .getByRole('button', { name: /update password/i })
+        .click();
+
+      // ResetPasswordPage redirects to /login on success.
+      await expect(visitorPage).toHaveURL(/\/login(\?|$)/);
+
+      // ---- New password works against the API; old one doesn't -----
+      const newLoginContext = await browser.newContext();
+      try {
+        const newLogin = await newLoginContext.request.post(
+          `${API_URL}/auth/jwt/login`,
+          { form: { username: fresh.email, password: newPassword } },
+        );
+        expect([200, 204]).toContain(newLogin.status());
+
+        // The reset doesn't wipe TOTP, so the second factor still gates
+        // the session — drive it through to confirm the account is
+        // fully recoverable.
+        const code = await generateTOTP({ secret: fresh.totpSecret });
+        const totpVerify = await newLoginContext.request.post(
+          `${API_URL}/auth/totp/verify`,
+          { data: { code } },
+        );
+        expect([200, 204]).toContain(totpVerify.status());
+
+        // Old password rejected (fastapi-users returns 400, not 401).
+        const oldLoginContext = await browser.newContext();
+        try {
+          const oldLogin = await oldLoginContext.request.post(
+            `${API_URL}/auth/jwt/login`,
+            { form: { username: fresh.email, password: 'Invitee-Pw-12345!' } },
+          );
+          expect(oldLogin.status()).toBeGreaterThanOrEqual(400);
+          expect(oldLogin.status()).toBeLessThan(500);
+        } finally {
+          await oldLoginContext.close();
+        }
+      } finally {
+        await newLoginContext.close();
+      }
+    } finally {
+      await visitorContext.close();
+      await adminContext.close();
+    }
+  });
+
+  test('reset-password without token shows the missing-token alert', async ({
+    page,
+  }) => {
+    await page.goto('/reset-password');
+    await expect(
+      page.getByText(/missing reset token/i),
+    ).toBeVisible();
+  });
+
+  test('reset-password rejects mismatched confirmation client-side', async ({
+    page,
+  }) => {
+    // Any non-empty token gets us past the missing-token early return —
+    // the test asserts the client-side validator fires before the API
+    // call goes out.
+    await page.goto('/reset-password?token=fake-token-for-validation-test');
+    await page.getByLabel(/^new password/i).fill('aaaaaaaaaa');
+    await page.getByLabel(/confirm password/i).fill('bbbbbbbbbb');
+    await page.getByRole('button', { name: /update password/i }).click();
+    // Mantine's useForm renders the validator's return string under the
+    // input. The exact text comes from ``acceptInvite.passwordMismatch``.
+    await expect(
+      page.getByText(/passwords do not match|wachtwoorden komen niet overeen/i),
+    ).toBeVisible();
+  });
+});

--- a/frontend/tests-e2e/profile-flows.spec.ts
+++ b/frontend/tests-e2e/profile-flows.spec.ts
@@ -1,0 +1,155 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+import { expect, test } from '@playwright/test';
+
+import {
+  API_URL,
+  createAndEnrolUserViaApi,
+  loginAsSuperAdmin,
+} from './helpers';
+
+/**
+ * Profile page flows that aren't already covered by the smoke /
+ * extended specs:
+ *  - Change password (and re-login with the new password)
+ *  - Active sessions table renders the current device
+ *  - Log out everywhere ends every session and bounces to /login
+ */
+
+const adminEmail = process.env.E2E_ADMIN_EMAIL;
+const adminPassword = process.env.E2E_ADMIN_PASSWORD;
+const adminTotpSecret = process.env.E2E_ADMIN_TOTP_SECRET;
+
+const haveSmokeEnv = Boolean(adminEmail && adminPassword && adminTotpSecret);
+
+test.skip(
+  !haveSmokeEnv,
+  'E2E_ADMIN_EMAIL / E2E_ADMIN_PASSWORD / E2E_ADMIN_TOTP_SECRET must be set (run via `make smoke`).',
+);
+
+test.describe('Profile flows', () => {
+  test.describe.configure({ mode: 'serial' });
+  // Several specs in this file build TWO browser contexts and walk
+  // through invite + accept + TOTP enrol + login. The default 30 s
+  // budget is fine; tighter timeouts here just race the legitimately
+  // expensive setup.
+  test.describe.configure({ timeout: 30_000 });
+
+  test('user can change their password via the profile page', async ({
+    browser,
+  }) => {
+    // Provision a fresh enrolled user so we don't disturb the smoke
+    // admin's password (other specs depend on it).
+    const adminContext = await browser.newContext();
+    const adminPage = await adminContext.newPage();
+    await loginAsSuperAdmin(adminPage);
+
+    const userContext = await browser.newContext();
+    const userPage = await userContext.newPage();
+    const fresh = await createAndEnrolUserViaApi(
+      adminPage.request,
+      userPage.request,
+    );
+    // ``createAndEnrolUserViaApi`` leaves the cookie on userPage.request;
+    // sync onto the browser context so navigation carries the session.
+    const apiCookies = await userPage.request.storageState();
+    await userContext.addCookies(apiCookies.cookies);
+
+    const newPassword = 'New-Profile-Pw-12345!';
+
+    try {
+      await userPage.goto('/profile');
+      await expect(
+        userPage.getByRole('heading', { name: /your profile/i }),
+      ).toBeVisible();
+
+      // Fill the change-password form. Mantine's PasswordInput nests
+      // the actual ``<input>`` inside a wrapper; anchor on the
+      // ``[type=password]`` selector instead of getByLabel which can
+      // resolve to the wrapper depending on Mantine's DOM shape.
+      const pwInputs = userPage.locator('input[type="password"]');
+      await pwInputs.nth(0).fill(newPassword);
+      await pwInputs.nth(1).fill(newPassword);
+      await userPage
+        .getByRole('button', { name: /^Update password$/i })
+        .click();
+
+      // Verify end-to-end via a fresh context: new password works,
+      // old one doesn't. Skips racing the auto-dismissing toast.
+      const probe = await browser.newContext();
+      try {
+        const newLogin = await probe.request.post(
+          `${API_URL}/auth/jwt/login`,
+          { form: { username: fresh.email, password: newPassword } },
+        );
+        expect([200, 204]).toContain(newLogin.status());
+        const oldLogin = await probe.request.post(
+          `${API_URL}/auth/jwt/login`,
+          { form: { username: fresh.email, password: 'Invitee-Pw-12345!' } },
+        );
+        expect(oldLogin.status()).toBeGreaterThanOrEqual(400);
+        expect(oldLogin.status()).toBeLessThan(500);
+      } finally {
+        await probe.close();
+      }
+    } finally {
+      await userContext.close();
+      await adminContext.close();
+    }
+  });
+
+  test('active sessions table shows the current device', async ({ page }) => {
+    await loginAsSuperAdmin(page);
+    await page.goto('/profile');
+
+    // Wait for the sessions section to mount.
+    await expect(
+      page.getByRole('heading', { name: /active sessions/i }),
+    ).toBeVisible();
+    // The user just logged in — at least one session exists, and one
+    // row carries the "This device" badge.
+    await expect(page.getByText(/this device/i).first()).toBeVisible();
+  });
+
+  test('logout everywhere ends every session and bounces to /login', async ({
+    browser,
+  }) => {
+    // Use a fresh user — wiping the smoke admin's sessions would
+    // cascade-fail every spec that ran before (they share the same
+    // session).
+    const adminContext = await browser.newContext();
+    const adminPage = await adminContext.newPage();
+    await loginAsSuperAdmin(adminPage);
+
+    const userContext = await browser.newContext();
+    const userPage = await userContext.newPage();
+    await createAndEnrolUserViaApi(adminPage.request, userPage.request);
+    const apiCookies = await userPage.request.storageState();
+    await userContext.addCookies(apiCookies.cookies);
+
+    try {
+      await userPage.goto('/profile');
+      // Stub ``window.confirm`` AFTER goto — navigation resets the
+      // window object so a pre-goto stub doesn't survive.
+      await userPage.evaluate(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any).confirm = () => true;
+      });
+      await userPage
+        .getByRole('button', { name: /log out everywhere/i })
+        .click();
+
+      // The handler navigates to /login with replace: true.
+      await expect(userPage).toHaveURL(/\/login(\?|$)/);
+
+      // Subsequent /users/me probe must come back unauth — server-side
+      // session revoked.
+      const meResp = await userPage.request.get(`${API_URL}/users/me`);
+      expect(meResp.status()).toBe(401);
+    } finally {
+      await userContext.close();
+      await adminContext.close();
+    }
+  });
+});

--- a/frontend/tests-e2e/reminders-admin.spec.ts
+++ b/frontend/tests-e2e/reminders-admin.spec.ts
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+import { expect, test } from '@playwright/test';
+
+import { API_URL, loginAsSuperAdmin } from './helpers';
+
+/**
+ * RemindersAdmin (`/admin/reminders`) coverage. Reminder rules drive
+ * host-app reminder scheduling — atrium ships the storage + admin UI;
+ * the host registers anchors. This spec proves the CRUD surface works
+ * end-to-end via the admin UI.
+ */
+
+const adminEmail = process.env.E2E_ADMIN_EMAIL;
+const adminPassword = process.env.E2E_ADMIN_PASSWORD;
+const adminTotpSecret = process.env.E2E_ADMIN_TOTP_SECRET;
+
+const haveSmokeEnv = Boolean(adminEmail && adminPassword && adminTotpSecret);
+
+test.skip(
+  !haveSmokeEnv,
+  'E2E_ADMIN_EMAIL / E2E_ADMIN_PASSWORD / E2E_ADMIN_TOTP_SECRET must be set (run via `make smoke`).',
+);
+
+test.describe('Reminders admin', () => {
+  test.describe.configure({ mode: 'serial' });
+  // Fail fast on broken UI — every step in this spec should resolve
+  // in <2 s on a healthy stack; 10 s is plenty.
+  test.describe.configure({ timeout: 10_000 });
+
+  test('admin creates, edits, deactivates, and deletes a reminder rule', async ({
+    page,
+  }) => {
+    await loginAsSuperAdmin(page);
+    await page.goto('/admin/reminders');
+
+    await expect(
+      page.getByRole('heading', { name: /reminder rules/i }),
+    ).toBeVisible();
+
+    // ---- Create -----------------------------------------------------
+    const ruleName = `E2E Reminder ${Date.now()}`;
+    const renamed = `${ruleName} (renamed)`;
+
+    // Open the create modal via the page-header button. Two
+    // ``RuleFormModal`` components are mounted (one for create, one
+    // for edit) but only opened={true} renders the dialog body.
+    const newBtn = page.getByRole('button', { name: /^New reminder$/i });
+    await expect(newBtn).toBeVisible();
+    // ``getByRole('button', name)`` matches BOTH the page-header
+    // button and the modal's submit "Save" button when the modal is
+    // mounted (it isn't yet, but matchers race) — use ``.first()`` so
+    // we click the page-header button only.
+    await newBtn.click();
+    const modal = page.getByRole('dialog');
+    await expect(modal).toBeVisible();
+    // Mantine renders required labels as "Name *". Match with an
+    // optional-asterisk regex so the test isn't brittle to that
+    // detail across Mantine versions.
+    await modal.getByLabel(/^Name(\s*\*)?$/).fill(ruleName);
+    // Pick the seeded ``invite`` template — every fresh atrium has it.
+    await modal.getByLabel(/email template/i).click();
+    await page.getByRole('option', { name: 'invite', exact: true }).click();
+    await modal.getByLabel(/^Anchor(\s*\*)?$/).fill('e2e_anchor');
+    await modal.getByLabel(/days offset/i).fill('-3');
+    await modal.getByRole('button', { name: /^save$/i }).click();
+    await expect(modal).toHaveCount(0);
+
+    // Row appears in the table.
+    const row = page.locator('tbody tr', { hasText: ruleName });
+    await expect(row).toBeVisible();
+    await expect(row).toContainText('invite');
+    await expect(row).toContainText('e2e_anchor');
+    await expect(row).toContainText('-3');
+    await expect(row.getByText(/^active$/i)).toBeVisible();
+
+    // ---- Edit (rename + flip active off) ----------------------------
+    // The edit / delete ActionIcons in the row aren't aria-labeled —
+    // anchor on row position. Two buttons: [0] edit, [1] delete.
+    const rowButtons = row.getByRole('button');
+    await rowButtons.nth(0).click();
+    const editModal = page.getByRole('dialog');
+    await expect(editModal).toBeVisible();
+    await editModal.getByLabel(/^Name(\s*\*)?$/).fill(renamed);
+    await editModal.getByLabel(/^Active$/).uncheck();
+    await editModal.getByRole('button', { name: /^save$/i }).click();
+    await expect(editModal).toHaveCount(0);
+
+    const renamedRow = page.locator('tbody tr', { hasText: renamed });
+    await expect(renamedRow).toBeVisible();
+    await expect(renamedRow.getByText(/^inactive$/i)).toBeVisible();
+
+    // Verify the API state matches what the UI shows.
+    const listResp = await page.request.get(`${API_URL}/admin/reminder-rules`);
+    const rules = (await listResp.json()) as Array<{
+      name: string;
+      template_key: string;
+      anchor: string;
+      days_offset: number;
+      active: boolean;
+    }>;
+    const created = rules.find((r) => r.name === renamed);
+    expect(created).toBeTruthy();
+    expect(created!.template_key).toBe('invite');
+    expect(created!.anchor).toBe('e2e_anchor');
+    expect(created!.days_offset).toBe(-3);
+    expect(created!.active).toBe(false);
+
+    // ---- Delete -----------------------------------------------------
+    await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).confirm = () => true;
+    });
+    await renamedRow.getByRole('button').nth(1).click();
+    await expect(
+      page.locator('tbody tr', { hasText: renamed }),
+    ).toHaveCount(0);
+  });
+});

--- a/frontend/tests-e2e/roles-admin.spec.ts
+++ b/frontend/tests-e2e/roles-admin.spec.ts
@@ -1,0 +1,169 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+import { randomBytes } from 'crypto';
+
+import { expect, test } from '@playwright/test';
+
+import { API_URL, loginAsSuperAdmin } from './helpers';
+
+/**
+ * RolesAdmin (`/admin/roles`) coverage. Backend pytest already exercises
+ * the underlying RBAC permission attach/detach + system-role guards;
+ * this spec proves the admin UI's create / edit / delete actions wire
+ * correctly and that system roles render as protected (no trash icon).
+ */
+
+const adminEmail = process.env.E2E_ADMIN_EMAIL;
+const adminPassword = process.env.E2E_ADMIN_PASSWORD;
+const adminTotpSecret = process.env.E2E_ADMIN_TOTP_SECRET;
+
+const haveSmokeEnv = Boolean(adminEmail && adminPassword && adminTotpSecret);
+
+test.skip(
+  !haveSmokeEnv,
+  'E2E_ADMIN_EMAIL / E2E_ADMIN_PASSWORD / E2E_ADMIN_TOTP_SECRET must be set (run via `make smoke`).',
+);
+
+function uniqueCode(): string {
+  // Lowercase, underscores, digits — matches the role-code validator.
+  return `e2e_role_${randomBytes(3).readUIntBE(0, 3)}`;
+}
+
+async function autoConfirm(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).confirm = () => true;
+  });
+}
+
+test.describe('Roles admin', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('admin creates a role with permissions, edits it, deletes it', async ({
+    page,
+  }) => {
+    await loginAsSuperAdmin(page);
+    await page.goto('/admin/roles');
+
+    // Wait for the existing system roles to render — at minimum
+    // super_admin / admin / user should be visible from the migration
+    // seed.
+    const table = page.locator('table').first();
+    await expect(table.getByText('Super admin')).toBeVisible();
+    await expect(table.getByText(/^Admin$/)).toBeVisible();
+    await expect(table.getByText(/^User$/)).toBeVisible();
+
+    // ---- Create ------------------------------------------------------
+    const code = uniqueCode();
+    const initialName = `E2E Role ${code}`;
+    const renamed = `Renamed ${code}`;
+
+    await page.getByRole('button', { name: /new role/i }).click();
+
+    const createDialog = page.getByRole('dialog');
+    await createDialog.getByLabel(/^code/i).fill(code);
+    await createDialog.getByLabel(/^name/i).fill(initialName);
+    // Attach two permissions — pick two that always exist via the
+    // 0001 seed: ``user.manage`` and ``audit.read``.
+    await createDialog
+      .getByRole('checkbox', { name: /user\.manage/ })
+      .check();
+    await createDialog
+      .getByRole('checkbox', { name: /audit\.read/ })
+      .check();
+    await createDialog.getByRole('button', { name: /save/i }).click();
+
+    // Modal closes, new row appears.
+    await expect(createDialog).toHaveCount(0);
+    const newRow = table.locator('tr', { hasText: initialName });
+    await expect(newRow).toBeVisible();
+    // No system badge on a fresh role — only seeded super_admin/admin/user
+    // carry the badge.
+    await expect(newRow.getByText(/^system$/)).toHaveCount(0);
+
+    // ---- Edit (rename + toggle a permission off) ---------------------
+    await newRow.getByRole('button', { name: initialName }).click();
+    const editDialog = page.getByRole('dialog');
+    await editDialog.getByLabel(/^name/i).fill(renamed);
+    // Drop user.manage; keep audit.read so the role still has at least
+    // one permission attached.
+    await editDialog
+      .getByRole('checkbox', { name: /user\.manage/ })
+      .uncheck();
+    await editDialog.getByRole('button', { name: /save/i }).click();
+    await expect(editDialog).toHaveCount(0);
+
+    // Row updates in place with the new label.
+    const renamedRow = table.locator('tr', { hasText: renamed });
+    await expect(renamedRow).toBeVisible();
+
+    // Verify the API state matches what we set.
+    const rolesResp = await page.request.get(`${API_URL}/admin/roles`);
+    const roles = (await rolesResp.json()) as Array<{
+      code: string;
+      name: string;
+      permissions: string[];
+    }>;
+    const created = roles.find((r) => r.code === code);
+    expect(created).toBeTruthy();
+    expect(created!.name).toBe(renamed);
+    expect(created!.permissions).toEqual(['audit.read']);
+
+    // ---- Delete ------------------------------------------------------
+    await autoConfirm(page);
+    await renamedRow
+      .getByRole('button', { name: /delete/i })
+      .click();
+
+    // Row gone after the mutation lands.
+    await expect(table.locator('tr', { hasText: renamed })).toHaveCount(0);
+  });
+
+  test('system roles cannot be deleted from the UI', async ({ page }) => {
+    await loginAsSuperAdmin(page);
+    await page.goto('/admin/roles');
+
+    // Anchor each row by its role-name button (an exact-text Mantine
+    // Button, unique per role) and walk to the enclosing <tr>. The
+    // ``hasText`` filter on ``tr`` matches the whole row's text and
+    // can't disambiguate "Admin" from "Super admin" with a regex.
+    for (const exactName of ['Super admin', 'Admin', 'User']) {
+      const nameButton = page.getByRole('button', { name: exactName, exact: true });
+      await expect(nameButton).toBeVisible();
+      const row = nameButton.locator('xpath=ancestor::tr[1]');
+      // The trash button is conditionally rendered only for non-system
+      // roles. Asserting count=0 proves the gate holds.
+      await expect(row.getByRole('button', { name: /delete/i })).toHaveCount(
+        0,
+      );
+      // The "system" badge confirms the row is the system row.
+      await expect(row.getByText(/^system$/i)).toBeVisible();
+    }
+  });
+
+  test('system role name field is read-only when editing', async ({
+    page,
+  }) => {
+    await loginAsSuperAdmin(page);
+    await page.goto('/admin/roles');
+
+    // Open the ``admin`` system role's edit modal — anchor by exact
+    // button text so we don't pick up "Super admin".
+    await page.getByRole('button', { name: 'Admin', exact: true }).click();
+
+    const dialog = page.getByRole('dialog');
+    // The system-rename guard renders the name field disabled; the
+    // explanatory description (``roles.systemRoleNoRename``) is
+    // attached to the input.
+    const nameInput = dialog.getByLabel(/^name/i);
+    await expect(nameInput).toBeDisabled();
+    await expect(
+      dialog.getByText(/system roles can't be renamed/i),
+    ).toBeVisible();
+
+    // Cancel out — no changes.
+    await dialog.getByRole('button', { name: /cancel/i }).click();
+    await expect(dialog).toHaveCount(0);
+  });
+});

--- a/frontend/tests-e2e/users-admin.spec.ts
+++ b/frontend/tests-e2e/users-admin.spec.ts
@@ -1,0 +1,278 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+import { randomBytes } from 'crypto';
+
+import { expect, test } from '@playwright/test';
+
+import {
+  API_URL,
+  createAndEnrolUserViaApi,
+  loginAsSuperAdmin,
+  readLatestEmailLogEntry,
+} from './helpers';
+
+/**
+ * UsersAdmin (`/admin/users`) coverage. Backend pytest already exercises
+ * the underlying RBAC + impersonation routes; these specs prove the
+ * admin UI's row actions wire to the right endpoints and the
+ * impersonation banner appears + dismisses correctly.
+ */
+
+const adminEmail = process.env.E2E_ADMIN_EMAIL;
+const adminPassword = process.env.E2E_ADMIN_PASSWORD;
+const adminTotpSecret = process.env.E2E_ADMIN_TOTP_SECRET;
+
+const haveSmokeEnv = Boolean(adminEmail && adminPassword && adminTotpSecret);
+
+test.skip(
+  !haveSmokeEnv,
+  'E2E_ADMIN_EMAIL / E2E_ADMIN_PASSWORD / E2E_ADMIN_TOTP_SECRET must be set (run via `make smoke`).',
+);
+
+function uniqueSuffix(): string {
+  return `${Date.now()}-${randomBytes(4).readUInt32BE(0)}`;
+}
+
+/** Stub window.confirm so the row actions don't hang on the prompt. */
+async function autoConfirm(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).confirm = () => true;
+  });
+}
+
+test.describe('Users admin', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('admin edits a user name + email via the modal', async ({ browser }) => {
+    const adminContext = await browser.newContext();
+    const adminPage = await adminContext.newPage();
+    await loginAsSuperAdmin(adminPage);
+
+    const targetContext = await browser.newContext();
+    const fresh = await createAndEnrolUserViaApi(
+      adminPage.request,
+      targetContext.request,
+    );
+    await targetContext.close();
+
+    try {
+      await adminPage.goto('/admin/users');
+      const usersTable = adminPage.locator('table').first();
+      const row = usersTable.locator('tr', { hasText: fresh.email });
+      await expect(row).toBeVisible();
+
+      // Clicking the name (UnstyledButton wrapping the Text + pencil)
+      // opens the edit modal. Use the pencil's aria-label as the
+      // anchor — the wrapped text isn't a button role.
+      await row.getByRole('button', { name: /edit/i }).first().click();
+
+      const newName = `E2E Renamed ${uniqueSuffix()}`;
+      const newEmail = `e2e-renamed-${uniqueSuffix()}@example.com`;
+      const dialog = adminPage.getByRole('dialog');
+      await dialog.getByLabel(/full name/i).fill(newName);
+      await dialog.getByLabel(/email/i).fill(newEmail);
+      await dialog.getByRole('button', { name: /save/i }).click();
+
+      // Modal closes; row updates with the new name + email.
+      await expect(dialog).toHaveCount(0);
+      const newRow = usersTable.locator('tr', { hasText: newEmail });
+      await expect(newRow).toBeVisible();
+      await expect(newRow).toContainText(newName);
+    } finally {
+      await adminContext.close();
+    }
+  });
+
+  test('admin assigns a role via the row MultiSelect', async ({ browser }) => {
+    const adminContext = await browser.newContext();
+    const adminPage = await adminContext.newPage();
+    await loginAsSuperAdmin(adminPage);
+
+    const targetContext = await browser.newContext();
+    const fresh = await createAndEnrolUserViaApi(
+      adminPage.request,
+      targetContext.request,
+    );
+    await targetContext.close();
+
+    try {
+      await adminPage.goto('/admin/users');
+      const row = adminPage
+        .locator('table')
+        .first()
+        .locator('tr', { hasText: fresh.email });
+      await expect(row).toBeVisible();
+
+      // The row's Roles cell carries a Mantine MultiSelect. The cell
+      // contains both a visible combobox input and hidden value-tracker
+      // inputs — anchor on the placeholder which is unique to the
+      // visible combobox.
+      await row.getByPlaceholder(/Pick roles/i).click();
+      await adminPage.getByRole('option', { name: /^admin$/i }).click();
+      // Click outside to close the dropdown.
+      await adminPage.locator('body').click({ position: { x: 5, y: 5 } });
+
+      // Confirm the change persisted by reading the user back.
+      await expect
+        .poll(async () => {
+          const resp = await adminPage.request.get(`${API_URL}/admin/users`);
+          const list = (await resp.json()) as Array<{
+            id: number;
+            email: string;
+            roles: string[];
+          }>;
+          const me = list.find((u) => u.email === fresh.email);
+          return me?.roles ?? [];
+        })
+        .toEqual(expect.arrayContaining(['admin', 'user']));
+    } finally {
+      await adminContext.close();
+    }
+  });
+
+  test('admin triggers a password-reset email', async ({ browser }) => {
+    const adminContext = await browser.newContext();
+    const adminPage = await adminContext.newPage();
+    await loginAsSuperAdmin(adminPage);
+
+    const targetContext = await browser.newContext();
+    const fresh = await createAndEnrolUserViaApi(
+      adminPage.request,
+      targetContext.request,
+    );
+    await targetContext.close();
+
+    try {
+      await autoConfirm(adminPage);
+      await adminPage.goto('/admin/users');
+      await autoConfirm(adminPage);
+
+      const row = adminPage
+        .locator('table')
+        .first()
+        .locator('tr', { hasText: fresh.email });
+      await row
+        .getByRole('button', { name: /Send password reset/i })
+        .click();
+
+      // The success notification carries the i18n string; wait for it
+      // before scraping the api logs (the email is enqueued + sent
+      // synchronously by ``send_and_log``).
+      await expect(
+        adminPage.getByText(/password reset email sent/i),
+      ).toBeVisible();
+
+      // The console mail backend logs the sent email — verify the
+      // recipient + template match.
+      const entry = readLatestEmailLogEntry('password_reset', fresh.email);
+      expect(entry.subject).toBeTruthy();
+    } finally {
+      await adminContext.close();
+    }
+  });
+
+  test('admin resets a user 2FA enrollment', async ({ browser }) => {
+    const adminContext = await browser.newContext();
+    const adminPage = await adminContext.newPage();
+    await loginAsSuperAdmin(adminPage);
+
+    const targetContext = await browser.newContext();
+    const fresh = await createAndEnrolUserViaApi(
+      adminPage.request,
+      targetContext.request,
+    );
+    await targetContext.close();
+
+    try {
+      await autoConfirm(adminPage);
+      await adminPage.goto('/admin/users');
+      await autoConfirm(adminPage);
+
+      const row = adminPage
+        .locator('table')
+        .first()
+        .locator('tr', { hasText: fresh.email });
+      await row.getByRole('button', { name: /Reset 2FA/i }).click();
+
+      await expect(
+        adminPage.getByText(/2FA reset — user will re-enroll/i),
+      ).toBeVisible();
+    } finally {
+      await adminContext.close();
+    }
+  });
+
+  test('super_admin impersonates a user and exits via the banner', async ({
+    browser,
+  }) => {
+    const adminContext = await browser.newContext();
+    const adminPage = await adminContext.newPage();
+    await loginAsSuperAdmin(adminPage);
+
+    const targetContext = await browser.newContext();
+    const fresh = await createAndEnrolUserViaApi(
+      adminPage.request,
+      targetContext.request,
+    );
+    await targetContext.close();
+
+    try {
+      await autoConfirm(adminPage);
+      await adminPage.goto('/admin/users');
+      await autoConfirm(adminPage);
+
+      const row = adminPage
+        .locator('table')
+        .first()
+        .locator('tr', { hasText: fresh.email });
+      await row.getByRole('button', { name: /^Impersonate$/i }).click();
+
+      // The handler invalidates queries + navigates to /. The
+      // ImpersonationBanner mounts with the target's full_name +
+      // the original admin's full_name.
+      await expect(adminPage).toHaveURL(/\/$/);
+      // The "logged in as ..." phrase is unique to the banner — the
+      // success toast just says "Now viewing as ...".
+      const banner = adminPage.getByText(/logged in as Smoke Admin/i);
+      await expect(banner).toBeVisible();
+
+      // Verify server-side: /users/me/context now reports the target
+      // identity with impersonating_from populated.
+      const ctxResp = await adminPage.request.get(
+        `${API_URL}/users/me/context`,
+      );
+      const ctx = (await ctxResp.json()) as {
+        email: string;
+        impersonating_from?: { email: string };
+      };
+      expect(ctx.email).toBe(fresh.email);
+      expect(ctx.impersonating_from?.email).toBe(adminEmail);
+
+      // Click the banner's Stop button — handler hits
+      // /admin/impersonate/stop and invalidates queries.
+      await adminPage
+        .getByRole('button', { name: /^Stop$/i })
+        .click();
+
+      // Banner clears once /users/me re-fetches.
+      await expect(
+        adminPage.getByText(/logged in as Smoke Admin/i),
+      ).toHaveCount(0);
+
+      // /users/me/context now reports the admin again.
+      const after = await adminPage.request.get(
+        `${API_URL}/users/me/context`,
+      );
+      const restored = (await after.json()) as {
+        email: string;
+        impersonating_from?: unknown;
+      };
+      expect(restored.email).toBe(adminEmail);
+      expect(restored.impersonating_from).toBeFalsy();
+    } finally {
+      await adminContext.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Bringing \`make smoke-extended\` from **42/43 → 61/62** by adding eight new specs covering the admin tabs and auth flows that had no UI coverage. Three real product bugs surfaced and got fixed in passing.

## New specs

| Spec | Surface |
|---|---|
| \`users-admin\` | UsersAdmin: edit modal, row MultiSelect role change, admin password reset, admin TOTP reset, super_admin impersonate + exit via banner |
| \`roles-admin\` | RolesAdmin: full CRUD on custom roles + permission attach/detach, system-role protections (no delete, no rename) |
| \`audit-admin\` | AuditAdmin: log viewer + entity filter, row click expands JSON diff |
| \`reminders-admin\` | RemindersAdmin: full CRUD on reminder rules |
| \`email-outbox\` | EmailOutboxAdmin: drain a pending row, row flips to \`sent\` and re-surfaces under the Sent filter |
| \`password-reset\` | /forgot-password → scrape token from console mail backend → /reset-password → log in with new password |
| \`profile-flows\` | Change password (verified end-to-end via API), active sessions table, log-out-everywhere |
| \`notifications\` | NotificationsBell: empty state, list rendering, mark-all-read |

## Product bugs fixed in passing

These were latent — \`smoke-extended\` ran at 42/43 because none of the broken paths were exercised before.

1. **Mantine Select duplicate-options crash on \`/admin/reminders\`.** \`RemindersAdmin\`'s template Select fed every \`(key, locale)\` row into \`data\`; with 4 locales per template since 0005, Mantine v9 throws \"Duplicate options are not supported\" and page-errors the whole modal. Dedupe by key.

2. **\`ReminderRuleCreate\` 422'd every host-defined \`kind\`/\`anchor\`.** Schema constrained both fields to \`Literal[...]\` enums baked from one specific host app's domain (\`booking_arrival\`, \`down_payment\`, etc.). The CLAUDE.md contract says both fields are free-form host-defined strings; the UI's helper-text agrees. Schema now accepts any string. The 422 detail (a list of validation-error objects) was *also* being passed to a Mantine Notification's \`message\`, which React tried to render as a child → React error #31 → blank page. Coerce to string for defence-in-depth.

3. **\`_check_template_exists\` crashed on every reminder create.** \`session.get(EmailTemplate, key)\` worked when the PK was a single column; since 0005 the PK is composite \`(key, locale)\` and \`session.get\` raises. Replaced with an explicit \`select\` query.

Plus migration **0007** adds a paste-able fallback \`{{ reset_url }}\` line to the \`password_reset\` template, mirroring the \`email_verify\` pattern. The sender's tag-strip drops \`<a href>\` URLs, so without this a user reading the email in a plaintext mail client sees \"Click here to set a new password\" with no link.

## Notes for reviewers

- All eight new specs use a 10–30 s describe-level timeout (not the default 30 s) so a regression fails fast instead of waiting out the full timeout.
- Two specs (\`email-outbox\`, \`notifications\`) seed test rows directly via \`mysql exec\` — the same pattern as the existing \`email-templates-i18n\` spec, used because the platform layer doesn't itself emit outbox rows or notifications (host apps do).
- Notification rendering tolerates non-string \`detail\` payloads now; can be backported to other admin components that have the same shape.

## Test plan

- [x] \`make smoke-extended\` → 61 passed, 1 skipped (HIBP fail-open, environment-conditional)
- [x] \`pytest tests/api/test_maintenance.py tests/api/test_app_config.py\` → 17 passed (no regressions)
- [x] Existing 42 specs unchanged in behaviour; new 19 specs all green