### PR TITLE
fix(test): wait for password PATCH in profile-flows change-pw spec

### DIFF
--- a/frontend/tests-e2e/profile-flows.spec.ts
+++ b/frontend/tests-e2e/profile-flows.spec.ts
@@ -71,12 +71,29 @@ test.describe('Profile flows', () => {
       const pwInputs = userPage.locator('input[type="password"]');
       await pwInputs.nth(0).fill(newPassword);
       await pwInputs.nth(1).fill(newPassword);
+      // ``.click()`` doesn't await the network request the click triggers,
+      // so probing /auth/jwt/login immediately afterwards races the
+      // password PATCH — on a slow Docker network the login lands before
+      // the new hash is committed and returns 400 (fastapi-users uses 400
+      // for bad credentials). Arm the response listener before clicking
+      // and await it; that also surfaces a clearer error if the backend
+      // itself rejects the password (HIBP, policy) instead of
+      // misattributing it to "wrong password" on the next request.
+      const updateResponse = userPage.waitForResponse(
+        (resp) =>
+          resp.url().endsWith('/api/users/me') &&
+          resp.request().method() === 'PATCH',
+      );
       await userPage
         .getByRole('button', { name: /^Update password$/i })
         .click();
+      const updateResp = await updateResponse;
+      expect(updateResp.status(), 'password PATCH must succeed').toBeLessThan(
+        400,
+      );
 
       // Verify end-to-end via a fresh context: new password works,
-      // old one doesn't. Skips racing the auto-dismissing toast.
+      // old one doesn't.
       const probe = await browser.newContext();
       try {
         const newLogin = await probe.request.post(


### PR DESCRIPTION
## Summary

The smoke-extended suite's *user can change their password via the profile page* test races: `.click()` on **Update password** doesn't await the `PATCH /api/users/me` it triggers, so the test's immediate `POST /auth/jwt/login` with the new password lands before the new hash commits and returns 400 (fastapi-users uses 400 for bad credentials, per CLAUDE.md gotcha #4). The assertion `expect([200, 204]).toContain(newLogin.status())` then fails.

The pre-existing comment about *"skipping racing the auto-dismissing toast"* addressed the wrong race — the dangerous one is the in-flight PATCH. Arming `waitForResponse` before the click and awaiting it serialises the two, and surfaces a clearer error if the backend itself rejects the password (HIBP, policy) rather than misattributing it to "wrong password" on the next request.

CI has been green because GHA's Linux + same-host Docker stack returns the PATCH faster than the next request can land. macOS Docker Desktop's userland networking adds enough latency that the race fires reliably.

## Test plan

- [x] Reproduced the failure locally before the fix (`Expected value: 400 / Received array: [200, 204]`)
- [x] `make smoke-extended` post-fix: 52 passed + 1 skipped (HIBP — intentional)
- [x] CI green