### PR TITLE
Mobile sidebar + home page polish (#100, #102, #103, #104)

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -10,6 +10,7 @@ import {
   Image,
   Menu,
   NavLink,
+  ScrollArea,
   Select,
   Title,
 } from '@mantine/core';
@@ -23,7 +24,7 @@ import {
   IconLogout,
 } from '@tabler/icons-react';
 import type { ReactElement } from 'react';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Outlet, Link, useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
@@ -52,6 +53,16 @@ export function AppLayout() {
   const location = useLocation();
   const adminItems = useAdminSectionItems();
   const settingsItems = useSettingsSectionItems();
+
+  // Controlled disclosure for the parent nav groups (Settings, Admin,
+  // any future host-registered group). Mantine v9's ``defaultOpened``
+  // is uncontrolled and desyncs on iOS WebKit when the user toggles
+  // parent A → parent B → parent A in quick succession: the chevron
+  // flips closed but the Collapse children stay rendered (issue #102).
+  // Driving ``opened`` from local state eliminates the desync.
+  const [openGroups, setOpenGroups] = useState<Record<string, boolean>>({});
+  const toggleGroup = (key: string) =>
+    setOpenGroups((s) => ({ ...s, [key]: !s[key] }));
 
   const initials = me?.full_name
     ? me.full_name
@@ -179,14 +190,24 @@ export function AppLayout() {
       </AppShell.Header>
 
       <AppShell.Navbar p="xs">
-        {buildNavLinks({
-          me: me ?? null,
-          adminItems,
-          settingsItems,
-          pathname: location.pathname,
-          onNavigate: close,
-          t,
-        })}
+        {/* ScrollArea wrap so when both Settings + Admin are expanded
+         *  on a small viewport the last items remain reachable instead
+         *  of being clipped below the fold (issue #103). On iOS Safari
+         *  the dynamic toolbar makes ``100vh`` overshoot, so without an
+         *  inner scroll container the bottom of the list is hidden
+         *  behind the Safari chrome. */}
+        <AppShell.Section grow component={ScrollArea} type="auto">
+          {buildNavLinks({
+            me: me ?? null,
+            adminItems,
+            settingsItems,
+            pathname: location.pathname,
+            onNavigate: close,
+            openGroups,
+            toggleGroup,
+            t,
+          })}
+        </AppShell.Section>
       </AppShell.Navbar>
 
       <AppShell.Main>
@@ -227,9 +248,20 @@ function buildNavLinks(args: {
   settingsItems: SectionItem[];
   pathname: string;
   onNavigate: () => void;
+  openGroups: Record<string, boolean>;
+  toggleGroup: (key: string) => void;
   t: ReturnType<typeof useTranslation>['t'];
 }) {
-  const { me, adminItems, settingsItems, pathname, onNavigate, t } = args;
+  const {
+    me,
+    adminItems,
+    settingsItems,
+    pathname,
+    onNavigate,
+    openGroups,
+    toggleGroup,
+    t,
+  } = args;
 
   type FlatItem = NavItem & { active: boolean };
   type GroupItem = SectionNavGroup & { active: boolean };
@@ -307,16 +339,20 @@ function buildNavLinks(args: {
 
   return entries.map((entry) => {
     if (isGroup(entry)) {
-      const opened = entry.active;
+      // Controlled opened state. Default to ``true`` for the active
+      // group so navigating into /settings or /admin auto-reveals the
+      // matching children on first paint; once the user has toggled
+      // explicitly, ``openGroups[key]`` overrides. An ``undefined``
+      // entry means "user has not toggled yet" → fall back to active.
+      const userToggled = openGroups[entry.key];
+      const opened = userToggled ?? entry.active;
       return (
         <NavLink
           key={entry.key}
           label={entry.label}
           leftSection={entry.icon}
-          // Default-open when we're already inside the group so the
-          // active child is visible without an extra click; users can
-          // still toggle it closed.
-          defaultOpened={opened}
+          opened={opened}
+          onClick={() => toggleGroup(entry.key)}
           // The parent itself isn't directly clickable — child links
           // own navigation. Marking it active when one of its children
           // is matches the highlight users expect from a sidebar.

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -126,7 +126,13 @@ export function AppLayout() {
       <AppShell.Header>
         <Group h="100%" px="md" justify="space-between">
           <Group gap="sm">
-            <Burger opened={opened} onClick={toggle} hiddenFrom="sm" size="sm" />
+            <Burger
+              opened={opened}
+              onClick={toggle}
+              hiddenFrom="sm"
+              size="sm"
+              aria-label={t('nav.toggle')}
+            />
             {brand?.logo_url && (
               <Link to="/" style={{ display: 'inline-flex' }} aria-label={t('app.title')}>
                 <Image

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -8,7 +8,8 @@
     "settings": "Einstellungen",
     "profile": "Profil",
     "logout": "Abmelden",
-    "notifications": "Benachrichtigungen"
+    "notifications": "Benachrichtigungen",
+    "toggle": "Navigation umschalten"
   },
   "home": {
     "welcome": "Willkommen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -8,7 +8,8 @@
     "settings": "Settings",
     "profile": "Profile",
     "logout": "Log out",
-    "notifications": "Notifications"
+    "notifications": "Notifications",
+    "toggle": "Toggle navigation"
   },
   "home": {
     "welcome": "Welcome",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -8,7 +8,8 @@
     "settings": "Paramètres",
     "profile": "Profil",
     "logout": "Se déconnecter",
-    "notifications": "Notifications"
+    "notifications": "Notifications",
+    "toggle": "Basculer la navigation"
   },
   "home": {
     "welcome": "Bienvenue",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -8,7 +8,8 @@
     "settings": "Instellingen",
     "profile": "Profiel",
     "logout": "Afmelden",
-    "notifications": "Meldingen"
+    "notifications": "Meldingen",
+    "toggle": "Navigatie wisselen"
   },
   "home": {
     "welcome": "Welkom",

--- a/frontend/src/routes/HomePage.tsx
+++ b/frontend/src/routes/HomePage.tsx
@@ -18,12 +18,13 @@ import { getHomeWidgets } from '@/host/registry';
  *  out of the 680px column. The atrium-shipped welcome content stays
  *  in the narrow column.
  *
- *  Once any host widget is registered the greeting + intro read as
- *  orphan chrome above whatever the widget itself owns, so we hide
- *  both (issue #100). On a fresh starter with zero widgets the
- *  greeting + intro still render so the page is never blank. The
- *  action buttons stay either way — they're useful nav regardless
- *  of whether a host owns the page. */
+ *  Once any host widget is registered the greeting + intro + action
+ *  buttons read as orphan atrium chrome above whatever the widget
+ *  itself owns, so we hide all three (issue #100). On a fresh starter
+ *  with zero widgets the greeting + intro + buttons still render so
+ *  the page is never blank and the user has a way into Profile /
+ *  Notifications / Admin. Host apps that want a richer landing surface
+ *  add their own widgets / nav. */
 export function HomePage() {
   const { t } = useTranslation();
   const { data: me } = useMe();
@@ -33,48 +34,46 @@ export function HomePage() {
   return (
     <Stack gap="md">
       <HostHomeWidgets />
-      <Container size={680}>
-        <Stack gap="md">
-          {!hasHostWidgets && (
-            <>
-              <Title order={2}>
-                {me?.full_name
-                  ? t('home.welcomeNamed', { name: me.full_name })
-                  : t('home.welcome')}
-              </Title>
-              <Text c="dimmed">{t('home.intro')}</Text>
-            </>
-          )}
-          <Group>
-            <Button
-              component={Link}
-              to="/profile"
-              variant="light"
-              leftSection={<IconUser size={16} />}
-            >
-              {t('nav.profile')}
-            </Button>
-            <Button
-              component={Link}
-              to="/notifications"
-              variant="light"
-              leftSection={<IconBell size={16} />}
-            >
-              {t('nav.notifications')}
-            </Button>
-            {isAdmin && (
+      {!hasHostWidgets && (
+        <Container size={680}>
+          <Stack gap="md">
+            <Title order={2}>
+              {me?.full_name
+                ? t('home.welcomeNamed', { name: me.full_name })
+                : t('home.welcome')}
+            </Title>
+            <Text c="dimmed">{t('home.intro')}</Text>
+            <Group>
               <Button
                 component={Link}
-                to="/admin"
+                to="/profile"
                 variant="light"
-                leftSection={<IconSettings size={16} />}
+                leftSection={<IconUser size={16} />}
               >
-                {t('nav.admin')}
+                {t('nav.profile')}
               </Button>
-            )}
-          </Group>
-        </Stack>
-      </Container>
+              <Button
+                component={Link}
+                to="/notifications"
+                variant="light"
+                leftSection={<IconBell size={16} />}
+              >
+                {t('nav.notifications')}
+              </Button>
+              {isAdmin && (
+                <Button
+                  component={Link}
+                  to="/admin"
+                  variant="light"
+                  leftSection={<IconSettings size={16} />}
+                >
+                  {t('nav.admin')}
+                </Button>
+              )}
+            </Group>
+          </Stack>
+        </Container>
+      )}
     </Stack>
   );
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -2,6 +2,17 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+/* iOS Safari rubber-bands the document and the dynamic toolbar
+ * collapses on scroll, which together cause the page to "jump up"
+ * when the user reaches the bottom — sometimes hiding content
+ * behind the address bar (issue #104). ``overscroll-behavior: none``
+ * disables the bounce on the root scroller without affecting any
+ * inner ScrollArea (those keep their default contain behaviour). */
+html,
+body {
+  overscroll-behavior-y: none;
+}
+
 /* iOS Safari auto-zooms on *editable* inputs whose computed font-size
  * is below 16px. Readonly inputs (e.g. Mantine's MonthPickerInput)
  * don't trigger the zoom, so leave those at their design size to

--- a/frontend/src/test/home-page-host-widgets.test.tsx
+++ b/frontend/src/test/home-page-host-widgets.test.tsx
@@ -10,12 +10,14 @@
  * heading.
  *
  * The contract:
- *  - Empty registry: greeting + intro render (preserves the
- *    fresh-starter zero-widget experience).
- *  - Any host widget registered: both lines disappear; the widget's
- *    own content is the page.
- *  - The action buttons (Profile / Notifications / Admin) stay either
- *    way — they're nav, not chrome.
+ *  - Empty registry: greeting + intro + nav action buttons render
+ *    (preserves the fresh-starter zero-widget experience and gives
+ *    the user a way into Profile / Notifications / Admin).
+ *  - Any host widget registered: the entire welcome container drops
+ *    as a unit — greeting, intro, and the Profile / Notifications /
+ *    Admin buttons. The buttons read as orphan atrium chrome above
+ *    a host widget; Profile / Notifications / Admin are still
+ *    reachable from the navbar in either case (issue #100).
  */
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
@@ -104,15 +106,32 @@ describe('HomePage — host-widget gate (#100)', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('keeps the nav action buttons even when a host widget is registered', () => {
+  it('drops the nav action buttons with the welcome container when a host widget is registered', () => {
     registerHomeWidget({
       key: 'host-card',
       render: () => <div>host</div>,
     });
     renderHome();
-    // Profile / Notifications are unconditional; Admin shows because
-    // the seeded user has the ``admin`` role. The buttons render as
-    // links via ``<Button component={Link}>`` so probe them by role.
+    // The welcome container ships greeting + intro + Profile /
+    // Notifications / Admin buttons together; once a host widget
+    // registers it drops as a unit so atrium chrome doesn't sit
+    // above the host's content. Profile / Notifications / Admin are
+    // still reachable from the navbar.
+    expect(
+      screen.queryByRole('link', { name: /profile/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: /notifications/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: /admin/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the nav action buttons on a fresh starter (zero widgets)', () => {
+    renderHome();
+    // Empty-registry case: the buttons must still be there so a
+    // fresh starter has a way into the rest of the app.
     expect(screen.getByRole('link', { name: /profile/i })).toBeInTheDocument();
     expect(
       screen.getByRole('link', { name: /notifications/i }),

--- a/frontend/tests-e2e/host-bundle.spec.ts
+++ b/frontend/tests-e2e/host-bundle.spec.ts
@@ -129,6 +129,19 @@ test.describe('host-bundle slot system', () => {
       timeout: 10_000,
     });
 
+    // Once a host registers a home widget the atrium-shipped welcome
+    // chrome (greeting + intro + Profile/Notifications/Admin buttons)
+    // hides — the widget owns the page (issue #100). The Profile /
+    // Notifications / Admin nav still lives in the header avatar
+    // menu and the sidebar, so this is purely the orphan-chrome
+    // removal.
+    await expect(
+      page.getByRole('heading', { name: /Welcome/i }),
+    ).toBeHidden();
+    await expect(
+      page.getByRole('link', { name: /^Profile$/i }),
+    ).toBeHidden();
+
     // 2. Nav item appears in the sidebar (visible on widescreen
     // viewports; mobile drawer would need a Burger click first).
     await expect(

--- a/frontend/tests-e2e/mobile-sidebar.spec.ts
+++ b/frontend/tests-e2e/mobile-sidebar.spec.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+import { test, expect } from '@playwright/test';
+
+import { loginAndPassTOTP } from './helpers';
+
+/**
+ * Mobile sidebar regressions: collapsible parent groups + scrollable
+ * navbar.
+ *
+ *   - Issue #102 — toggling parent A → parent B → parent A on iOS
+ *     WebKit left the chevron in the closed state but the children
+ *     still rendered. The fix moves Mantine's NavLink to controlled
+ *     ``opened`` state. This spec runs under chromium with a mobile
+ *     viewport, which does NOT reproduce the underlying WebKit
+ *     desync, but asserts the *invariant* the fix encodes: tapping a
+ *     parent twice always closes its children. That guarantees we
+ *     don't accidentally regress to the uncontrolled pattern.
+ *
+ *   - Issue #103 — when both Settings + Admin were expanded the last
+ *     items spilled below the viewport on a phone. The fix wraps the
+ *     navbar children in ``<AppShell.Section grow component={ScrollArea}>``.
+ *     Tested by expanding both groups on a short viewport and
+ *     scrolling the navbar to the bottom item.
+ */
+
+const email = process.env.E2E_ADMIN_EMAIL;
+const password = process.env.E2E_ADMIN_PASSWORD;
+const totpSecret = process.env.E2E_ADMIN_TOTP_SECRET;
+
+test.use({ viewport: { width: 390, height: 700 } });
+
+test.beforeAll(() => {
+  if (!email || !password || !totpSecret) {
+    throw new Error(
+      'E2E_ADMIN_EMAIL, E2E_ADMIN_PASSWORD and E2E_ADMIN_TOTP_SECRET must be set to run the mobile-sidebar test.',
+    );
+  }
+});
+
+test('parent NavLink toggle closes its children on the second tap', async ({
+  page,
+}) => {
+  await loginAndPassTOTP(page, email!, password!, totpSecret!);
+  await expect(page).toHaveURL('/');
+
+  // Open the burger menu.
+  await page.getByRole('button', { name: /toggle navigation|burger/i }).click();
+
+  // Scope to the navbar <aside> so we don't match the "Admin" button
+  // on the home page card.
+  const navbar = page.locator('aside');
+  const adminToggle = navbar.getByText(/^Admin$/i);
+  await expect(adminToggle).toBeVisible();
+
+  // First tap — Admin opens, the System child becomes visible.
+  await adminToggle.click();
+  const systemChild = navbar.getByRole('link', { name: /^System$/i });
+  await expect(systemChild).toBeVisible();
+
+  // Second tap — Admin closes again, the child disappears. This is
+  // the assertion that issue #102 violated under iOS WebKit.
+  await adminToggle.click();
+  await expect(systemChild).toBeHidden();
+});
+
+test('navbar is scrollable when content overflows the viewport', async ({
+  page,
+}) => {
+  await loginAndPassTOTP(page, email!, password!, totpSecret!);
+  await expect(page).toHaveURL('/');
+
+  await page.getByRole('button', { name: /toggle navigation|burger/i }).click();
+
+  const navbar = page.locator('aside');
+
+  // Expand the Admin group — atrium ships seven admin tabs which on a
+  // 700px viewport pushes the bottom items below the fold.
+  await navbar.getByText(/^Admin$/i).click();
+
+  // The bottom item must be reachable via scroll. Without the
+  // ScrollArea wrapper the navbar would clip and ``scrollIntoView``
+  // would silently no-op while the element stayed below the fold.
+  const lastTab = navbar.getByRole('link', { name: /Email templates/i });
+  await lastTab.scrollIntoViewIfNeeded();
+  await expect(lastTab).toBeVisible();
+});

--- a/frontend/tests-e2e/mobile-sidebar.spec.ts
+++ b/frontend/tests-e2e/mobile-sidebar.spec.ts
@@ -46,11 +46,11 @@ test('parent NavLink toggle closes its children on the second tap', async ({
   await expect(page).toHaveURL('/');
 
   // Open the burger menu.
-  await page.getByRole('button', { name: /toggle navigation|burger/i }).click();
+  await page.getByRole('button', { name: /toggle navigation/i }).click();
 
   // Scope to the navbar <aside> so we don't match the "Admin" button
   // on the home page card.
-  const navbar = page.locator('aside');
+  const navbar = page.getByRole('navigation');
   const adminToggle = navbar.getByText(/^Admin$/i);
   await expect(adminToggle).toBeVisible();
 
@@ -71,9 +71,9 @@ test('navbar is scrollable when content overflows the viewport', async ({
   await loginAndPassTOTP(page, email!, password!, totpSecret!);
   await expect(page).toHaveURL('/');
 
-  await page.getByRole('button', { name: /toggle navigation|burger/i }).click();
+  await page.getByRole('button', { name: /toggle navigation/i }).click();
 
-  const navbar = page.locator('aside');
+  const navbar = page.getByRole('navigation');
 
   // Expand the Admin group — atrium ships seven admin tabs which on a
   // 700px viewport pushes the bottom items below the fold.


### PR DESCRIPTION
## Summary

Four mobile/home UX bugs reported on iPhone Safari + Chrome; bundled into one PR because they ship together cleanly and are the same axis of polish.

- **#100** — `HomePage` action buttons (Profile / Notifications / Admin) survived the v0.21.0 greeting hide and looked like orphan chrome above a host home widget. Move the entire welcome `Container` (greeting + intro + buttons) inside the `!hasHostWidgets` gate so it drops as a unit. Empty-state behaviour unchanged.
- **#102** — Mantine v9 `<NavLink defaultOpened={…}>` is uncontrolled and desyncs on iOS WebKit when the user toggles parent A → parent B → parent A: chevron flips closed but the `<Collapse>` content stays rendered. Switch to controlled `opened` + `onClick` toggle backed by `useState<Record<string, boolean>>` keyed by the entry key. The active group still defaults open on first paint until the user explicitly toggles.
- **#103** — When both Settings + Admin expand on a phone-sized viewport the last admin tabs spilled past the visible viewport. Wrap the navbar in `<AppShell.Section grow component={ScrollArea}>` (the documented Mantine pattern). iOS Safari's dynamic toolbar makes `100vh` overshoot, so without an inner scroller the bottom items hid behind the address bar.
- **#104** — iOS Safari rubber-bands the document at the bottom edge while the dynamic toolbar collapses on scroll-down; together they cause a "jump up" that hides content behind the address bar. `overscroll-behavior-y: none` on `html, body` disables only the root rubber-band; inner `ScrollArea`s keep their default contain behaviour.
- Drive-by a11y improvement: Mantine's `<Burger>` had no accessible name. Added `aria-label={t('nav.toggle')}` with translations seeded for en/nl/de/fr.

Closes #100. Closes #102. Closes #103. Closes #104.

## Test plan

- [x] `tsc -b --noEmit` clean.
- [x] `make smoke` (9 tests) green against the rebuilt e2e image.
- [x] New `mobile-sidebar.spec.ts` (extended project, 390x700 viewport, 2 tests) green — asserts the second-tap-closes invariant from #102 and the navbar-scroll reachability from #103.
- [x] `host-bundle.spec.ts` extended to assert the welcome heading and the home Profile button are hidden when a host home widget is registered (covers #100).
- [ ] Manual verification on a real iPhone (Safari + Chrome) for #102 and #104 — the chromium-based Playwright suite cannot reproduce the underlying iOS WebKit behaviours, only the new invariants. Reachable at `https://localhost:9443` while the smoke stack is up.