### PR TITLE
Widen vite-plugin-css-injected-by-js peer to ^3 || ^4 || ^5

### DIFF
--- a/packages/host-bundle-utils/package.json
+++ b/packages/host-bundle-utils/package.json
@@ -39,7 +39,7 @@
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
-    "vite-plugin-css-injected-by-js": "^3.0.0"
+    "vite-plugin-css-injected-by-js": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {
     "vite": {


### PR DESCRIPTION
## Summary

Closes #110.

`@brendanbank/atrium-host-bundle-utils` declared `vite-plugin-css-injected-by-js: ^3.0.0` while the sibling `vite` peer spans four majors. Hosts on the plugin's v5 (e.g. casa) work fine — typecheck, vitest, and `vite build` all green — but `pnpm install` emits an `unmet peer` warning on every install. The narrow peer was an oversight when the `vite` peer was widened, not a real constraint.

The dynamic import in `src/vite/index.ts:88-96` already handles both `.default` and direct-function export shapes, and atrium's own `examples/hello-world/frontend` already ships v5.0.1 against this package.

## What changed

- `packages/host-bundle-utils/package.json`: peer range widened to `^3.0.0 || ^4.0.0 || ^5.0.0`. No source code change; lockfile unchanged.

## Test plan

- [x] `pnpm install --lockfile-only` — no diff
- [x] `pnpm typecheck` (host-bundle-utils) — clean
- [x] `pnpm test` (host-bundle-utils) — 45/45 pass
- A pure peer-range metadata change has no functional regression test inside this repo. The `make smoke-hello` path indirectly covers it (hello-world consumes v5.0.1 against this peer).