### PR TITLE
test(unit): PAT rate-limit + lifetime cap unit tests (follow-up to #117)

### DIFF
--- a/backend/tests/unit/test_pat_lifetime_caps.py
+++ b/backend/tests/unit/test_pat_lifetime_caps.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Unit tests for the lifetime-cap helpers in ``app.api.auth_tokens``.
+
+Pure date arithmetic — no DB, no FastAPI, no fixtures. The integration
+tests exercise the same code paths through the real endpoint, but
+unit-testing the cap logic in isolation makes the boundary cases
+(None inputs, max-lifetime ceiling, naive vs aware datetimes)
+faster to read and harder to regress.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from app.api.auth_tokens import (
+    _cap_absolute_expires_at,
+    _cap_expires_at,
+    _row_status,
+)
+from app.models.auth_token import AuthToken
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+# ---- _cap_expires_at ----------------------------------------------------
+
+
+def test_cap_expires_at_no_input_no_policy_means_never():
+    """``None`` in, ``None`` out when there's no policy ceiling."""
+    assert _cap_expires_at(None, None) is None
+
+
+def test_cap_expires_at_no_input_with_policy_lands_at_ceiling():
+    """Caller asked for no expiry but operator policy caps at N days
+    — token still gets an expiry at ``now + N``."""
+    before = _utcnow()
+    result = _cap_expires_at(None, max_lifetime_days=30)
+    assert result is not None
+    delta = result - before
+    # Allow a generous second of slack for clock advancing during the
+    # call without making the test flaky.
+    assert timedelta(days=29, hours=23) < delta <= timedelta(days=30, seconds=2)
+
+
+def test_cap_expires_at_request_below_policy_uses_request():
+    """If the caller's request fits inside the policy ceiling, use it
+    verbatim — no surprise extension."""
+    before = _utcnow()
+    result = _cap_expires_at(7, max_lifetime_days=30)
+    delta = result - before
+    assert timedelta(days=6, hours=23) < delta <= timedelta(days=7, seconds=2)
+
+
+def test_cap_expires_at_request_above_policy_clamps_silently():
+    """A request for 90 days under a 7-day policy lands at 7 days.
+    The endpoint refuses overreach loudly elsewhere; here we silently
+    clamp because the caller's intent (a long-lived token) is
+    honoured to the policy maximum."""
+    before = _utcnow()
+    result = _cap_expires_at(90, max_lifetime_days=7)
+    delta = result - before
+    assert timedelta(days=6, hours=23) < delta <= timedelta(days=7, seconds=2)
+
+
+def test_cap_expires_at_request_with_no_policy_uses_request():
+    before = _utcnow()
+    result = _cap_expires_at(365, max_lifetime_days=None)
+    delta = result - before
+    assert timedelta(days=364, hours=23) < delta <= timedelta(days=365, seconds=2)
+
+
+# ---- _cap_absolute_expires_at ------------------------------------------
+
+
+def test_cap_absolute_expires_at_passthrough_when_no_policy():
+    far = _utcnow() + timedelta(days=365)
+    assert _cap_absolute_expires_at(far, None) == far
+
+
+def test_cap_absolute_expires_at_passthrough_when_below_ceiling():
+    """User requests 5 days under a 30-day policy — keep the user's
+    value, don't push it out to 30."""
+    target = _utcnow() + timedelta(days=5)
+    result = _cap_absolute_expires_at(target, max_lifetime_days=30)
+    assert result == target
+
+
+def test_cap_absolute_expires_at_clamps_to_now_plus_max():
+    """User requests 365 days under a 30-day policy — land at
+    now + 30 (not the user's far-future value)."""
+    before = _utcnow()
+    target = _utcnow() + timedelta(days=365)
+    result = _cap_absolute_expires_at(target, max_lifetime_days=30)
+    delta = result - before
+    assert timedelta(days=29, hours=23) < delta <= timedelta(days=30, seconds=2)
+
+
+def test_cap_absolute_expires_at_none_passthrough():
+    assert _cap_absolute_expires_at(None, max_lifetime_days=30) is None
+
+
+# ---- _row_status -------------------------------------------------------
+
+
+def test_row_status_active_when_no_expiry_no_revoke():
+    row = AuthToken(
+        token_prefix="atr_pat_aaaa",
+        token_hash="x",
+        scopes=[],
+        created_at=_utcnow(),
+    )
+    assert _row_status(row) == "active"
+
+
+def test_row_status_revoked_wins_over_expiry():
+    """A token revoked *and* past its expiry is reported as ``revoked``
+    — the explicit operator action ranks above the implicit timeout."""
+    past = _utcnow() - timedelta(days=10)
+    row = AuthToken(
+        token_prefix="atr_pat_aaaa",
+        token_hash="x",
+        scopes=[],
+        created_at=past,
+        expires_at=past + timedelta(days=1),
+        revoked_at=_utcnow(),
+    )
+    assert _row_status(row) == "revoked"
+
+
+def test_row_status_expired_when_past_expires_at():
+    row = AuthToken(
+        token_prefix="atr_pat_aaaa",
+        token_hash="x",
+        scopes=[],
+        created_at=_utcnow() - timedelta(days=10),
+        expires_at=_utcnow() - timedelta(seconds=1),
+    )
+    assert _row_status(row) == "expired"
+
+
+def test_row_status_active_when_expires_at_in_future():
+    row = AuthToken(
+        token_prefix="atr_pat_aaaa",
+        token_hash="x",
+        scopes=[],
+        created_at=_utcnow(),
+        expires_at=_utcnow() + timedelta(days=1),
+    )
+    assert _row_status(row) == "active"

--- a/backend/tests/unit/test_pat_rate_limit.py
+++ b/backend/tests/unit/test_pat_rate_limit.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Unit tests for the per-token sliding-window rate limiter.
+
+Pure data-structure tests — no DB, no FastAPI. Time is patched via
+``time.monotonic`` so a 60-second window can be advanced in zero
+wall-clock time.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services import pat_rate_limit
+from app.services.pat_rate_limit import PatSlidingWindow
+
+
+@pytest.fixture
+def fake_clock(monkeypatch):
+    """Replace ``time.monotonic`` inside ``pat_rate_limit`` with a
+    settable value so the tests can step through the window without
+    sleeping."""
+    state = {"now": 1_000_000.0}
+
+    def _now() -> float:
+        return state["now"]
+
+    monkeypatch.setattr(pat_rate_limit.time, "monotonic", _now)
+    return state
+
+
+def test_first_n_requests_allowed_then_429(fake_clock):
+    win = PatSlidingWindow()
+    for _ in range(3):
+        allowed, retry = win.check(token_id=1, limit=3)
+        assert allowed is True
+        assert retry == 0
+    allowed, retry = win.check(token_id=1, limit=3)
+    assert allowed is False
+    assert retry >= 1
+
+
+def test_window_slides_after_60_seconds(fake_clock):
+    """Hits older than 60 s drop out of the window — the bucket
+    refills automatically as time advances."""
+    win = PatSlidingWindow()
+    for _ in range(2):
+        assert win.check(token_id=1, limit=2)[0] is True
+    assert win.check(token_id=1, limit=2)[0] is False
+
+    # Advance past the window — both prior hits age out.
+    fake_clock["now"] += 61
+    assert win.check(token_id=1, limit=2)[0] is True
+    assert win.check(token_id=1, limit=2)[0] is True
+    assert win.check(token_id=1, limit=2)[0] is False
+
+
+def test_partial_window_slide_only_drops_old_hits(fake_clock):
+    """Two hits at t=0, two more at t=30. At t=70 the first two are
+    out of window, the second two still count."""
+    win = PatSlidingWindow()
+    win.check(token_id=1, limit=4)
+    win.check(token_id=1, limit=4)
+    fake_clock["now"] += 30
+    win.check(token_id=1, limit=4)
+    win.check(token_id=1, limit=4)
+    # Cap at 4 — bucket full.
+    assert win.check(token_id=1, limit=4)[0] is False
+
+    # Advance to t=70: first two hits aged out; bucket has 2/4.
+    fake_clock["now"] += 40
+    assert win.check(token_id=1, limit=4)[0] is True
+    assert win.check(token_id=1, limit=4)[0] is True
+    # 4/4 again.
+    assert win.check(token_id=1, limit=4)[0] is False
+
+
+def test_separate_token_ids_have_independent_buckets(fake_clock):
+    """Rate limiting is per-token — one token's burst must not
+    starve another's budget."""
+    win = PatSlidingWindow()
+    for _ in range(3):
+        assert win.check(token_id=1, limit=3)[0] is True
+    assert win.check(token_id=1, limit=3)[0] is False
+
+    # Token 2 is unaffected.
+    assert win.check(token_id=2, limit=3)[0] is True
+
+
+def test_retry_after_at_least_one_second(fake_clock):
+    """Even when the oldest hit is < 1 s from ageing out, Retry-After
+    must be at least 1 — clients shouldn't retry on a 0-s header."""
+    win = PatSlidingWindow()
+    win.check(token_id=1, limit=1)
+    # 59.5 s later: the oldest hit ages out in 0.5 s.
+    fake_clock["now"] += 59.5
+    allowed, retry = win.check(token_id=1, limit=1)
+    assert allowed is False
+    assert retry >= 1
+
+
+def test_reset_specific_token_clears_only_its_bucket(fake_clock):
+    win = PatSlidingWindow()
+    win.check(token_id=1, limit=1)
+    win.check(token_id=2, limit=1)
+    win.reset(token_id=1)
+    assert win.check(token_id=1, limit=1)[0] is True   # bucket fresh
+    assert win.check(token_id=2, limit=1)[0] is False  # untouched
+
+
+def test_reset_all_clears_every_bucket(fake_clock):
+    win = PatSlidingWindow()
+    win.check(token_id=1, limit=1)
+    win.check(token_id=2, limit=1)
+    win.reset()
+    assert win.check(token_id=1, limit=1)[0] is True
+    assert win.check(token_id=2, limit=1)[0] is True
+
+
+def test_module_level_check_rate_limit_uses_singleton(fake_clock):
+    """``check_rate_limit`` is what ``PATAuthMiddleware`` calls. It
+    delegates to a process-wide ``PatSlidingWindow``; ``reset_for_tests``
+    clears it. Verify both."""
+    pat_rate_limit.reset_for_tests()
+    assert pat_rate_limit.check_rate_limit(token_id=42, limit_per_minute=2) == (
+        True,
+        0,
+    )
+    assert pat_rate_limit.check_rate_limit(token_id=42, limit_per_minute=2) == (
+        True,
+        0,
+    )
+    allowed, retry = pat_rate_limit.check_rate_limit(
+        token_id=42, limit_per_minute=2
+    )
+    assert allowed is False
+    assert retry >= 1
+
+    pat_rate_limit.reset_for_tests(token_id=42)
+    assert pat_rate_limit.check_rate_limit(token_id=42, limit_per_minute=2)[0] is True


### PR DESCRIPTION
Follow-up to #117 (Phase 2 PATs). I pushed these unit tests to ``pat-phase-2`` after the PR had already merged, so they never landed on master — opening as a separate small PR.

## Summary

Phase 2's pure-logic helpers were only exercised transitively through the integration tests. Match Phase 1's pattern of dedicated ``tests/unit/`` files for leaf modules and add focused coverage:

- **``PatSlidingWindow``** — window slide, partial slide, per-token bucket isolation, retry-after floor, reset semantics, module singleton (8 tests).
- **``_cap_expires_at`` / ``_cap_absolute_expires_at``** — policy cap edge cases: None inputs, below-ceiling passthrough, silent clamp on overreach (9 tests).
- **``_row_status``** — revoked-wins-over-expired ordering (4 tests).

Time is patched via ``monkeypatch`` on ``time.monotonic`` so the 60-second window advances in zero wall-clock time.

## Test plan

- [x] ``uv run pytest tests/unit/test_pat_rate_limit.py tests/unit/test_pat_lifetime_caps.py`` — 21 passed in ~6 s
- [x] ``uv run ruff check .`` clean
- [x] Full suite ``make test-backend`` — 321 passed (300 prior + 21 new)