### PR TITLE
Phase 4 PATs: enable default + README + log redaction (#116)

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,26 @@ shows the setup picker to unenrolled users — the distinct code lets
 the UI surface a clearer "your account requires 2FA" hint. Empty
 list (the default) = no enforcement.
 
+## Personal Access Tokens
+
+Long-lived bearer tokens that let scripts, MCP sidecars, CI jobs, and
+other non-interactive callers act as a user without driving the cookie
++ 2FA login flow. A PAT carries a subset of its issuing user's
+permissions and is checked against the user's *current* permissions on
+every request — losing a permission silently drops the matching scope
+from every token the user holds. Tokens are revocable, expirable, and
+auditable; the wire format is GitHub-style (`atr_pat_…`) so leaks are
+detectable by secret scanners and the structlog redactor masks the
+secret portion in any log line that captures it.
+
+Users manage their own tokens at **Profile → Tokens**; super-admins
+see every token across all users at **Admin → Tokens** and can also
+mint service-account users that exist only to hold PATs. PATs are
+enabled by default; flip `pats.enabled` off via `/admin/app-config` if
+a tenant needs to disable programmatic auth wholesale. Full design
+spec: [issue #112](https://github.com/brendanbank/atrium/issues/112).
+Host-app integration notes: [`docs/published-images.md`](docs/published-images.md).
+
 ## CAPTCHA (optional)
 
 Atrium can gate the unauthenticated auth endpoints (login + forgot

--- a/backend/app/auth/pat_middleware.py
+++ b/backend/app/auth/pat_middleware.py
@@ -119,7 +119,7 @@ def _q(value: str) -> str:
 
 async def _read_pats_config():
     """Read ``app_settings['pats']``. On any failure return the model
-    defaults (which include ``enabled=False``).
+    defaults (which include ``enabled=True`` since Phase 4).
 
     Reading on every PAT-presenting request is fine: PATs are far
     rarer than cookie requests, and a 2-3 ms DB hit per PAT call is

--- a/backend/app/logging.py
+++ b/backend/app/logging.py
@@ -2,11 +2,69 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import logging
+import re
 import sys
+from typing import Any
 
 import structlog
 
 from app.settings import get_settings
+
+# A PAT is ``atr_pat_<32 base64url>_<6 base32>`` — see
+# ``app.auth.pat_format``. We match the prefix plus any run of the
+# alphabet either body half uses (base64url + ``_`` separator + base32);
+# this is intentionally generous so a single regex catches both the
+# full 47-char token and any truncated/concatenated form an operator
+# might have logged by accident.
+_PAT_TOKEN_RE = re.compile(r"atr_pat_[A-Za-z0-9_-]+")
+_REDACTION_TAG = "***REDACTED***"
+
+
+def _redact_pat_match(match: re.Match[str]) -> str:
+    """Keep the 12-char lookup prefix (``atr_pat_`` + 4 secret chars)
+    when the captured run is long enough to contain it. The lookup
+    prefix is also what ``auth_tokens.token_prefix`` stores, so a
+    redacted log line still correlates to a row in the DB. Anything
+    shorter is collapsed entirely — there's no useful identifier
+    left."""
+    full = match.group(0)
+    if len(full) > 12:
+        return f"{full[:12]}{_REDACTION_TAG}"
+    return _REDACTION_TAG
+
+
+def _redact_value(value: Any) -> Any:
+    """Walk ``value`` and replace every ``atr_pat_*`` substring with
+    a redaction tag. Strings get an in-place regex sub; mappings and
+    sequences are recursed; everything else passes through.
+
+    The recursion preserves the container type (``dict``, ``list``,
+    ``tuple``) so structured headers / payloads survive intact —
+    only the secret is masked. ``set`` and ``frozenset`` are also
+    walked, but they're unusual in log payloads."""
+    if isinstance(value, str):
+        return _PAT_TOKEN_RE.sub(_redact_pat_match, value)
+    if isinstance(value, dict):
+        return {k: _redact_value(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact_value(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(_redact_value(v) for v in value)
+    return value
+
+
+def redact_pat_tokens(
+    _logger: Any, _method_name: str, event_dict: dict[str, Any]
+) -> dict[str, Any]:
+    """structlog processor that strips ``atr_pat_*`` from every field.
+
+    Catches the obvious leak channels (a stray ``Authorization``
+    header, a request body printed in a debug log, a token spliced
+    into an exception message) without forcing each call site to
+    remember to scrub. The processor is keyed on the token prefix
+    only — it doesn't try to recognise password fields or other
+    secrets, since those have no stable wire shape to match on."""
+    return {key: _redact_value(value) for key, value in event_dict.items()}
 
 
 def configure_logging() -> None:
@@ -23,6 +81,7 @@ def configure_logging() -> None:
         structlog.contextvars.merge_contextvars,
         structlog.processors.add_log_level,
         structlog.processors.TimeStamper(fmt="iso", utc=True),
+        redact_pat_tokens,
     ]
     if settings.environment == "dev":
         processors.append(structlog.dev.ConsoleRenderer())

--- a/backend/app/services/app_config.py
+++ b/backend/app/services/app_config.py
@@ -135,13 +135,13 @@ class PatsConfig(BaseModel):
     limits and audit-sampling knobs don't dilute the password /
     captcha / 2FA settings.
 
-    ``enabled`` defaults to ``False`` for the v1 ship. Operators
-    flip it on per environment once they've reviewed the audit
-    surface and the host app's permission slugs.
+    ``enabled`` defaults to ``True`` — fresh deploys ship with PATs
+    available. Operators who want to disable PATs opt out via
+    ``/admin/app-config``; the kill switch still applies post-incident.
     """
 
     enabled: bool = Field(
-        default=False,
+        default=True,
         description="Disable to turn off PATs entirely (kill switch).",
     )
     max_lifetime_days: int | None = Field(

--- a/backend/tests/unit/test_pat_log_redaction.py
+++ b/backend/tests/unit/test_pat_log_redaction.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Unit tests for ``app.logging.redact_pat_tokens``.
+
+A leaked PAT is a credential leak. The structlog processor scrubs
+``atr_pat_*`` substrings from every field in the event dict so a
+request body or ``Authorization`` header that ends up in a log line
+doesn't carry a usable token. The 12-char lookup prefix is preserved
+because it matches ``auth_tokens.token_prefix`` — the operator can
+correlate a redacted log line to a row, but cannot recover the
+secret.
+"""
+from __future__ import annotations
+
+import json
+
+import structlog
+
+from app.auth.pat_format import generate_token
+from app.logging import (
+    _PAT_TOKEN_RE,
+    _REDACTION_TAG,
+    redact_pat_tokens,
+)
+
+# ---- the regex itself ---------------------------------------------------
+
+
+def test_regex_matches_full_token():
+    full, _ = generate_token()
+    assert _PAT_TOKEN_RE.fullmatch(full) is not None
+
+
+def test_regex_does_not_match_unrelated_strings():
+    assert _PAT_TOKEN_RE.search("hello world") is None
+    assert _PAT_TOKEN_RE.search("atrium_audit_log") is None
+    # Bare prefix without any secret body is not a token.
+    assert _PAT_TOKEN_RE.search("atr_pat_") is None
+
+
+# ---- redaction processor ------------------------------------------------
+
+
+def test_redacts_bare_token_in_string_field():
+    full, prefix = generate_token()
+    event = {"event": f"saw token {full}", "level": "info"}
+
+    result = redact_pat_tokens(None, "info", event)
+
+    assert full not in result["event"]
+    assert _REDACTION_TAG in result["event"]
+    # Lookup prefix preserved for correlation with auth_tokens.token_prefix.
+    assert prefix in result["event"]
+
+
+def test_redacts_authorization_header_value():
+    full, prefix = generate_token()
+    event = {
+        "event": "request",
+        "headers": {"Authorization": f"Bearer {full}", "X-Other": "ok"},
+    }
+
+    result = redact_pat_tokens(None, "info", event)
+
+    assert full not in result["headers"]["Authorization"]
+    assert prefix in result["headers"]["Authorization"]
+    assert result["headers"]["Authorization"].startswith("Bearer atr_pat_")
+    # Untouched fields survive untouched.
+    assert result["headers"]["X-Other"] == "ok"
+    assert result["event"] == "request"
+
+
+def test_redacts_inside_nested_lists_and_tuples():
+    full, _ = generate_token()
+    event = {
+        "items": [f"prefix {full} suffix", "no token here"],
+        "pair": (full, "ok"),
+    }
+
+    result = redact_pat_tokens(None, "info", event)
+
+    assert full not in result["items"][0]
+    assert _REDACTION_TAG in result["items"][0]
+    assert result["items"][1] == "no token here"
+    # Tuple shape preserved.
+    assert isinstance(result["pair"], tuple)
+    assert full not in result["pair"][0]
+    assert result["pair"][1] == "ok"
+
+
+def test_redacts_multiple_tokens_in_one_string():
+    full_a, _ = generate_token()
+    full_b, _ = generate_token()
+    event = {"event": f"a={full_a} b={full_b}"}
+
+    result = redact_pat_tokens(None, "info", event)
+
+    assert full_a not in result["event"]
+    assert full_b not in result["event"]
+    assert result["event"].count(_REDACTION_TAG) == 2
+
+
+def test_passes_non_string_values_through():
+    event = {"count": 42, "active": True, "extra": None}
+    assert redact_pat_tokens(None, "info", event) == event
+
+
+def test_short_prefix_only_match_is_collapsed_entirely():
+    # ``atr_pat_`` + 1 secret char isn't long enough to contain a
+    # useful 12-char correlation prefix; collapse it completely so
+    # nothing leaks.
+    event = {"event": "atr_pat_x"}
+
+    result = redact_pat_tokens(None, "info", event)
+
+    assert result["event"] == _REDACTION_TAG
+
+
+# ---- integration with the structlog renderer ----------------------------
+
+
+def test_processor_chain_redacts_through_json_renderer():
+    """Wire the processor up like ``configure_logging`` does and
+    confirm the rendered JSON line carries no plaintext token."""
+    full, prefix = generate_token()
+    structlog.configure(
+        processors=[
+            redact_pat_tokens,
+            structlog.processors.JSONRenderer(),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(20),
+        cache_logger_on_first_use=False,
+    )
+    try:
+        captured: list[str] = []
+
+        class _Capture:
+            def msg(self, message: str) -> None:
+                captured.append(message)
+
+            info = msg
+
+        logger = structlog.wrap_logger(_Capture())
+        logger.info("inbound", auth=f"Bearer {full}")
+    finally:
+        structlog.reset_defaults()
+
+    assert len(captured) == 1
+    payload = json.loads(captured[0])
+    assert full not in captured[0]
+    assert _REDACTION_TAG in payload["auth"]
+    assert prefix in payload["auth"]

--- a/backend/tests/unit/test_pats_config_defaults.py
+++ b/backend/tests/unit/test_pats_config_defaults.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Unit tests pinning the ``PatsConfig`` defaults.
+
+Phase 4 flipped ``enabled`` from ``False`` to ``True`` so fresh
+deploys ship with PATs available. The other knobs (lifetime cap,
+per-user cap, rate limit, audit sample rate, dormant warning) stay
+where Phase 1 set them, but the test pins them too — a silent change
+to any default would alter the behaviour of every deployment that
+hasn't written a ``pats`` row yet, which is precisely the breakage
+``app_settings`` defaults are designed to resist.
+"""
+from __future__ import annotations
+
+from app.services.app_config import PatsConfig
+
+
+def test_pats_enabled_defaults_to_true():
+    """Phase 4 default. New deploys get PATs out of the box."""
+    assert PatsConfig().enabled is True
+
+
+def test_pats_other_defaults_pinned():
+    cfg = PatsConfig()
+    assert cfg.max_lifetime_days is None
+    assert cfg.max_per_user == 50
+    assert cfg.default_rate_limit_per_minute == 600
+    assert cfg.use_audit_sample_rate == 0.02
+    assert cfg.dormant_warning_days == 90

--- a/docs/published-images.md
+++ b/docs/published-images.md
@@ -273,6 +273,36 @@ FastAPI but emits a deprecation warning. **Use the migration form** unless
 you need runtime discovery — it sidesteps the lifespan-vs-events conflict
 and matches the schema-shaped nature of permissions.
 
+### Personal Access Tokens (PATs)
+
+PATs are enabled by default in atrium (`pats.enabled = True`). Host
+apps don't have to do anything to support them: your routes get the
+same `request.user` and the same `require_perm(...)` checks regardless
+of whether the caller authenticated via the cookie + 2FA flow or via a
+`Authorization: Bearer atr_pat_…` header. The PAT middleware mounts
+upstream of the route handlers and sets the same `Principal` on the
+request scope — `principal.auth_method` is `"pat"` (or
+`"service_account_pat"`) when you want to branch, but you usually
+shouldn't have to.
+
+PATs respect host-registered permissions automatically. Any permission
+seeded via `seed_permissions_sync` / `seed_permissions` (above) appears
+in the user's scope picker on **Profile → Tokens** as soon as the user
+holds it, and a super-admin granted `auth.pats.admin_read` sees every
+host permission show up in the **Admin → Tokens** filters. There's no
+host-side wiring step — registering the permission is the integration.
+
+The audit + rate-limit infrastructure is platform-owned too: PAT
+creation, rotation, revocation, and use are recorded in `audit_log`,
+with use-events sampled at the rate set by
+`pats.use_audit_sample_rate`. Per-token rate limits default to 600
+req/min and are tunable through `/admin/app-config`. PAT-authed
+requests are subject to maintenance mode like every other request —
+this is by design (see issue #112 §13). If a host app needs an
+automated caller to keep working during maintenance, add the path to
+`MaintenanceMiddleware`'s allow-list rather than working around the
+PAT layer.
+
 ---
 
 ## Frontend extension contract


### PR DESCRIPTION
## Summary

Final phase of the Personal Access Tokens spec ([issue #112](https://github.com/brendanbank/atrium/issues/112)). Closes [#116](https://github.com/brendanbank/atrium/issues/116).

- Flip `PatsConfig.enabled` default from `False` to `True` — fresh deploys ship with PATs available; operators opt out via `/admin/app-config`.
- Add `redact_pat_tokens` structlog processor in `app/logging.py` that scrubs `atr_pat_*` from every event field while preserving the 12-char lookup prefix (so a log line still correlates to `auth_tokens.token_prefix`). Active for both JSON and Console renderers.
- README section under Auth describing what PATs are and linking to the design spec and host-dev addendum.
- `docs/published-images.md` host-dev addendum: host routes get the same `request.user` and `require_perm` checks regardless of auth method; host-registered permissions automatically appear in the scope picker; PATs are subject to maintenance mode by design.
- Unit tests for the redaction processor (8 cases) and `PatsConfig` defaults (2 cases).

## Out of scope (follow-ups)

- GitHub secret-scanning partnership application + `/api/auth/tokens/secret-scan-webhook` revocation handler. The partnership form points at a public webhook, which needs to exist first — file as a 24-hour follow-up after release.
- Hand-written CHANGELOG / release notes for the version that ships PATs (mention service accounts as a sibling). Belongs with the release tag, not this PR.

## Test plan

- [x] `pytest tests/unit/` — 11 new tests pass.
- [x] Full backend suite — 332 passed.
- [x] `ruff check` — clean.
- [ ] Manual smoke on a fresh deploy (`make smoke` extension or manual): create PAT via UI → use it → revoke. Defer until merge to master + release-image rebuild.

## Notes

- The flip isn't reversible mid-release: once shipped, downgrading would leave existing PAT rows orphaned. That's fine — `pats.enabled=False` makes them all 401 on use without any schema change.
- The redaction processor is keyed on the `atr_pat_` prefix only; other secrets (passwords, JWTs) have no stable wire shape to match on and aren't covered here.