### PR TITLE
docs: surface host-extension foot-guns (closes #122)

### DIFF
--- a/docs/new-project/README.md
+++ b/docs/new-project/README.md
@@ -169,16 +169,24 @@ from fastapi import FastAPI
 
 from app.host_sdk.worker import HostWorkerCtx
 
+# Optional: register an app_settings namespace at module-import time.
+# Atrium imports this bootstrap module from BOTH the api and the worker
+# process. `register_namespace` mutates a per-process dict in
+# `app.services.app_config`, so a call from inside `init_app` is only
+# visible to the api process — `init_worker`-registered code calling
+# `get_namespace(session, "your_ns")` would `KeyError`. Register at
+# module top-level so both processes pick it up on import.
+#
+# from app.services.app_config import register_namespace
+# from .config import YourConfig
+# register_namespace("your_ns", YourConfig, public=False)
+
 
 def init_app(app: FastAPI) -> None:
     """Called once during create_app(), after every atrium router is
     included and before the SPA static mount + ASGI start."""
     from .router import router
     app.include_router(router)
-    # Optional: register an app_settings namespace.
-    # from app.services.app_config import register_namespace
-    # from .config import YourConfig
-    # register_namespace("your_ns", YourConfig, public=False)
 
 
 def init_worker(host: HostWorkerCtx) -> None:
@@ -986,7 +994,7 @@ Adding an endpoint, a job, a UI fragment — the standard moves:
 | New permission                | A new alembic migration                                  | `seed_permissions_sync(op.get_bind(), [...], grants={...})`                |
 | Recurring tick                | `<your_pkg>/schedule.py` async function                  | `host.scheduler.add_job(fn, "interval", seconds=N, ...)` in `init_worker`  |
 | Durable async job             | A handler `(session, job, payload) -> None`              | `host.register_job_handler(kind="...", handler=..., description="...")` in `init_worker` |
-| Admin-tunable flag            | A Pydantic `BaseModel` config class                      | `register_namespace("ns", Model, public=False)` in `init_app`              |
+| Admin-tunable flag            | A Pydantic `BaseModel` config class                      | `register_namespace("ns", Model, public=False)` at module top-level of `bootstrap.py` (api + worker both import the module — calling from `init_app` only reaches the api) |
 | Per-user notification         | Inside the txn that mutated the row                      | `from app.services.notifications import notify_user`                       |
 | Outbound email (queued)       | A template row in `email_templates` + a callsite         | `from app.email.sender import enqueue_and_log`                             |
 | Synchronous email             | Same template; for password-reset-style flows            | `from app.email.sender import send_and_log`                                |

--- a/docs/new-project/SKILL.md
+++ b/docs/new-project/SKILL.md
@@ -101,6 +101,11 @@ Create these files (full contents in [`README.md`](README.md), section
   description=...)` and APScheduler ticks via
   `host.scheduler.add_job(...)`. Either may be absent (atrium logs
   `host.init_app.absent`); both run loud if the module fails to import.
+  **Call `register_namespace(...)` at module top-level**, not inside
+  `init_app` — atrium imports `bootstrap.py` from both the api and the
+  worker process, but only the api calls `init_app`. A namespace
+  registered inside `init_app` is invisible to worker handlers and
+  every `get_namespace(session, "ns")` from there will `KeyError`.
 - `backend/src/<your_pkg>/models.py` — define `class HostBase(DeclarativeBase)`
   and your tables on it. **Never** parent host tables on `app.db.Base`.
 - `backend/src/<your_pkg>/router.py` — a normal FastAPI APIRouter.

--- a/docs/published-images.md
+++ b/docs/published-images.md
@@ -13,6 +13,15 @@ npx @brendanbank/create-atrium-host casa-del-leone
 cd casa-del-leone && cp .env.example .env && make dev-bootstrap
 ```
 
+`make dev-bootstrap` here is the **host's own** target (emitted by the
+scaffolder: clean + up + migrate + seed admin + seed bundle, no
+1Password dependency). Atrium parent's `Makefile` happens to define a
+target with the same name as an operator-laptop convenience for
+working on atrium itself; it's not intended for host repos and pulls
+secrets from a `1Password atrium dev` vault item that hosts won't
+have. Same name, different contracts — run it from the host repo
+directory.
+
 The scaffolder ([`packages/create-atrium-host`](../packages/create-atrium-host/))
 emits a working repo wired against the published image and the host SDK
 packages. Use it for any vanilla host shape; drop down to the manual
@@ -217,7 +226,13 @@ Through the registries atrium already exposes:
   routers — the host owns its full path.
 - **App-config namespaces** — `register_namespace("my_ns", MyModel, public=False)`
   from `app.services.app_config`. Reaches the admin UI at
-  `/admin/app-config` automatically.
+  `/admin/app-config` automatically. **Call this at module-import
+  time** (top-level of `bootstrap.py`), not inside `init_app`:
+  atrium's worker process also imports the bootstrap module but
+  doesn't run `init_app`, and `NAMESPACES` lives in a module-level
+  dict that's per-process. A namespace registered inside `init_app`
+  raises `KeyError` from any `get_namespace(session, "my_ns")` in
+  worker-registered handlers.
 - **Job handlers** — `host.register_job_handler(kind="my_kind",
   handler=handler, description="...")` from `init_worker(host)`. The
   runner dispatches `scheduled_jobs` rows to registered handlers;
@@ -499,6 +514,13 @@ The factory returns a complete library-mode config: emits a single
 and defines `process.env.NODE_ENV` so the externalised React +
 TanStack Query references resolve. Pass `extraConfig` to layer
 plugins on top.
+
+`vite-plugin-css-injected-by-js` is an optional peer dep of
+`@brendanbank/atrium-host-bundle-utils` — install it as a
+devDependency in the host's `frontend/package.json`. The
+scaffolder-emitted template lists it; a fresh `vite.config.ts` that
+imports `hostBundleConfig` without it fails the first `pnpm build`
+with `Cannot find package 'vite-plugin-css-injected-by-js'`.
 
 **Bundle entry — ~10 lines of registration calls:**
 

--- a/packages/host-bundle-utils/README.md
+++ b/packages/host-bundle-utils/README.md
@@ -25,6 +25,20 @@ pnpm add @brendanbank/atrium-host-bundle-utils \
         @brendanbank/atrium-host-types
 ```
 
+If you use the Vite preset (the `./vite` subpath, see below), also add
+the optional peer dep as a devDependency:
+
+```bash
+pnpm add -D vite vite-plugin-css-injected-by-js
+```
+
+`vite` and `vite-plugin-css-injected-by-js` are declared optional so
+runtime-only consumers (host bundles imported into another build
+system, Vitest harnesses) don't pull them in, but
+`hostBundleConfig({ entry })` resolves the plugin at build time —
+without it, the first `pnpm build` fails with
+`Cannot find package 'vite-plugin-css-injected-by-js'`.
+
 The package is published on the public npm registry. No `.npmrc`,
 no auth token, no PAT. If you adopted atrium before v0.15.1 and
 have an `@brendanbank:registry=https://npm.pkg.github.com` line in


### PR DESCRIPTION
## Summary

Three small docs fixes for the foot-guns surfaced by the atrium-pa Spike D full-surface composition run (issue #122).

- **`register_namespace` placement** — the docs showed it inside `init_app`, but `NAMESPACES` is a per-process module-level dict and the worker process imports `bootstrap.py` without ever calling `init_app`. Worker handlers calling `get_namespace(session, "ns")` then hit `KeyError`. Moved the example to module-import time in `docs/new-project/README.md`, `docs/new-project/SKILL.md`, and `docs/published-images.md`, with the *why* inline so readers can judge edge cases.
- **`vite-plugin-css-injected-by-js` peer dep** — declared optional on `@brendanbank/atrium-host-bundle-utils@0.23.0`, but a fresh host wiring `hostBundleConfig({ entry })` from `/vite` fails the first `pnpm build` with `Cannot find package`. Added a callout next to the `hostBundleConfig` snippet in `docs/published-images.md` and surfaced the install line up next to the install snippet in `packages/host-bundle-utils/README.md` (the previous mention was several paragraphs further down). The scaffolder template already lists it; the gap was purely in the manual walkthrough.
- **`make dev-bootstrap` name collision** — atrium parent's target is an operator-laptop convenience that needs 1Password CLI + an `atrium dev` vault item; the scaffolder-emitted target is a host-local lifecycle (clean + up + migrate + seed admin + seed bundle) with no 1Password dep. Same name, different contracts. Added a callout right under the on-ramp snippet in `docs/published-images.md`.

No code changes. The reporter (also @brendanbank) offered to send a PR — this is it.

Closes #122.

## Test plan

- [ ] `docs/new-project/README.md` step 9 table now reads "at module top-level of `bootstrap.py`" for the namespace row, and the bootstrap.py example shows `register_namespace` at module level (commented) with the why-comment above `init_app`
- [ ] `docs/new-project/SKILL.md` bootstrap.py bullet calls out the module-level placement and the worker `KeyError` failure mode
- [ ] `docs/published-images.md` App-config namespaces bullet has the module-import-time callout; the on-ramp snippet flags the dev-bootstrap collision; the `hostBundleConfig` block names `vite-plugin-css-injected-by-js` as an optional peer dep with the failure mode
- [ ] `packages/host-bundle-utils/README.md` Installation section shows the peer-dep `pnpm add -D` line right next to the main install command