### PR TITLE
fix(docker): drop default-libmysqlclient-dev from runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 
 RUN apt-get update \
- && apt-get install -y --no-install-recommends default-libmysqlclient-dev curl \
+ && apt-get install -y --no-install-recommends curl \
  && rm -rf /var/lib/apt/lists/* \
  && groupadd --system --gid 1000 app \
  && useradd --system --uid 1000 --gid app --create-home --home-dir /home/app app


### PR DESCRIPTION
## Summary

Closes #124. Removes `default-libmysqlclient-dev` from the `runtime` stage of `Dockerfile`. The `-dev` metapackage was pulling `linux-libc-dev` (kernel headers) as a transitive, generating ~96 high-severity Trivy alerts that propagated to every consumer of the published `ghcr.io/brendanbank/atrium` image (atrium-pa: 496/502 alerts were this single package).

## Why drop it entirely instead of switching to `libmariadb3`

The Python deps don't need a libmysqlclient at runtime at all:

- `backend/pyproject.toml` uses `aiomysql` (pure Python wrapper around PyMySQL).
- `PyMySQL` is also pure Python.
- `uv.lock` has zero matches for `mysqlclient` / `mariadb` / `libmysql`.

The build stage (`backend-base`) keeps `default-libmysqlclient-dev` so `uv sync` retains the dev headers if a wheel ever needs them, but that stage is discarded — only `/opt/venv` ships into the runtime image.

## Verification

Local build + smoke:

- `docker build --target runtime` succeeds.
- `dpkg -l linux-libc-dev` → no packages found.
- `python -c "import aiomysql, app.main"` → OK.

## Test plan

- [ ] CI green
- [ ] After merge + `ghcr.io` push, downstream `atrium-pa` Trivy alerts drop from ~505 to ~9