### PR TITLE
host-bundle-utils: refresh useAtriumLocation on popstate (closes #134)

### DIFF
--- a/packages/host-bundle-utils/src/react/index.ts
+++ b/packages/host-bundle-utils/src/react/index.ts
@@ -223,8 +223,9 @@ const SSR_LOCATION: AtriumLocation = {
 // Module-level cache so `useSyncExternalStore.getSnapshot` returns a
 // referentially-stable object across renders — re-creating it every
 // call would cause React to tear-loop the subscriber. The cache is
-// refreshed only when an `atrium:locationchange` event lands or, on
-// the first read, lazily from `window.location`.
+// refreshed when an `atrium:locationchange` event lands, when a
+// native `popstate` fires (browser back/forward), or, on the first
+// read, lazily from `window.location`.
 let cachedLocation: AtriumLocation | null = null;
 
 function readWindowLocation(): AtriumLocation {
@@ -250,7 +251,7 @@ function getServerLocationSnapshot(): AtriumLocation {
 
 function subscribeLocation(onChange: () => void): () => void {
   if (typeof window === 'undefined') return () => {};
-  const handler = (e: Event) => {
+  const onAtrium = (e: Event) => {
     const detail = (e as CustomEvent<Partial<AtriumLocation> | undefined>)
       .detail;
     if (
@@ -273,8 +274,23 @@ function subscribeLocation(onChange: () => void): () => void {
     }
     onChange();
   };
-  window.addEventListener(ATRIUM_LOCATION_EVENT, handler);
-  return () => window.removeEventListener(ATRIUM_LOCATION_EVENT, handler);
+  // ``popstate`` fires after ``window.location`` has already been
+  // updated, so reading pathname/search/hash from it here is safe.
+  // This catches browser back/forward and any other history change
+  // that doesn't go through ``useAtriumNavigate`` (which dispatches
+  // its own ``atrium:locationchange``). Without this listener the
+  // module-level cache would stay pinned to the previous URL until
+  // the next atrium-mediated nav (issue #134).
+  const onPopstate = () => {
+    cachedLocation = readWindowLocation();
+    onChange();
+  };
+  window.addEventListener(ATRIUM_LOCATION_EVENT, onAtrium);
+  window.addEventListener('popstate', onPopstate);
+  return () => {
+    window.removeEventListener(ATRIUM_LOCATION_EVENT, onAtrium);
+    window.removeEventListener('popstate', onPopstate);
+  };
 }
 
 /** Subscribe to atrium's react-router location changes from inside a

--- a/packages/host-bundle-utils/test/useAtriumLocation.test.tsx
+++ b/packages/host-bundle-utils/test/useAtriumLocation.test.tsx
@@ -264,6 +264,63 @@ describe('useAtriumLocation', () => {
     window.history.replaceState({}, '', origin + '/');
   });
 
+  test('native popstate refreshes the snapshot from window.location (#134)', () => {
+    // Browser back/forward does not go through `useAtriumNavigate`, so
+    // no `atrium:locationchange` fires. Without a popstate listener the
+    // module-level cache would stay pinned to whatever the previous
+    // atrium-mediated nav set, causing host bundles that derive route
+    // state from `useAtriumLocation().pathname` to render the previous
+    // URL's content (e.g. `/people/7` instead of `/people/6` after a
+    // back-then-click).
+    const origin = window.location.origin;
+    render(<LocationProbe id="loc" />);
+
+    // Seed a known cache value via a well-formed atrium event.
+    act(() => {
+      dispatchAtriumLocation({
+        pathname: '/people/7',
+        search: '',
+        hash: '',
+      });
+    });
+    expect(screen.getByTestId('loc').textContent).toBe('/people/7||');
+
+    // Simulate browser back: rewrite window.location directly (bypassing
+    // useAtriumNavigate so no atrium:locationchange fires) and dispatch
+    // a native popstate. The hook must re-read window.location.
+    act(() => {
+      window.history.replaceState({}, '', `${origin}/people`);
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
+    expect(screen.getByTestId('loc').textContent).toBe('/people||');
+
+    // Restore for later tests.
+    window.history.replaceState({}, '', `${origin}/`);
+  });
+
+  test('atrium event detail wins over window.location when both fire (#134)', () => {
+    // Sanity-check the listener ordering: an atrium:locationchange that
+    // arrives with a structured detail (the normal nav path) must use
+    // the detail, not fall back to window.location. This is the
+    // existing contract; the popstate listener addition must not break
+    // it.
+    const origin = window.location.origin;
+    render(<LocationProbe id="loc" />);
+
+    act(() => {
+      // Window.location says /raw, but atrium's detail says /detail.
+      window.history.replaceState({}, '', `${origin}/raw`);
+      dispatchAtriumLocation({
+        pathname: '/detail',
+        search: '?from=event',
+        hash: '',
+      });
+    });
+    expect(screen.getByTestId('loc').textContent).toBe('/detail|?from=event|');
+
+    window.history.replaceState({}, '', `${origin}/`);
+  });
+
   test('unsubscribes on unmount', () => {
     const { unmount } = render(<LocationProbe id="loc" />);
     unmount();


### PR DESCRIPTION
## Summary

`useAtriumLocation` kept a module-level pathname cache that only refreshed on `atrium:locationchange`. Native `popstate` (browser back/forward, or any history change that bypasses `useAtriumNavigate`) updated `window.location` but not the cache, so host bundles that derived route state from `useAtriumLocation().pathname` rendered the previous URL's content until the next atrium-mediated nav.

`subscribeLocation` now also listens to `popstate` and re-reads `window.location` when it fires. `popstate` runs after the URL has already been updated, so the read is safe. `nonce` stays at whatever the previous atrium event set — `popstate` is not an atrium-mediated dispatch, so there is no new nonce to advance; that matches today's behaviour for the same-URL re-click case.

## Test plan

- [x] New Vitest case: dispatching `popstate` after `replaceState` refreshes the snapshot from `window.location` (the back-button repro from the issue).
- [x] New Vitest case: an `atrium:locationchange` with a structured detail still wins over `window.location`, pinning the existing contract under the new dual-listener wiring.
- [x] `pnpm test` in `packages/host-bundle-utils` — 47/47 passing.
- [x] `pnpm typecheck` in `packages/host-bundle-utils` — clean.

## Downstream

Unblocks removal of the host-side `useReactivePathname` workaround in `Brendan-Bank/atrium-pa#241` once an SDK release with this fix is published and pinned.

Closes #134.