### PR TITLE
host-bundle-utils: refresh useAtriumLocation cache on subscribe (closes #137)

### DIFF
--- a/packages/host-bundle-utils/src/react/index.ts
+++ b/packages/host-bundle-utils/src/react/index.ts
@@ -251,6 +251,19 @@ function getServerLocationSnapshot(): AtriumLocation {
 
 function subscribeLocation(onChange: () => void): () => void {
   if (typeof window === 'undefined') return () => {};
+  // Refresh on subscribe so a fresh subscriber always reads the current
+  // `window.location`. Hosts whose route tree mounts/unmounts components
+  // per route can have brief windows with no subscriber attached: the
+  // previous detail page unmounts on browser-back (popstate refresh
+  // fires, listeners are torn down), then a click navigates to a new
+  // detail page. The intervening `atrium:locationchange` lands while no
+  // listener is attached, so the module-level cache stays pinned to the
+  // last URL. Reading `window.location` here closes that gap (#137).
+  // `onChange` is intentionally NOT called: `useSyncExternalStore`
+  // invokes `getSnapshot` after `subscribe` and re-renders if the result
+  // differs from the previous snapshot.
+  cachedLocation = readWindowLocation();
+
   const onAtrium = (e: Event) => {
     const detail = (e as CustomEvent<Partial<AtriumLocation> | undefined>)
       .detail;

--- a/packages/host-bundle-utils/test/useAtriumLocation.test.tsx
+++ b/packages/host-bundle-utils/test/useAtriumLocation.test.tsx
@@ -321,6 +321,77 @@ describe('useAtriumLocation', () => {
     window.history.replaceState({}, '', `${origin}/`);
   });
 
+  test('fresh subscriber after a subscriber-less window reads current window.location, not the stale cache (#137)', () => {
+    // Repro: detail-page A mounts → subscribes → cache holds /people/7.
+    // Browser-back unmounts A and the popstate refresh leaves the cache
+    // at /people. A click then navigates to /people/6 via
+    // useAtriumNavigate, which dispatches atrium:locationchange — but no
+    // host-side subscriber is attached during that window, so the cache
+    // stays at /people. Detail-page B mounts; without the subscribe-time
+    // refresh it would read /people from the cache and render the wrong
+    // id.
+    const origin = window.location.origin;
+
+    // Step 1: page A subscribes and the cache holds /people/7.
+    const a = render(<LocationProbe id="a" />);
+    act(() => {
+      dispatchAtriumLocation({
+        pathname: '/people/7',
+        search: '',
+        hash: '',
+      });
+    });
+    expect(screen.getByTestId('a').textContent).toBe('/people/7||');
+
+    // Step 2: page A unmounts (subscriber-less from here).
+    a.unmount();
+
+    // Step 3: window.location changes to /people/6 while no subscriber
+    // is attached. We rewrite directly to simulate a navigation that the
+    // host bundle missed (the atrium:locationchange detail or popstate
+    // fired into the void).
+    window.history.replaceState({}, '', `${origin}/people/6`);
+
+    // Step 4: page B mounts and must observe /people/6, not the stale
+    // /people/7 the cache still holds.
+    render(<LocationProbe id="b" />);
+    expect(screen.getByTestId('b').textContent).toBe('/people/6||');
+
+    window.history.replaceState({}, '', `${origin}/`);
+  });
+
+  test('subscribe-time refresh also covers a missed atrium:locationchange (no popstate)', () => {
+    // Same as above but the missed event was an atrium:locationchange
+    // dispatched by useAtriumNavigate while no subscriber was attached.
+    // We can't dispatch the event into a void and have it move
+    // window.location (jsdom doesn't intercept the synthesized popstate
+    // the way a real browser would), so we emulate the post-conditions:
+    // window.location moved, and the cache still holds the previous URL
+    // because the listener wasn't attached.
+    const origin = window.location.origin;
+
+    // Seed cache to a known stale value via a well-formed event.
+    const a = render(<LocationProbe id="a" />);
+    act(() => {
+      dispatchAtriumLocation({
+        pathname: '/people',
+        search: '',
+        hash: '',
+      });
+    });
+    expect(screen.getByTestId('a').textContent).toBe('/people||');
+    a.unmount();
+
+    // While no subscriber is attached, navigation lands the URL at
+    // /people/6. (popstate did not fire — this is the navigate path.)
+    window.history.replaceState({}, '', `${origin}/people/6`);
+
+    render(<LocationProbe id="b" />);
+    expect(screen.getByTestId('b').textContent).toBe('/people/6||');
+
+    window.history.replaceState({}, '', `${origin}/`);
+  });
+
   test('unsubscribes on unmount', () => {
     const { unmount } = render(<LocationProbe id="loc" />);
     unmount();


### PR DESCRIPTION
## Summary

- Refresh the module-level \`cachedLocation\` from \`window.location\`
  inside \`subscribeLocation\` so a fresh subscriber that mounts after a
  brief subscriber-less window reads the current URL instead of the
  stale value left behind by the previous tear-down.
- The #134 popstate listener fix only kept the cache fresh while a
  subscriber was attached. Hosts whose route tree mounts/unmounts
  components per route (the OOTB \`useAtriumNavigate\` + per-path
  subtree pattern) hit a window where no host-side listener is
  attached: detail-page A unmounts on browser-back, an
  \`atrium:locationchange\` for the next click lands into the void,
  then detail-page B mounts and reads the cache pinned to the previous
  URL.
- \`onChange\` is intentionally not called from \`subscribe\` —
  \`useSyncExternalStore\` re-reads \`getSnapshot\` after subscribing
  and re-renders if the result differs.

## Test plan

- [x] \`pnpm --filter @brendanbank/atrium-host-bundle-utils test\` —
  49 tests pass, including two new regression cases:
  - fresh subscriber after a subscriber-less window with a missed
    popstate reads current \`window.location\`.
  - same shape but the missed event was an \`atrium:locationchange\`.
- [x] \`pnpm --filter @brendanbank/atrium-host-bundle-utils typecheck\`.