### PR TITLE
Stamp email_verified_at on invite accept

### DIFF
--- a/backend/app/api/invites.py
+++ b/backend/app/api/invites.py
@@ -217,6 +217,11 @@ async def accept_invite(
             is_verified=True,  # invite recipient is verified by possession of token
         )
     )
+    # Stamp the canonical verification timestamp. ``is_verified`` above is
+    # the legacy fastapi-users flag the login gate still honours as a
+    # fallback; ``email_verified_at`` is the primary signal and the only
+    # one a future cleanup of that fallback would keep reading.
+    user.email_verified_at = now
     # Grant every RBAC role the invite carried.
     for role_code in invite.role_codes:
         await assign_role(session, user_id=user.id, role_code=role_code)

--- a/backend/tests/api/test_invite_flow.py
+++ b/backend/tests/api/test_invite_flow.py
@@ -306,3 +306,9 @@ async def test_accept_creates_user_via_user_manager(client, engine):
         assert u.hashed_password != "Real-Pw-12345!"
         assert u.hashed_password.startswith(("$argon2", "$2b$", "$2a$"))
         assert u.is_verified is True
+        # Both verification signals stamped: ``is_verified`` is the legacy
+        # fastapi-users flag the login gate still falls back to, but
+        # ``email_verified_at`` is the canonical column. If only the
+        # legacy flag were set, a future cleanup of the fallback in
+        # ``auth/manager.py`` would lock every invite-accepted user out.
+        assert u.email_verified_at is not None


### PR DESCRIPTION
## Summary

- Accept-invite was setting only the legacy fastapi-users `is_verified` flag; the canonical `email_verified_at` column stayed NULL.
- Login still works today thanks to the OR-fallback in `auth/manager.py`, but any cleanup of that fallback would lock every invite-accepted user out.
- Stamp `email_verified_at = now` on the freshly created user alongside the existing `is_verified=True`.

Closes #156

## Test plan

- [ ] `backend/tests/api/test_invite_flow.py::test_accept_creates_user_via_user_manager` extended to assert both signals are set.