### PR TITLE
Surface password-policy rejection reason on ProfilePage

### DIFF
--- a/frontend/src/routes/ProfilePage.tsx
+++ b/frontend/src/routes/ProfilePage.tsx
@@ -146,10 +146,12 @@ export function ProfilePage() {
         color: 'teal',
         message: t('profile.savedPassword'),
       });
-    } catch {
+    } catch (err) {
+      const resp = (err as { response?: { data?: { detail?: string } } })
+        .response;
       notifications.show({
         color: 'red',
-        message: t('profile.saveFailed'),
+        message: resp?.data?.detail ?? t('profile.saveFailed'),
       });
     } finally {
       setChangingPassword(false);


### PR DESCRIPTION
## Summary

- ProfilePage's Update Password handler swallowed the backend error with a bare `catch {}`, so users who hit the password policy (HIBP, missing symbol, etc.) only saw "Could not save changes".
- Mirror the pattern already used three times in the same file (and on `ResetPasswordPage` / `AcceptInvitePage`): pull `response.data.detail` off the axios error, fall back to the generic message.

Closes #155

## Test plan

- [ ] Manual: try saving a known-breached password from ProfilePage; toast shows the policy reason.
- [ ] Manual: admin-impersonation password change hits the same code path.