### PR TITLE
fix(spa): LoginPage honors ?from= URL query (server-side redirects)

### DIFF
--- a/frontend/src/lib/redirect.test.ts
+++ b/frontend/src/lib/redirect.test.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeRedirect } from './redirect';
+
+describe('sanitizeRedirect', () => {
+  it('returns null for nullish / empty values', () => {
+    expect(sanitizeRedirect(null)).toBeNull();
+    expect(sanitizeRedirect(undefined)).toBeNull();
+    expect(sanitizeRedirect('')).toBeNull();
+  });
+
+  it('accepts same-origin site-absolute paths', () => {
+    expect(sanitizeRedirect('/')).toBe('/');
+    expect(sanitizeRedirect('/dashboard')).toBe('/dashboard');
+    expect(sanitizeRedirect('/oauth/authorize?client_id=x&state=y')).toBe(
+      '/oauth/authorize?client_id=x&state=y',
+    );
+    expect(sanitizeRedirect('/foo#frag')).toBe('/foo#frag');
+  });
+
+  it('rejects protocol-relative URLs', () => {
+    expect(sanitizeRedirect('//evil.example')).toBeNull();
+    expect(sanitizeRedirect('//evil.example/path')).toBeNull();
+  });
+
+  it('rejects absolute URLs with a scheme', () => {
+    expect(sanitizeRedirect('https://evil.example')).toBeNull();
+    expect(sanitizeRedirect('http://evil.example')).toBeNull();
+    expect(sanitizeRedirect('javascript:alert(1)')).toBeNull();
+    expect(sanitizeRedirect('data:text/html,<script>')).toBeNull();
+  });
+
+  it('rejects relative paths without leading slash', () => {
+    expect(sanitizeRedirect('foo')).toBeNull();
+    expect(sanitizeRedirect('./foo')).toBeNull();
+    expect(sanitizeRedirect('../foo')).toBeNull();
+  });
+
+  it('preserves the inner redirect_uri when it contains a full URL', () => {
+    // atrium-pa's /oauth/authorize bounces to /login?from=<encoded
+    // authorize URL>, where the encoded URL itself contains a
+    // redirect_uri=https://claude.ai/... query value. The from-VALUE
+    // (after URL-decoding) starts with `/oauth/authorize` so it's a
+    // valid path; the inner https:// is just part of the query.
+    const from =
+      '/oauth/authorize?client_id=abc&redirect_uri=https://claude.ai/cb';
+    expect(sanitizeRedirect(from)).toBe(from);
+  });
+});

--- a/frontend/src/lib/redirect.ts
+++ b/frontend/src/lib/redirect.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+/**
+ * Sanitise an in-app post-login redirect target.
+ *
+ * Both `LoginPage` and `TwoFactorPage` read a `from` parameter to
+ * decide where to navigate after a successful authentication step.
+ * The value may come from React Router state (set by `<RequireAuth>`)
+ * or from the URL's `?from=` query (set by `api.ts`'s 401 hard-
+ * redirect and by server-side routes that 302 unauth visitors to
+ * `/login` — e.g. atrium-pa's `/oauth/authorize`).
+ *
+ * Without sanitisation, `?from=https://evil.example` (or
+ * `//evil.example`) lets a phishing email bounce the user post-login
+ * to an attacker-controlled origin where their fresh session cookie
+ * would NOT travel — but where the attacker can mimic the SPA shell
+ * and harvest credentials.
+ *
+ * Accepts: `/`, `/foo`, `/foo?bar=baz`, `/foo#frag` (same-origin
+ * site-absolute paths).
+ *
+ * Rejects (returns `null`): empty / null, anything not starting with
+ * `/`, anything starting with `//` (protocol-relative), anything with
+ * a scheme like `javascript:`. The caller falls through to its own
+ * default ('/').
+ */
+export function sanitizeRedirect(
+  value: string | null | undefined,
+): string | null {
+  if (!value) return null;
+  if (!value.startsWith('/')) return null;
+  if (value.startsWith('//')) return null;
+  return value;
+}

--- a/frontend/src/routes/LoginPage.tsx
+++ b/frontend/src/routes/LoginPage.tsx
@@ -25,6 +25,7 @@ import { useAppConfig } from '@/hooks/useAppConfig';
 import { ME_QUERY_KEY } from '@/hooks/useAuth';
 import { CaptchaWidget } from '@/components/CaptchaWidget';
 import type { TOTPState } from '@/hooks/useTOTP';
+import { sanitizeRedirect } from '@/lib/redirect';
 
 export function LoginPage() {
   const { t } = useTranslation();
@@ -46,8 +47,22 @@ export function LoginPage() {
     },
   });
 
-  const redirectTo =
-    (location.state as { from?: string } | null)?.from ?? '/';
+  // Honour `from` from two sources, in priority order:
+  // 1. React Router state — set by <RequireAuth> when an in-SPA
+  //    navigation hits a protected route.
+  // 2. URL query string ?from=… — set by `api.ts`'s hard-redirect on
+  //    401 and by any server-side handler that bounces the browser
+  //    here (e.g. atrium-pa's /oauth/authorize, which 302s unauth
+  //    visitors to /login?from=/oauth/authorize?…). Without the query
+  //    fallback the SPA dropped the destination and landed every
+  //    post-login redirect on `/`.
+  // Both sources are constrained to a same-origin relative path
+  // (must start with `/`, must NOT start with `//`, no scheme) to
+  // close the open-redirect surface — `?from=https://evil.example`
+  // would otherwise let a phishing email bounce the user post-login.
+  const fromFromState = (location.state as { from?: string } | null)?.from;
+  const fromFromQuery = new URLSearchParams(location.search).get('from');
+  const redirectTo = sanitizeRedirect(fromFromState ?? fromFromQuery) ?? '/';
 
   const handleSubmit = form.onSubmit(async ({ email, password }) => {
     setError(null);

--- a/frontend/src/routes/TwoFactorPage.tsx
+++ b/frontend/src/routes/TwoFactorPage.tsx
@@ -35,6 +35,7 @@ import {
   useWebAuthnAuthenticate,
   useWebAuthnRegister,
 } from '@/hooks/useWebAuthn';
+import { sanitizeRedirect } from '@/lib/redirect';
 
 /**
  * /2fa page — hosts both enrollment and returning-user challenge.
@@ -49,7 +50,11 @@ export function TwoFactorPage() {
   const location = useLocation();
   const { data: state, isLoading, isFetching, refetch } = useTOTPState();
 
-  const from = new URLSearchParams(location.search).get('from') ?? '/';
+  // Sanitise — see lib/redirect.ts. Without this, `?from=//evil.example`
+  // could phish a fresh post-2FA session into an attacker origin.
+  const from = sanitizeRedirect(
+    new URLSearchParams(location.search).get('from'),
+  ) ?? '/';
 
   useEffect(() => {
     // Wait for the background refetch before trusting `session_passed`:


### PR DESCRIPTION
## Summary
LoginPage only read \`from\` from React Router state, so any server-side handler that bounced an unauth visitor to \`/login?from=<path>\` had its destination dropped — the SPA landed on \`/\` post-login regardless.

Concrete trigger: atrium-pa's \`/oauth/authorize\` (recent V3M3 hotfix) 302s unauth visitors to \`/login?from=/oauth/authorize?…\` so Claude.ai's MCP connect flow can resume after sign-in. Without this fix the user logs in and is stranded.

- New \`src/lib/redirect.ts::sanitizeRedirect\` — only accepts same-origin site-absolute paths (no \`//\`, no scheme). Closes the open-redirect surface \`?from=\` would otherwise introduce.
- LoginPage reads state \`from\` OR \`location.search\` (in that order), then sanitises.
- TwoFactorPage already read \`from\` from \`location.search\`; now sanitises too — direct links to \`/2fa?from=//evil.example\` could have phished a fresh post-2FA session.
- 6 unit tests for \`sanitizeRedirect\`.

## Test plan
- [x] \`npm test -- src/lib/redirect.test.ts\` — 6/6 pass.
- [x] \`npx tsc --noEmit\` — clean.
- [x] \`npx eslint\` on touched files — clean.
- [ ] Manual: hit \`https://pa.banzai.nl/oauth/authorize?…\` while signed out; verify post-login bounces back to the in-flight authorize URL rather than \`/\`.