### PR TITLE
Gate /docs + /openapi.json and app version behind auth in prod

### DIFF
--- a/backend/app/api/app_config.py
+++ b/backend/app/api/app_config.py
@@ -17,10 +17,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.auth.principal import SCOPE_KEY, Principal
 from app.auth.rbac import require_perm
+from app.auth.users import _current_user_or_none
 from app.db import get_session
 from app.models.auth import User
 from app.services import app_config as app_config_service
@@ -32,9 +34,20 @@ admin_router = APIRouter(prefix="/admin/app-config", tags=["admin"])
 
 @public_router.get("/app-config")
 async def get_public(
+    request: Request,
+    user: User | None = Depends(_current_user_or_none),
     session: AsyncSession = Depends(get_session),
 ) -> dict[str, Any]:
-    return await app_config_service.get_public_config(session)
+    # The bundle stays anonymous-readable (brand / i18n / system / the
+    # auth carve-out), but the backend ``version`` is only handed to an
+    # authenticated caller so it can't be used to fingerprint the
+    # deployment pre-login (issue #179). A cookie session (even partial,
+    # pre-2FA) or a PAT-authed request both count as authenticated.
+    pat_principal = request.scope.get(SCOPE_KEY)
+    authenticated = user is not None or isinstance(pat_principal, Principal)
+    return await app_config_service.get_public_config(
+        session, include_version=authenticated
+    )
 
 
 @admin_router.get("")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,8 +6,10 @@ import os
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-from fastapi import APIRouter, FastAPI, Request
+from fastapi import APIRouter, Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
+from fastapi.responses import HTMLResponse, JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.api.account_deletion import admin_router as account_deletion_admin_router
@@ -41,8 +43,9 @@ from app.api.webauthn import router as webauthn_router
 from app.auth.backend import auth_backend
 from app.auth.pat_middleware import PATAuthMiddleware
 from app.auth.schemas import UserRead, UserUpdate
-from app.auth.users import fastapi_users
+from app.auth.users import fastapi_users, require_admin
 from app.logging import configure_logging, log
+from app.models.auth import User
 from app.services.audit import set_impersonator
 from app.services.captcha import CaptchaLoginMiddleware
 from app.services.maintenance import MaintenanceMiddleware
@@ -83,6 +86,41 @@ class ImpersonationAuditMiddleware(BaseHTTPMiddleware):
         return response
 
 
+def _mount_protected_docs(app: FastAPI) -> None:
+    """Re-serve the OpenAPI schema + Swagger/ReDoc UIs behind the admin
+    gate.
+
+    In prod the app is constructed with ``docs_url``/``redoc_url``/
+    ``openapi_url`` set to ``None`` so an anonymous caller can't pull the
+    full internal route map from ``/openapi.json`` (issue #178 — a
+    black-box scan enumerated 228 endpoints, including every admin
+    route, for free). These replacements serve the same content but
+    require the ``admin`` role, keeping the docs available to operators
+    without handing the API surface to the internet. ``require_admin``
+    chains through ``current_user``, so the full-2FA session gate applies
+    too. Registered before the SPA catch-all mount so they win the match.
+    """
+    docs_gate = Depends(require_admin)
+
+    @app.get("/openapi.json", include_in_schema=False)
+    async def protected_openapi(_: User = docs_gate) -> JSONResponse:
+        return JSONResponse(app.openapi())
+
+    @app.get("/docs", include_in_schema=False)
+    async def protected_swagger(_: User = docs_gate) -> HTMLResponse:
+        return get_swagger_ui_html(
+            openapi_url="/openapi.json",
+            title=f"{app.title} - Swagger UI",
+        )
+
+    @app.get("/redoc", include_in_schema=False)
+    async def protected_redoc(_: User = docs_gate) -> HTMLResponse:
+        return get_redoc_html(
+            openapi_url="/openapi.json",
+            title=f"{app.title} - ReDoc",
+        )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     configure_logging()
@@ -93,10 +131,17 @@ async def lifespan(app: FastAPI):
 
 def create_app() -> FastAPI:
     settings = get_settings()
+    is_prod = settings.environment == "prod"
     app = FastAPI(
         title="Atrium API",
         version="0.1.0",
         lifespan=lifespan,
+        # In prod the unauthenticated docs + schema are suppressed and
+        # re-mounted behind an admin gate below (issue #178). Dev keeps
+        # the open Swagger/ReDoc/OpenAPI endpoints for DX.
+        docs_url=None if is_prod else "/docs",
+        redoc_url=None if is_prod else "/redoc",
+        openapi_url=None if is_prod else "/openapi.json",
     )
 
     app.add_middleware(
@@ -201,6 +246,12 @@ def create_app() -> FastAPI:
             log.info(
                 "host.init_app.absent", module=host_module
             )
+
+    # In prod, re-expose the docs + OpenAPI schema behind require_admin.
+    # Added before the SPA catch-all mount so the explicit routes match
+    # first (issue #178).
+    if is_prod:
+        _mount_protected_docs(app)
 
     # Mount the built SPA last so it acts as the catch-all. Conditional
     # on the directory existing so a dev tree without ``pnpm build``

--- a/backend/app/services/app_config.py
+++ b/backend/app/services/app_config.py
@@ -294,15 +294,22 @@ async def put_namespace(
     return validated
 
 
-async def get_public_config(session: AsyncSession) -> dict[str, Any]:
+async def get_public_config(
+    session: AsyncSession, *, include_version: bool = False
+) -> dict[str, Any]:
     """Bundle every public namespace into one response — the frontend
     hits this once at boot and feeds it to MantineProvider/i18n/etc.
 
     Top-level ``version`` carries the running backend's version so the
     SPA can mirror it to ``window.__ATRIUM_VERSION__`` for host-bundle
-    feature detection (issue #43).
+    feature detection (issue #43). It's only included when the caller is
+    authenticated (``include_version=True``): an unauthenticated version
+    string lets a black-box scanner fingerprint exact dependency
+    versions for CVE-matching, so it stays behind auth (issue #179).
     """
-    out: dict[str, Any] = {"version": _atrium_version()}
+    out: dict[str, Any] = {}
+    if include_version:
+        out["version"] = _atrium_version()
     for ns in NAMESPACES.values():
         if not ns.public:
             continue

--- a/backend/tests/api/test_app_config.py
+++ b/backend/tests/api/test_app_config.py
@@ -34,10 +34,34 @@ async def _wipe_app_config(engine, *keys: str) -> None:
         await s.commit()
 
 
+def _expected_version() -> str:
+    import tomllib
+    from pathlib import Path
+
+    pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    with pyproject.open("rb") as fh:
+        return tomllib.load(fh)["project"]["version"]
+
+
 @pytest.mark.asyncio
-async def test_public_endpoint_includes_version(client, engine):
+async def test_public_endpoint_hides_version_when_anonymous(client, engine):
+    """Issue #179 — the backend ``version`` lets a black-box scanner
+    fingerprint exact dependency versions for CVE-matching, so it must
+    NOT appear in the unauthenticated bundle. The rest of the public
+    config (brand / i18n / system / auth carve-out) stays anonymous."""
+    r = await client.get("/app-config")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "version" not in body, body
+    # The anonymous bundle is still useful — brand etc. are present.
+    assert "brand" in body, body
+
+
+@pytest.mark.asyncio
+async def test_public_endpoint_includes_version_when_authenticated(client, engine):
     """Issue #43 — top-level ``version`` lets host bundles mirror the
-    running atrium release onto ``window.__ATRIUM_VERSION__``.
+    running atrium release onto ``window.__ATRIUM_VERSION__``. Now gated
+    behind auth (issue #179), so an authenticated session still gets it.
 
     Issue #57 — the published runtime image doesn't install
     ``atrium-backend`` as a distribution, so ``importlib.metadata``
@@ -45,12 +69,10 @@ async def test_public_endpoint_includes_version(client, engine):
     value against ``pyproject.toml`` so any future dist-metadata
     breakage shows up in CI instead of in production.
     """
-    import tomllib
-    from pathlib import Path
+    expected = _expected_version()
 
-    pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
-    with pyproject.open("rb") as fh:
-        expected = tomllib.load(fh)["project"]["version"]
+    user = await seed_user(engine)
+    await login(client, user.email, "user-pw-123", engine=engine)
 
     r = await client.get("/app-config")
     assert r.status_code == 200, r.text

--- a/backend/tests/api/test_docs_gating.py
+++ b/backend/tests/api/test_docs_gating.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Issue #178 — the OpenAPI schema + Swagger/ReDoc UIs must not be
+served to anonymous callers in prod.
+
+A black-box scan of a prod deployment pulled the full internal route
+map (228 endpoints, every admin route) from an unauthenticated
+``/openapi.json``. In prod those endpoints are constructed with
+``openapi_url``/``docs_url``/``redoc_url`` set to ``None`` and re-mounted
+behind ``require_admin``. Dev keeps them open for DX.
+
+These tests build the app directly (no ``/api`` prefix wrapper) because
+the docs live at the un-prefixed root, and toggle ``ENVIRONMENT`` per
+case. ``get_settings`` is ``lru_cache``-d, so each helper clears the
+cache on the way in and out.
+"""
+from __future__ import annotations
+
+import contextlib
+
+import httpx
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.db import get_session
+from app.main import create_app
+from app.settings import get_settings
+from tests.helpers import seed_admin, seed_user
+
+
+@contextlib.asynccontextmanager
+async def _client_for_env(engine, environment, monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", environment)
+    if environment == "prod":
+        # ``_prod_sanity`` refuses to boot with the dev-default secrets.
+        monkeypatch.setenv("APP_SECRET_KEY", "prod-secret-not-the-default")
+        monkeypatch.setenv("JWT_SECRET", "prod-jwt-not-the-default")
+    get_settings.cache_clear()
+    try:
+        app = create_app()
+        factory = async_sessionmaker(
+            engine, expire_on_commit=False, autoflush=False
+        )
+
+        async def _override_get_session():
+            async with factory() as s:
+                yield s
+
+        app.dependency_overrides[get_session] = _override_get_session
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as c:
+            yield c
+    finally:
+        # Drop the prod-flavoured Settings so the rest of the suite sees
+        # the dev defaults again.
+        get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_docs_open_in_dev(engine, monkeypatch):
+    async with _client_for_env(engine, "dev", monkeypatch) as client:
+        r = await client.get("/openapi.json")
+        assert r.status_code == 200, r.text
+        assert "openapi" in r.json()
+        assert (await client.get("/docs")).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_docs_gated_for_anonymous_in_prod(engine, monkeypatch):
+    async with _client_for_env(engine, "prod", monkeypatch) as client:
+        for path in ("/openapi.json", "/docs", "/redoc"):
+            r = await client.get(path)
+            assert r.status_code == 401, (path, r.status_code, r.text)
+
+
+@pytest.mark.asyncio
+async def test_docs_gated_for_non_admin_in_prod(engine, monkeypatch):
+    user = await seed_user(engine)
+    async with _client_for_env(engine, "prod", monkeypatch) as client:
+        r = await client.post(
+            "/api/auth/jwt/login",
+            data={"username": user.email, "password": "user-pw-123"},
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        assert r.status_code in (200, 204), r.text
+        # Authenticated but lacks the admin role → 403, not 401.
+        assert (await client.get("/openapi.json")).status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_docs_accessible_to_admin_in_prod(engine, monkeypatch):
+    admin = await seed_admin(engine)
+    async with _client_for_env(engine, "prod", monkeypatch) as client:
+        r = await client.post(
+            "/api/auth/jwt/login",
+            data={"username": admin.email, "password": "admin-pw-123"},
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        assert r.status_code in (200, 204), r.text
+
+        schema = await client.get("/openapi.json")
+        assert schema.status_code == 200, schema.text
+        assert "openapi" in schema.json()
+
+        docs = await client.get("/docs")
+        assert docs.status_code == 200
+        assert "swagger-ui" in docs.text.lower()

--- a/backend/tests/api/test_docs_gating.py
+++ b/backend/tests/api/test_docs_gating.py
@@ -21,12 +21,31 @@ import contextlib
 
 import httpx
 import pytest
+import pytest_asyncio
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from app.db import get_session
 from app.main import create_app
 from app.settings import get_settings
 from tests.helpers import seed_admin, seed_user
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _truncate_seeded_users(engine):
+    """These tests seed users directly through ``engine`` and drive
+    logins, but build their own app instead of using the ``client`` /
+    ``session`` fixtures — so nothing truncates ``users`` etc. on
+    teardown. Without this, a seeded ``admin@example.com`` leaks into
+    the next test in the xdist shard and collides on its own
+    ``seed_admin`` (a 1062 duplicate-key IntegrityError). Mirror the
+    conftest cleanup for just the tables these tests touch."""
+    yield
+    async with engine.begin() as conn:
+        await conn.execute(text("SET FOREIGN_KEY_CHECKS=0"))
+        for table in ("auth_sessions", "user_roles", "users"):
+            await conn.execute(text(f"TRUNCATE TABLE `{table}`"))
+        await conn.execute(text("SET FOREIGN_KEY_CHECKS=1"))
 
 
 @contextlib.asynccontextmanager


### PR DESCRIPTION
## Summary

Two related defense-in-depth findings from a black-box assessment of a prod deployment.

**#178 — docs + schema enumerable by anonymous callers.** In prod the app is now constructed with `docs_url`/`redoc_url`/`openapi_url=None`, and `/docs`, `/redoc`, `/openapi.json` are re-mounted behind `require_admin`. Previously an unauthenticated caller could pull the entire internal route map (228 endpoints, including every admin route such as impersonate / break-glass / secrets-rotate) from the public `/openapi.json`. No data leaked, but it handed an attacker the full API surface for free. Dev keeps the open Swagger/ReDoc/OpenAPI endpoints for DX — the gate is `environment == "prod"` only. `require_admin` chains through `current_user`, so the full-2FA session gate applies.

**#179 — backend version leaked to anonymous callers.** `GET /api/app-config` returned `"version":"x.y.z"` to unauthenticated callers, enabling trivial CVE-matching to fingerprint dependency versions. `get_public_config()` now emits `version` only when the caller is authenticated (cookie session — even partial — or a PAT). The rest of the public bundle (brand / i18n / system / the `auth.allow_signup` + captcha carve-out) is unchanged.

### Frontend impact (#179)

No frontend change needed. `window.__ATRIUM_VERSION__` is mirrored from the boot `/app-config` call, which carries the auth cookie for an already-logged-in browser — so authenticated users (the case where host-bundle feature detection matters) still get the version at boot. Anonymous boots simply leave it `undefined`, which `main.tsx` already treats as optional. This supersedes the unauthenticated-version decision from #43 for the prod posture.

## Test plan

- `backend/tests/api/test_docs_gating.py` (new): docs open unauthenticated in dev; `/openapi.json`, `/docs`, `/redoc` return 401 anonymous and 403 for a non-admin in prod; admin gets 200 + real Swagger/schema.
- `backend/tests/api/test_app_config.py`: split the version test into anonymous (version absent, brand still present) and authenticated (version present, pinned to `pyproject.toml`).
- Full backend suite green (`uv run pytest`), 342 passed.

Closes #178
Closes #179