### PR TITLE
Fix mobile 2FA autofill: single OTP field instead of segmented PinInput

### DIFF
--- a/frontend/src/components/OtpInput.tsx
+++ b/frontend/src/components/OtpInput.tsx
@@ -1,0 +1,62 @@
+import { TextInput } from '@mantine/core';
+
+interface OtpInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  length?: number;
+  autoFocus?: boolean;
+  'aria-label'?: string;
+}
+
+/**
+ * Single-field one-time-code input.
+ *
+ * Deliberately NOT Mantine's segmented <PinInput>. A PinInput renders one
+ * <input maxlength="1"> per digit; desktop password-manager *extensions*
+ * (e.g. 1Password on the desktop) cope because they fill per-field, but
+ * mobile *native* autofill (iOS Password AutoFill — which 1Password drives
+ * on iOS — and Android Autofill) inserts the whole code into the single
+ * focused field in one shot, where maxlength=1 truncates it to a single
+ * digit and the code never lands.
+ *
+ * A single <input autocomplete="one-time-code" inputmode="numeric"> is the
+ * autofill target 1Password and Apple document, so it fills correctly on
+ * both desktop and mobile. We strip non-digits and clamp to `length` so the
+ * field behaves like the PinInput it replaces.
+ */
+export function OtpInput({
+  value,
+  onChange,
+  length = 6,
+  autoFocus,
+  'aria-label': ariaLabel,
+}: OtpInputProps) {
+  return (
+    <TextInput
+      value={value}
+      onChange={(event) =>
+        onChange(event.currentTarget.value.replace(/\D/g, '').slice(0, length))
+      }
+      autoFocus={autoFocus}
+      autoComplete="one-time-code"
+      inputMode="numeric"
+      type="text"
+      name="one-time-code"
+      maxLength={length}
+      aria-label={ariaLabel}
+      size="xl"
+      w={220}
+      styles={{
+        input: {
+          textAlign: 'center',
+          letterSpacing: '0.4em',
+          // letter-spacing adds a trailing gap after the last digit; nudge
+          // the content right by the same amount so it stays centered.
+          textIndent: '0.4em',
+          fontFamily: 'var(--mantine-font-family-monospace)',
+          fontVariantNumeric: 'tabular-nums',
+        },
+      }}
+    />
+  );
+}

--- a/frontend/src/components/TwoFactorSetupModal.tsx
+++ b/frontend/src/components/TwoFactorSetupModal.tsx
@@ -10,7 +10,6 @@ import {
   Group,
   Loader,
   Modal,
-  PinInput,
   Stack,
   Text,
 } from '@mantine/core';
@@ -24,6 +23,7 @@ import {
   useTOTPConfirm,
   useTOTPSetup,
 } from '@/hooks/useTOTP';
+import { OtpInput } from '@/components/OtpInput';
 
 type Method = 'totp' | 'email';
 
@@ -141,7 +141,12 @@ function TOTPSetupInner({
           {t('twoFactor.enterFirstCode')}
         </Text>
         <Center>
-          <PinInput length={6} type="number" oneTimeCode value={code} onChange={setCode} autoFocus />
+          <OtpInput
+            value={code}
+            onChange={setCode}
+            autoFocus
+            aria-label={t('twoFactor.codeInputLabel')}
+          />
         </Center>
         {error && <Alert color="red">{error}</Alert>}
         <Group justify="flex-end">
@@ -206,7 +211,12 @@ function EmailOTPSetupInner({
           {sent ? t('twoFactor.emailSentIntro') : t('twoFactor.emailSending')}
         </Text>
         <Center>
-          <PinInput length={6} type="number" oneTimeCode value={code} onChange={setCode} autoFocus />
+          <OtpInput
+            value={code}
+            onChange={setCode}
+            autoFocus
+            aria-label={t('twoFactor.codeInputLabel')}
+          />
         </Center>
         {error && <Alert color="red">{error}</Alert>}
         <Group justify="flex-end">

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -103,6 +103,7 @@
     "setupIntro": "Scannen Sie diesen QR-Code mit Ihrer Authenticator-App (Google Authenticator, 1Password, Bitwarden, Authy, …) und geben Sie anschließend den sechsstelligen Code ein, um die Einrichtung abzuschließen.",
     "manualSecret": "Oder geben Sie diesen Code manuell ein",
     "enterFirstCode": "Geben Sie den sechsstelligen Code aus der App ein",
+    "codeInputLabel": "Einmalcode",
     "confirmSubmit": "Bestätigen und fortfahren",
     "setupSuccess": "Zwei-Faktor-Authentifizierung aktiviert.",
     "challengeTitle": "Geben Sie Ihren Code ein",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -103,6 +103,7 @@
     "setupIntro": "Scan this QR code with your authenticator app (Google Authenticator, 1Password, Bitwarden, Authy, …), then enter the 6-digit code it shows to finish enrollment.",
     "manualSecret": "Or enter this code manually",
     "enterFirstCode": "Enter the 6-digit code from the app",
+    "codeInputLabel": "One-time code",
     "confirmSubmit": "Confirm and continue",
     "setupSuccess": "Two-factor authentication enabled.",
     "challengeTitle": "Enter your code",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -103,6 +103,7 @@
     "setupIntro": "Scannez ce QR code avec votre application d'authentification (Google Authenticator, 1Password, Bitwarden, Authy, …) puis saisissez le code à six chiffres affiché pour terminer l'inscription.",
     "manualSecret": "Ou saisissez ce code manuellement",
     "enterFirstCode": "Saisissez le code à six chiffres de l'application",
+    "codeInputLabel": "Code à usage unique",
     "confirmSubmit": "Confirmer et continuer",
     "setupSuccess": "Double authentification activée.",
     "challengeTitle": "Saisissez votre code",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -103,6 +103,7 @@
     "setupIntro": "Scan deze QR-code met je authenticator-app (Google Authenticator, 1Password, Bitwarden, Authy, …) en voer daarna de zescijferige code in om de aanmelding af te ronden.",
     "manualSecret": "Of voer deze code handmatig in",
     "enterFirstCode": "Voer de zescijferige code uit de app in",
+    "codeInputLabel": "Eenmalige code",
     "confirmSubmit": "Bevestigen en doorgaan",
     "setupSuccess": "Tweestapsverificatie ingeschakeld.",
     "challengeTitle": "Voer je code in",

--- a/frontend/src/routes/TwoFactorPage.tsx
+++ b/frontend/src/routes/TwoFactorPage.tsx
@@ -11,7 +11,6 @@ import {
   Group,
   Loader,
   Paper,
-  PinInput,
   Stack,
   Text,
   Title,
@@ -36,6 +35,7 @@ import {
   useWebAuthnRegister,
 } from '@/hooks/useWebAuthn';
 import { isServerRoute, sanitizeRedirect } from '@/lib/redirect';
+import { OtpInput } from '@/components/OtpInput';
 
 /**
  * /2fa page — hosts both enrollment and returning-user challenge.
@@ -254,13 +254,11 @@ function TOTPSetupFlow({
                   {t('twoFactor.enterFirstCode')}
                 </Text>
                 <Center>
-                  <PinInput
-                    length={6}
-                    type="number"
-                    oneTimeCode
+                  <OtpInput
                     value={code}
                     onChange={setCode}
                     autoFocus
+                    aria-label={t('twoFactor.codeInputLabel')}
                   />
                 </Center>
                 {error && <Alert color="red">{error}</Alert>}
@@ -335,13 +333,11 @@ function EmailOTPSetupFlow({
                 {sent ? t('twoFactor.emailSentIntro') : t('twoFactor.emailSending')}
               </Text>
               <Center>
-                <PinInput
-                  length={6}
-                  type="number"
-                  oneTimeCode
+                <OtpInput
                   value={code}
                   onChange={setCode}
                   autoFocus
+                  aria-label={t('twoFactor.codeInputLabel')}
                 />
               </Center>
               {error && <Alert color="red">{error}</Alert>}
@@ -538,13 +534,11 @@ function TOTPChallengeForm({
                 {t('twoFactor.challengeIntro')}
               </Text>
               <Center>
-                <PinInput
-                  length={6}
-                  type="number"
-                  oneTimeCode
+                <OtpInput
                   value={code}
                   onChange={setCode}
                   autoFocus
+                  aria-label={t('twoFactor.codeInputLabel')}
                 />
               </Center>
               {error && <Alert color="red">{error}</Alert>}
@@ -619,13 +613,11 @@ function EmailOTPChallengeForm({
                 {sent ? t('twoFactor.emailSentIntro') : t('twoFactor.emailSending')}
               </Text>
               <Center>
-                <PinInput
-                  length={6}
-                  type="number"
-                  oneTimeCode
+                <OtpInput
                   value={code}
                   onChange={setCode}
                   autoFocus
+                  aria-label={t('twoFactor.codeInputLabel')}
                 />
               </Center>
               {error && <Alert color="red">{error}</Alert>}

--- a/frontend/src/test/otp-input.test.tsx
+++ b/frontend/src/test/otp-input.test.tsx
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+/**
+ * Regression coverage for ``OtpInput``.
+ *
+ * The bug this guards against: 2FA code entry used Mantine's segmented
+ * ``<PinInput>`` (one ``<input maxlength="1">`` per digit). Desktop
+ * password-manager *extensions* fill those per-field, but mobile *native*
+ * autofill (iOS Password AutoFill — which 1Password drives on iOS — and
+ * Android Autofill) inserts the whole code into the single focused field,
+ * where ``maxlength=1`` truncates it to one digit and the code never lands.
+ *
+ * The fix is a single ``<input autocomplete="one-time-code"
+ * inputmode="numeric">``, the autofill target 1Password and Apple document.
+ * These tests pin that contract: exactly one input, the right autofill
+ * attributes, and PinInput-equivalent behaviour (digits only, clamped to
+ * length) so a native autofill of the full code is accepted intact.
+ */
+import { useState } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { MantineProvider } from '@mantine/core';
+
+import { OtpInput } from '@/components/OtpInput';
+
+afterEach(cleanup);
+
+function Harness({ length }: { length?: number }) {
+  const [code, setCode] = useState('');
+  return (
+    <MantineProvider>
+      <OtpInput
+        value={code}
+        onChange={setCode}
+        length={length}
+        aria-label="One-time code"
+      />
+      <output data-testid="value">{code}</output>
+    </MantineProvider>
+  );
+}
+
+describe('OtpInput', () => {
+  it('renders a single autofill-friendly input, not a segmented field', () => {
+    render(<Harness />);
+    const input = screen.getByLabelText('One-time code') as HTMLInputElement;
+    // A segmented PinInput would render six inputs; a native autofill of
+    // the whole code only lands when there is exactly one.
+    expect(screen.getAllByRole('textbox')).toHaveLength(1);
+    expect(input.getAttribute('autocomplete')).toBe('one-time-code');
+    expect(input.getAttribute('inputmode')).toBe('numeric');
+  });
+
+  it('accepts a full 6-digit code typed/pasted/autofilled in one shot', () => {
+    render(<Harness />);
+    const input = screen.getByLabelText('One-time code') as HTMLInputElement;
+    // Native autofill sets the whole string at once — the maxlength=1
+    // truncation that broke PinInput must not happen here.
+    fireEvent.change(input, { target: { value: '123456' } });
+    expect(screen.getByTestId('value')).toHaveTextContent('123456');
+  });
+
+  it('strips non-digits and clamps to length', () => {
+    render(<Harness />);
+    const input = screen.getByLabelText('One-time code') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '12-34 56789' } });
+    expect(screen.getByTestId('value')).toHaveTextContent('123456');
+  });
+
+  it('honours a custom length', () => {
+    render(<Harness length={4} />);
+    const input = screen.getByLabelText('One-time code') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '987654' } });
+    expect(screen.getByTestId('value')).toHaveTextContent('9876');
+  });
+});


### PR DESCRIPTION
## Summary

On mobile, 1Password (and any password manager) failed to autofill the
2FA 6-digit code, while desktop autofilled fine.

**Root cause:** 2FA code entry used Mantine's segmented `<PinInput>`,
which renders six `<input maxlength="1">` boxes. Desktop password-manager
*extensions* fill those per-field, but mobile *native* autofill (iOS
Password AutoFill — which 1Password drives on iOS — and Android Autofill)
inserts the whole code into the single focused field in one shot, where
`maxlength=1` truncates it to a single digit and the code never lands.
1Password's [developer docs](https://www.1password.dev/web/compatible-website-design/)
and Apple's Password AutoFill both target a single field carrying
`autocomplete="one-time-code"`.

**Fix:** new single-field `OtpInput` (`autocomplete="one-time-code"`,
`inputmode="numeric"`, digit-stripping + length clamp) replacing
`PinInput` at all six call sites — `TwoFactorPage` (TOTP/email setup +
TOTP/email challenge) and `TwoFactorSetupModal` (TOTP + email). Adds a
`twoFactor.codeInputLabel` aria-label across en/nl/de/fr.

## Test plan

- `tsc --noEmit` ✅, `eslint` (changed files) ✅
- New `src/test/otp-input.test.tsx`: asserts exactly one input, correct
  autofill attributes, accepts a one-shot full-code fill (the case
  `maxlength=1` broke), strips non-digits, clamps to length ✅
- Full Vitest suite: 120 passed ✅
- E2E unaffected — the 2FA e2e helpers drive the flow via the API and
  never touch this input.

The autofill behavior itself is OS-native and can't be exercised in
Playwright/Vitest, so the regression test pins the field *contract*
(single field + `one-time-code` + numeric) rather than the OS interaction.