### PR TITLE
Help 1Password match the account on the 2FA page

### DIFF
--- a/frontend/src/components/AutofillUsernameField.tsx
+++ b/frontend/src/components/AutofillUsernameField.tsx
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+/**
+ * Visually-hidden, autofill-tagged username field for the 2FA page.
+ *
+ * The /2fa challenge page otherwise has only a one-time-code field. iOS
+ * Password AutoFill (which 1Password uses on iOS) and desktop password
+ * managers scope autofill to a specific account using the page's username
+ * field. With none present, 1Password can match the *domain* but not the
+ * *account* — so on the OTP page it opens the whole vault instead of
+ * jumping to the matching login, and falls back to copying the code to the
+ * clipboard rather than filling it inline.
+ *
+ * Carrying the signing-in email in an `autocomplete="username"` field gives
+ * the autofill machinery the account context it needs. The field is kept in
+ * the DOM (the sr-only pattern, not `display:none`) so the autofill
+ * heuristics still see it, and `aria-hidden` keeps the decoy out of the
+ * screen-reader tree.
+ *
+ * Renders nothing when the email is unknown (e.g. a hard reload of /2fa
+ * where the login-page navigation state was lost) — the page degrades to
+ * its previous behaviour rather than shipping an empty, unfillable field.
+ */
+export function AutofillUsernameField({ email }: { email?: string }) {
+  if (!email) return null;
+  return (
+    <input
+      type="text"
+      name="username"
+      autoComplete="username"
+      value={email}
+      readOnly
+      tabIndex={-1}
+      aria-hidden="true"
+      style={{
+        position: 'absolute',
+        width: 1,
+        height: 1,
+        padding: 0,
+        margin: -1,
+        overflow: 'hidden',
+        clip: 'rect(0, 0, 0, 0)',
+        whiteSpace: 'nowrap',
+        border: 0,
+      }}
+    />
+  );
+}

--- a/frontend/src/routes/LoginPage.tsx
+++ b/frontend/src/routes/LoginPage.tsx
@@ -78,8 +78,13 @@ export function LoginPage() {
       // challenge screen (one or more methods enrolled).
       const { data: state } = await api.get<TOTPState>('/auth/totp/state');
       if (!state.session_passed) {
+        // Carry the email so /2fa can render a hidden autocomplete="username"
+        // field — without it password managers (1Password on iOS) match the
+        // domain but not the account on the OTP-only page, so they can't jump
+        // to the right login or fill the code inline.
         navigate(`/2fa?from=${encodeURIComponent(redirectTo)}`, {
           replace: true,
+          state: { email },
         });
         return;
       }

--- a/frontend/src/routes/TwoFactorPage.tsx
+++ b/frontend/src/routes/TwoFactorPage.tsx
@@ -36,6 +36,7 @@ import {
 } from '@/hooks/useWebAuthn';
 import { isServerRoute, sanitizeRedirect } from '@/lib/redirect';
 import { OtpInput } from '@/components/OtpInput';
+import { AutofillUsernameField } from '@/components/AutofillUsernameField';
 
 /**
  * /2fa page — hosts both enrollment and returning-user challenge.
@@ -48,6 +49,10 @@ import { OtpInput } from '@/components/OtpInput';
 export function TwoFactorPage() {
   const navigate = useNavigate();
   const location = useLocation();
+  // Passed by LoginPage so the challenge forms can render a hidden
+  // autocomplete="username" field for password-manager account matching.
+  // Absent on a hard reload of /2fa — the field degrades to nothing.
+  const email = (location.state as { email?: string } | null)?.email;
   const { data: state, isLoading, isFetching, refetch } = useTOTPState();
 
   // Sanitise — see lib/redirect.ts. Without this, `?from=//evil.example`
@@ -88,7 +93,13 @@ export function TwoFactorPage() {
     state.email_otp_confirmed ||
     state.webauthn_credential_count > 0;
   if (anyConfirmed) {
-    return <TwoFactorChallenge state={state} onVerified={() => refetch()} />;
+    return (
+      <TwoFactorChallenge
+        state={state}
+        email={email}
+        onVerified={() => refetch()}
+      />
+    );
   }
   return <TwoFactorSetup state={state} onChange={() => refetch()} />;
 }
@@ -364,6 +375,7 @@ type ChallengePhase = 'webauthn' | 'picker' | 'totp' | 'email';
 
 function TwoFactorChallenge({
   state,
+  email,
   onVerified,
 }: {
   state: {
@@ -371,6 +383,7 @@ function TwoFactorChallenge({
     email_otp_confirmed: boolean;
     webauthn_credential_count: number;
   };
+  email?: string;
   onVerified: () => void;
 }) {
   const { t } = useTranslation();
@@ -491,18 +504,32 @@ function TwoFactorChallenge({
   const canGoBack = hasWebAuthn || fallbackMethods.length > 1;
   const backHandler = canGoBack ? () => setPhase('picker') : undefined;
   if (phase === 'totp') {
-    return <TOTPChallengeForm onVerified={onVerified} onBack={backHandler} />;
+    return (
+      <TOTPChallengeForm
+        onVerified={onVerified}
+        onBack={backHandler}
+        email={email}
+      />
+    );
   }
-  return <EmailOTPChallengeForm onVerified={onVerified} onBack={backHandler} />;
+  return (
+    <EmailOTPChallengeForm
+      onVerified={onVerified}
+      onBack={backHandler}
+      email={email}
+    />
+  );
 }
 
 
 function TOTPChallengeForm({
   onVerified,
   onBack,
+  email,
 }: {
   onVerified: () => void;
   onBack?: () => void;
+  email?: string;
 }) {
   const { t } = useTranslation();
   const verify = useTOTPVerify();
@@ -530,6 +557,7 @@ function TOTPChallengeForm({
         <Paper withBorder shadow="md" p="xl" radius="md">
           <form onSubmit={handleSubmit}>
             <Stack>
+              <AutofillUsernameField email={email} />
               <Text size="sm" c="dimmed" ta="center">
                 {t('twoFactor.challengeIntro')}
               </Text>
@@ -566,9 +594,11 @@ function TOTPChallengeForm({
 function EmailOTPChallengeForm({
   onVerified,
   onBack,
+  email,
 }: {
   onVerified: () => void;
   onBack?: () => void;
+  email?: string;
 }) {
   const { t } = useTranslation();
   const requestCode = useEmailOTPRequest();
@@ -609,6 +639,7 @@ function EmailOTPChallengeForm({
         <Paper withBorder shadow="md" p="xl" radius="md">
           <form onSubmit={handleSubmit}>
             <Stack>
+              <AutofillUsernameField email={email} />
               <Text size="sm" c="dimmed" ta="center">
                 {sent ? t('twoFactor.emailSentIntro') : t('twoFactor.emailSending')}
               </Text>

--- a/frontend/src/test/autofill-username-field.test.tsx
+++ b/frontend/src/test/autofill-username-field.test.tsx
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Brendan Bank
+// SPDX-License-Identifier: BSD-2-Clause
+
+/**
+ * Regression coverage for ``AutofillUsernameField``.
+ *
+ * The /2fa challenge page has only a one-time-code field. Password managers
+ * (1Password on iOS) scope autofill to an account via the page's username
+ * field; with none present they match the domain but not the account, so on
+ * the OTP page they open the whole vault instead of jumping to the matching
+ * login and filling the code inline. This field supplies that context.
+ *
+ * Pins the contract: an ``autocomplete="username"`` input carrying the email
+ * when known, and nothing at all when the email is absent (a hard reload of
+ * /2fa) so the page never ships an empty, unfillable decoy field.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+
+import { AutofillUsernameField } from '@/components/AutofillUsernameField';
+
+afterEach(cleanup);
+
+describe('AutofillUsernameField', () => {
+  it('renders an autocomplete="username" field carrying the email', () => {
+    const { container } = render(
+      <AutofillUsernameField email="info@brendanbank.com" />,
+    );
+    const input = container.querySelector('input');
+    expect(input).not.toBeNull();
+    expect(input?.getAttribute('autocomplete')).toBe('username');
+    expect((input as HTMLInputElement).value).toBe('info@brendanbank.com');
+    // Read-only and out of the tab order — it's a decoy for the password
+    // manager, never something the user edits or tabs into.
+    expect(input?.hasAttribute('readonly')).toBe(true);
+    expect(input?.getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('renders nothing when the email is unknown', () => {
+    const { container } = render(<AutofillUsernameField />);
+    expect(container.querySelector('input')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #183. On mobile, 1Password showed the password button but
didn't jump to the matching login or fill the 2FA code inline — it fell
back to copying the code to the clipboard.

**Root cause:** the `/2fa` challenge page has only a one-time-code field.
iOS Password AutoFill (which 1Password uses on iOS) scopes autofill to a
specific account using the page's **username** field. With none present,
1Password matched the *domain* but not the *account*, so it opened the
whole vault instead of the matching item. (Confirmed from device
screenshots: the item is correctly configured with a TOTP + both URLs.)

**Fix:** add a visually-hidden `autocomplete="username"` field
(`AutofillUsernameField`) carrying the signing-in email. `LoginPage`
passes the email to `/2fa` via router state; `TwoFactorPage` threads it
into the TOTP and email-OTP challenge forms. Kept in the DOM via the
sr-only pattern (not `display:none`) so autofill heuristics see it;
renders nothing when the email is unknown (a hard reload of `/2fa`).

Per Apple's [Password AutoFill workflow](https://developer.apple.com/documentation/security/about-the-password-autofill-workflow).

## Test plan

- `tsc --noEmit` ✅, eslint (changed files) ✅
- New `autofill-username-field.test.tsx` (renders the tagged field with
  the email; renders nothing without it) ✅
- Full Vitest suite: 122 passed ✅

Note: iOS native autofill can't be exercised in Playwright/Vitest, so the
test pins the field contract rather than the OS interaction.