### PR TITLE
Serve SPA shell with no-store on client-side route fallback

### DIFF
--- a/backend/app/static.py
+++ b/backend/app/static.py
@@ -22,17 +22,25 @@ class SPAStaticFiles(StaticFiles):
     """
 
     async def get_response(self, path: str, scope: Scope):
+        served_spa_shell = path in ("", "index.html")
         try:
             response = await super().get_response(path, scope)
         except HTTPException as exc:
             if exc.status_code == 404 and scope.get("method") == "GET":
+                # Client-side route (e.g. /admin/audit) — fall back to the
+                # shell. ``path`` still names the original route here, so we
+                # track the shell-served case explicitly: without it the
+                # no-store header below never lands and browsers heuristically
+                # cache the shell, pinning the user to a stale asset bundle
+                # until a hard reload.
                 response = await super().get_response("index.html", scope)
+                served_spa_shell = True
             else:
                 raise
 
         if path.startswith("assets/"):
             response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
-        elif path in ("", "index.html"):
+        elif served_spa_shell:
             response.headers["Cache-Control"] = "no-store"
 
         return response


### PR DESCRIPTION
## Problem

After a release, reloading (not hard-reloading) on any deep route — `/admin/audit`, `/profile`, etc. — kept serving a stale frontend. Only a DevTools hard reload picked up the new bundle.

## Root cause

`SPAStaticFiles` already does the textbook cache-busting split: `/assets/*` (Vite-hashed) are `immutable`, `index.html` is `no-store`. But the `no-store` branch keyed on the request `path`. On a client-side route, `super().get_response()` 404s and we fall back to serving `index.html` — while `path` still names the original route. Neither cache-control branch matched, so the shell went out with **no** `Cache-Control` header, browsers applied heuristic caching, and the user stayed pinned to the old asset hashes until a hard reload.

Reloading from `/` worked (path `""` matched); any sub-path did not.

## Fix

Track whether we actually served the SPA shell (root, `index.html`, or the fallback) and stamp `Cache-Control: no-store` in every case. A plain reload from any path now re-fetches the shell, sees the new hashed asset names, and pulls the new bundle.

No service worker / PWA in play, and nginx has `proxy_cache off`, so this was the only leak in the chain.

## Note

The first reload after deploying this still needs to be a hard reload — the currently-cached shell predates the fix. Every reload after that is fine.