### PR TITLE
Show configured brand name on the login page instead of "Atrium"

### DIFF
--- a/frontend/src/routes/LoginPage.tsx
+++ b/frontend/src/routes/LoginPage.tsx
@@ -33,6 +33,7 @@ export function LoginPage() {
   const location = useLocation();
   const qc = useQueryClient();
   const { data: appConfig } = useAppConfig();
+  const brandName = appConfig?.brand?.name?.trim() || t('app.title');
   const allowSignup = appConfig?.auth?.allow_signup === true;
   const captchaProvider = appConfig?.auth?.captcha_provider ?? 'none';
   const [error, setError] = useState<string | null>(null);
@@ -122,7 +123,7 @@ export function LoginPage() {
     <Center h="100vh">
       <Container size={420} w="100%">
         <Title ta="center" mb="lg">
-          {t('app.title')}
+          {brandName}
         </Title>
         <Paper withBorder shadow="md" p="xl" radius="md">
           <form onSubmit={handleSubmit}>


### PR DESCRIPTION
## Problem

On `/login`, the page heading rendered the i18n key `app.title` (which defaults to **"Atrium"**), ignoring the operator-configured `brand.name` from the public `/app-config` bundle. The post-login `AppLayout` already uses `brand?.name ?? t('app.title')`, so a renamed tenant saw their brand everywhere *except* the one pre-auth screen they hit first.

Reported against a host deployment whose login page still showed "Atrium" despite a configured brand name.

## Fix

`LoginPage.tsx` now reads `brand.name` from the bundle (already fetched on that page via `useAppConfig`) and falls back to the i18n title only when no brand name is set:

```tsx
const brandName = appConfig?.brand?.name?.trim() || t('app.title');
```

## Scope

Checked the other unauthenticated pages (Register, Forgot/Reset password, Verify email, Accept invite, 2FA) — they all render page-specific titles, not the app/brand name, so the login page was the only one affected.

`pnpm typecheck` passes.