### PR TITLE
ci: auto-relock + auto-merge Dependabot grouped npm PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,14 @@ updates:
   # instead of one per directory. Without this, a vite bump in
   # /examples/hello-world/frontend opens its own PR even though
   # the same package lives in /frontend.
+  #
+  # Caveat this triggers: on a GROUPED multi-directory update
+  # Dependabot bumps the package.json files but leaves both pnpm
+  # lockfiles stale, failing `pnpm install --frozen-lockfile`. The
+  # pnpm-lock-refresh / pnpm-lock-commit workflow pair intercepts
+  # these PRs and regenerates the lockfiles; dependabot-auto-merge
+  # then merges patch/minor groups once CI is green. See
+  # docs/dependabot-automation.md.
   - package-ecosystem: "npm"
     directories:
       - "/frontend"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,132 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: dependabot-auto-merge
+
+# Auto-merges Dependabot's grouped npm version bumps once CI is green,
+# so the weekly Mantine/Tiptap/etc. refresh stops needing manual
+# clicks. Two jobs, two triggers:
+#
+#   mark  (pull_request) — runs on the Dependabot PR, reads the update
+#         metadata, and labels the PR `npm-automerge` UNLESS the group
+#         contains a major-version bump (those still want human eyes).
+#
+#   merge (workflow_run: CI completed) — fires when a CI run finishes
+#         on a dependabot/npm_and_yarn/* branch; if that PR carries the
+#         `npm-automerge` label and CI passed on its current head, it
+#         squash-merges. master has no branch-protection required
+#         checks, so native auto-merge can't gate on CI — this
+#         workflow_run gate is the equivalent.
+#
+# The relock pair (pnpm-lock-refresh / pnpm-lock-commit) pushes the
+# corrected lockfiles with a PAT, which re-runs CI on the fixed commit;
+# this workflow then sees that green run and merges. Without the PAT,
+# the label is still applied but the merge waits for a CI run that
+# passes on the head commit.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  mark:
+    if: >
+      github.event_name == 'pull_request' &&
+      github.actor == 'dependabot[bot]' &&
+      startsWith(github.head_ref, 'dependabot/npm_and_yarn/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98  # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Ensure the npm-automerge label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        # Idempotent: --force creates it or updates it in place, so the
+        # later --add-label never fails on a missing label.
+        run: |
+          gh label create npm-automerge --repo "$REPO" --force \
+            --color 0e8a16 \
+            --description "Dependabot npm group is patch/minor; auto-merge once CI is green"
+
+      - name: Label patch/minor groups for auto-merge
+        # Group PRs report the highest semver bump in update-type, so a
+        # single major in the batch keeps the whole PR out of the
+        # auto-merge lane. CI (typecheck/lint/unit/build/e2e/scaffolder)
+        # is the actual safety gate; this just scopes WHICH PRs merge
+        # unattended.
+        if: >
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label npm-automerge
+
+  merge:
+    if: >
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'dependabot/npm_and_yarn/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Merge if labelled and CI is green on the head commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          CI_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          [[ "$HEAD_BRANCH" =~ ^dependabot/npm_and_yarn/[A-Za-z0-9._/-]+$ ]] \
+            || { echo "unexpected branch name; skipping" >&2; exit 0; }
+
+          PR_JSON=$(gh pr list --repo "$REPO" --head "$HEAD_BRANCH" --state open \
+            --json number,headRefOid,labels,author --jq '.[0] // empty')
+          if [ -z "$PR_JSON" ]; then
+            echo "No open PR for $HEAD_BRANCH; nothing to merge."
+            exit 0
+          fi
+
+          NUMBER=$(jq -r '.number' <<<"$PR_JSON")
+          HEAD_OID=$(jq -r '.headRefOid' <<<"$PR_JSON")
+          HAS_LABEL=$(jq -r '[.labels[].name] | index("npm-automerge") != null' <<<"$PR_JSON")
+          IS_DEPENDABOT=$(jq -r '(.author.login // "") | test("dependabot")' <<<"$PR_JSON")
+
+          if [ "$HAS_LABEL" != "true" ]; then
+            echo "PR #$NUMBER not labelled npm-automerge (likely a major bump); leaving for review."
+            exit 0
+          fi
+          if [ "$IS_DEPENDABOT" != "true" ]; then
+            echo "PR #$NUMBER author is not Dependabot; refusing to auto-merge." >&2
+            exit 0
+          fi
+          # Only merge the exact commit CI just validated — guards
+          # against a newer push that hasn't been checked yet.
+          if [ "$HEAD_OID" != "$CI_SHA" ]; then
+            echo "PR head ($HEAD_OID) moved past the CI'd commit ($CI_SHA); waiting for its CI."
+            exit 0
+          fi
+
+          echo "Squash-merging PR #$NUMBER ($HEAD_BRANCH)."
+          gh pr merge "$NUMBER" --repo "$REPO" --squash --delete-branch

--- a/.github/workflows/pnpm-lock-commit.yml
+++ b/.github/workflows/pnpm-lock-commit.yml
@@ -1,0 +1,150 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: pnpm-lock-commit
+
+# Privileged half of the pnpm-lock-refresh split (see that file for
+# context). Triggered when the unprivileged refresh finishes
+# successfully on a Dependabot PR; this one runs in the base-repo
+# context (default branch's YAML), holds contents: write, and never
+# checks out the PR branch — the lockfiles are written through the
+# GitHub Git Data API directly. That keeps every "untrusted-checkout"
+# anti-pattern out of the privileged path: no actions/checkout of a PR
+# ref, no run: block executing a script from PR content.
+#
+# Push token: PUSH_TOKEN prefers a fine-grained PAT (Dependabot can't
+# push to its own PRs, and a commit pushed with the default
+# GITHUB_TOKEN does NOT re-trigger pull_request workflows). With the
+# PAT, the relock commit re-runs CI on the corrected lockfiles so the
+# PR can go green and auto-merge. Without it, the workflow still
+# commits the lockfiles (via the fallback GITHUB_TOKEN) but CI won't
+# re-run automatically — see docs/dependabot-automation.md for the
+# one-time secret setup.
+#
+# The flow:
+#   1. Validate the originating workflow_run was a successful
+#      Dependabot pull_request event.
+#   2. Download the lockfiles + pr-meta artifacts from that run.
+#   3. Sanity-check the metadata before any of it touches the API.
+#   4. Build ONE atomic commit (Git Data API) updating whichever of
+#      the two lockfiles actually changed, fast-forward only.
+
+on:
+  workflow_run:
+    workflows: ["pnpm-lock-refresh"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: read
+  actions: read
+
+jobs:
+  push-locks:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download lockfiles artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: pnpm-locks
+          path: artifact-locks
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download PR metadata
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: pr-meta
+          path: artifact-pr-meta
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate metadata and commit changed lockfiles
+        env:
+          # Prefer the PAT so the relock commit re-triggers CI; fall
+          # back to GITHUB_TOKEN (commits, but no re-trigger).
+          GH_TOKEN: ${{ secrets.DEPENDABOT_LOCKFILE_TOKEN || secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        # Whole step is bash with set -euo pipefail and explicit env
+        # vars — nothing comes from ${{ ... }} interpolation, nothing
+        # from the artifact is fed to a shell unquoted. Fails closed on
+        # any unexpected metadata shape.
+        run: |
+          set -euo pipefail
+
+          NUMBER=$(cat artifact-pr-meta/number)
+          HEAD_REF=$(cat artifact-pr-meta/head_ref)
+          HEAD_SHA=$(cat artifact-pr-meta/head_sha)
+
+          [[ "$NUMBER"   =~ ^[0-9]+$ ]]           || { echo "bad PR number" >&2; exit 1; }
+          [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]     || { echo "bad SHA"       >&2; exit 1; }
+          [[ "$HEAD_REF" =~ ^[A-Za-z0-9._/-]+$ ]] || { echo "bad ref"       >&2; exit 1; }
+
+          # The branch tip must still match the SHA the artifact was
+          # generated against. If it moved, abort rather than clobber a
+          # newer commit with a stale lockfile.
+          BRANCH_HEAD_SHA=$(gh api -H "Accept: application/vnd.github+json" \
+            "repos/$REPO/branches/$HEAD_REF" --jq '.commit.sha')
+          if [ "$BRANCH_HEAD_SHA" != "$HEAD_SHA" ]; then
+            echo "Branch moved (artifact=$HEAD_SHA, branch=$BRANCH_HEAD_SHA); skipping."
+            exit 0
+          fi
+
+          # Base tree = the tree of the current head commit.
+          BASE_TREE=$(gh api -H "Accept: application/vnd.github+json" \
+            "repos/$REPO/git/commits/$HEAD_SHA" --jq '.tree.sha')
+
+          # For each lockfile, create a blob only if it differs from
+          # what's on the branch; collect the changed ones into a tree.
+          TREE_ENTRIES='[]'
+          for PATH_REL in "pnpm-lock.yaml" "frontend/pnpm-lock.yaml"; do
+            NEW_FILE="artifact-locks/$PATH_REL"
+            [ -f "$NEW_FILE" ] || { echo "missing artifact $NEW_FILE" >&2; exit 1; }
+
+            CUR_B64=$(gh api -H "Accept: application/vnd.github+json" \
+              "repos/$REPO/contents/$PATH_REL?ref=$HEAD_REF" --jq '.content' | tr -d '\n')
+            NEW_B64=$(base64 -w0 < "$NEW_FILE" 2>/dev/null || base64 < "$NEW_FILE" | tr -d '\n')
+            CUR_NORM=$(printf '%s' "$CUR_B64" | base64 -d | sha256sum)
+            NEW_NORM=$(printf '%s' "$NEW_B64" | base64 -d | sha256sum)
+            if [ "$CUR_NORM" = "$NEW_NORM" ]; then
+              echo "$PATH_REL unchanged"
+              continue
+            fi
+
+            BLOB_SHA=$(jq -n --arg c "$NEW_B64" '{content:$c, encoding:"base64"}' \
+              | gh api -X POST -H "Accept: application/vnd.github+json" \
+                  "repos/$REPO/git/blobs" --input - --jq '.sha')
+            TREE_ENTRIES=$(jq -c \
+              --arg path "$PATH_REL" --arg sha "$BLOB_SHA" \
+              '. += [{path:$path, mode:"100644", type:"blob", sha:$sha}]' \
+              <<<"$TREE_ENTRIES")
+            echo "$PATH_REL changed -> blob $BLOB_SHA"
+          done
+
+          if [ "$TREE_ENTRIES" = "[]" ]; then
+            echo "Both lockfiles already current; nothing to commit."
+            exit 0
+          fi
+
+          NEW_TREE=$(jq -n --arg base "$BASE_TREE" --argjson tree "$TREE_ENTRIES" \
+            '{base_tree:$base, tree:$tree}' \
+            | gh api -X POST -H "Accept: application/vnd.github+json" \
+                "repos/$REPO/git/trees" --input - --jq '.sha')
+
+          NEW_COMMIT=$(jq -n \
+            --arg msg "Build(deps): refresh pnpm lockfiles after Dependabot bump" \
+            --arg tree "$NEW_TREE" --arg parent "$HEAD_SHA" \
+            '{message:$msg, tree:$tree, parents:[$parent]}' \
+            | gh api -X POST -H "Accept: application/vnd.github+json" \
+                "repos/$REPO/git/commits" --input - --jq '.sha')
+
+          # Fast-forward-only ref update: force=false so a concurrent
+          # push aborts us instead of being overwritten.
+          gh api -X PATCH -H "Accept: application/vnd.github+json" \
+            "repos/$REPO/git/refs/heads/$HEAD_REF" \
+            -f sha="$NEW_COMMIT" -F force=false > /dev/null
+          echo "Committed refreshed lockfiles to $HEAD_REF (PR #$NUMBER) as $NEW_COMMIT"

--- a/.github/workflows/pnpm-lock-refresh.yml
+++ b/.github/workflows/pnpm-lock-refresh.yml
@@ -1,0 +1,100 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: pnpm-lock-refresh
+
+# Dependabot's grouped, multi-directory npm updates bump the
+# package.json files in /frontend and /examples/hello-world/frontend
+# but leave the pnpm lockfiles untouched, so every such PR lands red
+# with ERR_PNPM_OUTDATED_LOCKFILE across the frontend / scaffolder /
+# e2e jobs until someone relocks by hand. (Dependabot updates a single
+# directory's lockfile fine; the grouped multi-directory pnpm case is
+# the gap.)
+#
+# This is the unprivileged half of a two-workflow split modelled on
+# uv-lock-refresh / uv-lock-commit. It regenerates BOTH lockfiles and
+# uploads them as artifacts; pnpm-lock-commit.yml then picks them up
+# via a workflow_run trigger and pushes them back to the PR branch
+# with elevated permissions. Keeping the checkout-of-PR-head step on a
+# read-only token follows the GitHub Security Lab "preventing pwn
+# requests" guidance. pnpm resolves the lockfile with
+# --lockfile-only --ignore-scripts, so no package lifecycle script
+# from the PR ever executes here regardless.
+
+on:
+  pull_request:
+    paths:
+      - "frontend/package.json"
+      - "frontend/pnpm-lock.yaml"
+      - "examples/hello-world/frontend/package.json"
+      - "pnpm-lock.yaml"
+
+permissions:
+  contents: read
+
+jobs:
+  relock:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      # Implicit checkout of PR head — fine, this job's token is
+      # read-only and pnpm runs with --ignore-scripts, so PR-supplied
+      # package code never executes with any repo-relevant capability.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
+        with:
+          version: 10.33.1
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: "22"
+
+      # Root workspace lock covers the hello-world example (a pnpm
+      # workspace member). The main SPA in /frontend is deliberately
+      # excluded from the workspace, so it relocks standalone with
+      # --ignore-workspace (see frontend/.npmrc).
+      - name: Regenerate root pnpm-lock.yaml
+        run: pnpm install --lockfile-only --ignore-scripts
+
+      - name: Regenerate frontend/pnpm-lock.yaml
+        working-directory: frontend
+        run: pnpm install --lockfile-only --ignore-scripts --ignore-workspace
+
+      - name: Capture PR metadata
+        # The privileged downstream workflow needs the branch + SHA to
+        # push back to. Carry them via artifact so the workflow_run
+        # consumer never has to trust anything from the PR head — it
+        # reads files we wrote and validates their shape, failing
+        # closed. Pass values via env, NOT ${{ ... }} interpolation in
+        # the run script, so a maliciously-named branch can't break
+        # out of the shell quoting (actions/code-injection).
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          mkdir -p pr-meta
+          printf '%s' "$PR_NUMBER"   > pr-meta/number
+          printf '%s' "$PR_HEAD_REF" > pr-meta/head_ref
+          printf '%s' "$PR_HEAD_SHA" > pr-meta/head_sha
+
+      - name: Upload lockfiles
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4.6.2
+        with:
+          name: pnpm-locks
+          # Both lockfiles, preserving their repo-relative paths so the
+          # consumer can map each back to its destination.
+          path: |
+            pnpm-lock.yaml
+            frontend/pnpm-lock.yaml
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Upload PR metadata
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4.6.2
+        with:
+          name: pr-meta
+          path: pr-meta/
+          retention-days: 1
+          if-no-files-found: error

--- a/docs/dependabot-automation.md
+++ b/docs/dependabot-automation.md
@@ -1,0 +1,77 @@
+# Dependabot lockfile auto-relock + auto-merge
+
+Dependabot's **grouped, multi-directory npm** updates (the weekly
+`npm-version-updates` group spanning `/frontend` and
+`/examples/hello-world/frontend`) bump the `package.json` files but
+leave both pnpm lockfiles untouched. Every such PR therefore lands red
+with `ERR_PNPM_OUTDATED_LOCKFILE` across the `frontend`, `scaffolder`,
+and `hello-world-e2e` jobs and needs a manual relock. This automation
+removes that toil.
+
+> Backend (`uv.lock`) is handled separately by `uv-lock-refresh.yml` /
+> `uv-lock-commit.yml`. Single-directory npm updates are fine —
+> Dependabot relocks those itself. Only the grouped multi-directory
+> pnpm case needs this.
+
+## What runs
+
+| Workflow | Trigger | Job | Does |
+| --- | --- | --- | --- |
+| `pnpm-lock-refresh.yml` | `pull_request` touching a frontend manifest/lock, Dependabot only | unprivileged (`contents: read`) | Checks out the PR head, regenerates the **root** lock (`pnpm install --lockfile-only --ignore-scripts`, covers the hello-world example) and the **standalone** `frontend/pnpm-lock.yaml` (`--ignore-workspace`), uploads both + PR metadata as artifacts. |
+| `pnpm-lock-commit.yml` | `workflow_run` of the above completing | privileged (`contents: write`) | Validates the metadata, then commits whichever lockfiles changed back to the PR branch in **one atomic Git Data API commit** (fast-forward only). Never checks out PR code. |
+| `dependabot-auto-merge.yml` | `pull_request` + `workflow_run` of `CI` | `mark` / `merge` | `mark` labels the PR `npm-automerge` unless the group contains a **major** bump. `merge` squash-merges a labelled PR once CI passes on its current head. |
+
+The split (unprivileged relock that touches PR content vs. privileged
+commit that never does) follows the GitHub Security Lab "preventing pwn
+requests" guidance, mirroring the existing `uv-lock-*` pair. pnpm runs
+with `--ignore-scripts`, so no package lifecycle script from the PR ever
+executes.
+
+## One-time setup (required for green CI + auto-merge)
+
+A commit pushed with the default `GITHUB_TOKEN` does **not** re-trigger
+`pull_request` workflows, so without a separate token the relock commit
+would land but CI wouldn't re-run on the fixed lockfiles — the PR would
+stay red and never auto-merge. Provide a token so the relock commit
+re-runs CI:
+
+1. Create a **fine-grained PAT** scoped to this repository with
+   **Contents: Read and write** (and **Pull requests: Read and write**
+   if you want it to be reusable). A short expiry plus calendar reminder
+   to rotate is fine.
+2. Add it as an **Actions** repository secret named
+   **`DEPENDABOT_LOCKFILE_TOKEN`**
+   (`Settings -> Secrets and variables -> Actions -> New repository
+   secret`). It's read only by `pnpm-lock-commit.yml`, which runs in the
+   trusted base context (not the Dependabot `pull_request` context), so
+   a standard Actions secret is correct — it does **not** need to be a
+   Dependabot secret.
+3. Ensure **Settings -> General -> Pull Requests -> Allow squash
+   merging** is enabled (it already is — the repo squash-merges).
+
+Without the secret the workflows still commit the refreshed lockfiles
+(via the fallback `GITHUB_TOKEN`); you just have to nudge CI to re-run
+(e.g. close/reopen the PR) and merge manually — i.e. no worse than
+today, minus the hand relock.
+
+## Scope / safety
+
+- Only `dependabot/npm_and_yarn/*` branches are eligible; backend,
+  Actions, and Docker updates are untouched.
+- **Major** version bumps are never auto-merged — the `mark` job leaves
+  them unlabelled for human review. Patch/minor groups auto-merge only
+  after the **full** CI suite (typecheck, lint, unit, build, e2e,
+  scaffolder, hello-world-e2e) passes on the relocked commit.
+- The `merge` job re-checks that the PR is Dependabot-authored, carries
+  the label, and that CI passed on the *exact* current head SHA before
+  merging.
+
+## Tuning
+
+- **Auto-merge majors too** (CI is comprehensive): drop the
+  `update-type` guard in the `mark` job so every group gets labelled.
+- **Relock only, no auto-merge**: delete `dependabot-auto-merge.yml`;
+  the relock pair still makes the PRs go green for a manual merge.
+- **Per-package or per-developer review**: add a required reviewer or
+  branch-protection rule on `master`; the `merge` job's `gh pr merge`
+  will then queue behind it.


### PR DESCRIPTION
Ends the manual hand-holding the grouped pnpm Dependabot PRs needed all session (#186/#191/#203/#204 were relocked by hand). Mirrors the existing `uv-lock-refresh` / `uv-lock-commit` split for the pnpm side.

## Why these bumps need help
Dependabot's grouped, **multi-directory** npm updates bump the `package.json`s in `/frontend` and `/examples/hello-world/frontend` but leave both pnpm lockfiles stale → every weekly refresh lands red with `ERR_PNPM_OUTDATED_LOCKFILE`. (Single-directory npm and backend `uv.lock` are fine — Dependabot relocks those itself.)

## What's added
| Workflow | Role |
| --- | --- |
| `pnpm-lock-refresh.yml` | **Unprivileged** (`contents: read`). On a Dependabot frontend PR, relocks the root lock (covers the hello-world example) + the standalone `frontend` lock (`--ignore-workspace`), both `--ignore-scripts`. Uploads artifacts. |
| `pnpm-lock-commit.yml` | **Privileged** (`contents: write`). On `workflow_run`, commits the changed lockfiles back via one atomic **Git Data API** commit (fast-forward only, never checks out PR code). |
| `dependabot-auto-merge.yml` | Labels patch/minor groups (`mark`) and squash-merges them once CI is green (`merge`). |

Security model mirrors `uv-lock-*`: the step that touches PR content holds no write scope, the privileged step never runs PR code, and pnpm runs `--ignore-scripts`.

## ⚠️ One-time setup required
A commit pushed with the default `GITHUB_TOKEN` does **not** re-trigger CI, so the relock commit needs a real token to make the PR go green + auto-merge:

1. Create a **fine-grained PAT** (this repo, **Contents: read/write**).
2. Add it as an **Actions** repo secret named **`DEPENDABOT_LOCKFILE_TOKEN`**.

Without it the workflows still commit the refreshed lockfiles via the fallback `GITHUB_TOKEN`; you just nudge CI + merge manually (still no hand relock). Full details + tuning (auto-merge majors too, relock-only, etc.) in **`docs/dependabot-automation.md`**.

## Notes
- master has no required-check branch protection, so auto-merge is gated via a `workflow_run(CI completed success)` job, not native auto-merge.
- **Majors are never auto-merged** — left labelled-less for review; patch/minor groups merge only after the full CI suite (typecheck/lint/unit/build/e2e/scaffolder/hello-world-e2e) passes on the relocked commit.
- `actionlint` clean (syntax + shellcheck).