### PR TITLE
fix: let hosts clear their own rows before a user is deleted

### DIFF
--- a/backend/app/api/admin_users.py
+++ b/backend/app/api/admin_users.py
@@ -25,6 +25,7 @@ from app.auth.manager import UserManager, get_user_manager
 from app.auth.rbac import get_user_permissions, require_perm
 from app.auth.schemas import UserRead
 from app.db import get_session
+from app.host_sdk.user_deletion import run_pre_user_delete_hooks
 from app.logging import log
 from app.models.auth import User, UserInvite
 from app.models.rbac import Role, user_roles
@@ -332,6 +333,9 @@ async def delete_user_permanent(
       - can't delete anyone who issued invites (invited_by has RESTRICT)
 
     Cascades:
+      - host-registered pre-delete hooks run first (a host's own tables
+        may declare restricting FKs into ``users.id``, which the
+        platform cascade below can't clear)
       - notifications: deleted (CASCADE)
       - audit_log.actor_user_id: set null (entries kept, actor anonymised)
     """
@@ -366,5 +370,9 @@ async def delete_user_permanent(
         action="delete",
         diff={"email": target.email},
     )
+    # Let the host clear its own rows first. A hook that raises aborts
+    # the delete — see run_pre_user_delete_hooks for why that's the
+    # right failure mode.
+    await run_pre_user_delete_hooks(session, target.id)
     await session.delete(target)
     await session.commit()

--- a/backend/app/host_sdk/user_deletion.py
+++ b/backend/app/host_sdk/user_deletion.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Pre-delete hooks for the user lifecycle.
+
+Atrium deletes a ``users`` row by handing it to SQLAlchemy and letting
+the database's own ``ON DELETE`` rules fan out. That is sufficient for
+platform-owned tables — ``auth_sessions``, ``notifications`` and
+friends declare ``CASCADE``, ``audit_log.actor_user_id`` declares
+``SET NULL`` so history survives with an anonymous actor.
+
+It is *not* sufficient for a host. A host is free to declare foreign
+keys into ``users.id`` with restricting semantics (and on MySQL an
+omitted ``ON DELETE`` clause **is** ``RESTRICT``), at which point the
+platform's delete aborts with errno 1451 and there is nothing atrium
+can do about it from the inside. Hosts need somewhere to clear their
+own rows first.
+
+That is what this module is: a registry the host writes to during
+``init_app`` / ``init_worker``, drained by atrium immediately before
+the ``users`` row goes. A deployment that registers nothing behaves
+exactly as it did before.
+
+Failures propagate — see :func:`run_pre_user_delete_hooks`.
+"""
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.logging import log
+
+UserDeleteHook = Callable[[AsyncSession, int], Awaitable[None]]
+"""``async (session, user_id) -> None``.
+
+Runs inside the caller's transaction, so a hook must not commit or
+roll back: whatever it deletes lands atomically with the ``users`` row
+itself.
+"""
+
+_hooks: dict[str, UserDeleteHook] = {}
+
+
+def register_pre_user_delete(name: str, hook: UserDeleteHook) -> None:
+    """Register ``hook`` to run before any user row is deleted.
+
+    ``name`` identifies the registrant in logs and dedupes re-entrant
+    registration (a host whose ``init_app`` runs in both the API and
+    worker processes registers the same hook twice by design).
+    Re-registering the same name replaces the previous hook and logs a
+    warning, matching ``HostWorkerCtx.register_job_handler``.
+    """
+    if not name:
+        raise ValueError("register_pre_user_delete: 'name' must be non-empty")
+    if name in _hooks:
+        log.warning("host.pre_user_delete.duplicate", name=name)
+    _hooks[name] = hook
+    log.info("host.pre_user_delete.registered", name=name)
+
+
+def clear_pre_user_delete_hooks() -> None:
+    """Drop every registered hook. For tests."""
+    _hooks.clear()
+
+
+async def run_pre_user_delete_hooks(
+    session: AsyncSession, user_id: int
+) -> list[str]:
+    """Run every registered hook against ``user_id``; return their names.
+
+    **Exceptions are not caught.** This is the deliberate opposite of
+    ``app.jobs.runner.run_one``, where one bad handler must not bring
+    the loop down. Here, a host that cannot clear its rows means the
+    delete has to fail: the alternative is atrium deleting the account
+    while orphan rows survive in host tables, or — where the host's FKs
+    restrict — failing on the ``DELETE FROM users`` anyway, with the
+    operator none the wiser about which subsystem is responsible.
+    Letting the error out rolls the caller's transaction back whole and
+    names the culprit.
+    """
+    ran: list[str] = []
+    for name, hook in list(_hooks.items()):
+        await hook(session, user_id)
+        ran.append(name)
+    if ran:
+        log.info("host.pre_user_delete.ran", user_id=user_id, hooks=ran)
+    return ran
+
+
+__all__ = [
+    "UserDeleteHook",
+    "clear_pre_user_delete_hooks",
+    "register_pre_user_delete",
+    "run_pre_user_delete_hooks",
+]

--- a/backend/app/jobs/builtin_handlers.py
+++ b/backend/app/jobs/builtin_handlers.py
@@ -25,6 +25,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.email.backend import EmailMessage, get_mail_backend
 from app.email.sender import render_template
+from app.host_sdk.user_deletion import run_pre_user_delete_hooks
 from app.jobs.runner import register_handler
 from app.logging import log
 from app.models.auth import User
@@ -218,10 +219,20 @@ async def account_hard_delete_handler(
 
     Soft-deleted users are anonymised the moment they request deletion;
     this handler completes the GDPR pipeline by deleting the row
-    outright once ``scheduled_hard_delete_at`` passes. Cascades fan out
-    via the FK definitions in 0001 (auth_sessions, notifications, etc.
-    are CASCADE; audit_log.actor_user_id is SET NULL so history is
+    outright once ``scheduled_hard_delete_at`` passes. Host-registered
+    pre-delete hooks run first (a host's tables may hold restricting
+    FKs into ``users.id``), then cascades fan out via the FK
+    definitions in 0001 (auth_sessions, notifications, etc. are
+    CASCADE; audit_log.actor_user_id is SET NULL so history is
     preserved with an anonymous actor).
+
+    Each user is deleted inside its own savepoint. One account that
+    can't be erased — a host hook that throws, a schema drift nobody
+    noticed — must not park every *other* pending erasure behind it:
+    this is the GDPR path, and head-of-line blocking here means
+    accounts silently outlive their deadline. A failure rolls back
+    that user alone, is logged at error level with the id, and the
+    next tick retries it.
     """
     del job, payload  # tick-driven, scans the whole table
 
@@ -238,10 +249,30 @@ async def account_hard_delete_handler(
         .scalars()
         .all()
     )
+    deleted = 0
+    failed = 0
     for user in targets:
-        await session.delete(user)
-    if targets:
-        log.info("account.hard_deleted", count=len(targets))
+        user_id = user.id
+        try:
+            async with session.begin_nested():
+                await run_pre_user_delete_hooks(session, user_id)
+                await session.delete(user)
+        except Exception as exc:
+            failed += 1
+            # Loud, and per-user: the previous behaviour was a single
+            # FAILED job row with no indication of which account or
+            # which subsystem refused.
+            log.error(
+                "account.hard_delete_failed",
+                user_id=user_id,
+                error=str(exc),
+            )
+        else:
+            deleted += 1
+    if deleted:
+        log.info("account.hard_deleted", count=deleted)
+    if failed:
+        log.warning("account.hard_delete_incomplete", count=failed)
 
 
 # ----- registration -----

--- a/backend/tests/api/test_account_deletion.py
+++ b/backend/tests/api/test_account_deletion.py
@@ -25,6 +25,10 @@ from sqlalchemy import delete, select
 from sqlalchemy.dialects.mysql import insert as mysql_insert
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
+from app.host_sdk.user_deletion import (
+    clear_pre_user_delete_hooks,
+    register_pre_user_delete,
+)
 from app.jobs.builtin_handlers import account_hard_delete_handler
 from app.models.auth import User
 from app.models.auth_session import AuthSession
@@ -222,3 +226,119 @@ async def test_hard_delete_handler_removes_expired_users(client, engine):
         ).scalar_one_or_none()
     assert gone is None
     assert kept is not None
+
+
+# --------------------------------------------------------------------------- #
+# #223 — host pre-delete hooks on both delete paths                            #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def _clean_hook_registry():
+    """The hook registry is process-global — leaking one would change
+    every later test's delete behaviour."""
+    clear_pre_user_delete_hooks()
+    yield
+    clear_pre_user_delete_hooks()
+
+
+@pytest.mark.asyncio
+async def test_admin_permanent_delete_runs_host_hooks(
+    client, engine, _clean_hook_registry
+):
+    """The host gets to clear its rows before the account goes."""
+    admin = await seed_super_admin(engine)
+    victim = await seed_user(engine, email="victim@example.com")
+    await login(client, admin.email, "super-pw-123", engine=engine)
+
+    seen: list[int] = []
+
+    async def _hook(_session, user_id: int) -> None:
+        seen.append(user_id)
+
+    register_pre_user_delete("test-host", _hook)
+
+    r = await client.delete(f"/admin/users/{victim.id}/permanent")
+    assert r.status_code == 204, r.text
+    assert seen == [victim.id]
+
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as s:
+        gone = (
+            await s.execute(select(User).where(User.id == victim.id))
+        ).scalar_one_or_none()
+    assert gone is None
+
+
+@pytest.mark.asyncio
+async def test_admin_permanent_delete_aborts_when_a_hook_fails(
+    client, engine, _clean_hook_registry
+):
+    """A host that can't clear its rows must not lose the account.
+
+    This is the #223 production failure in miniature: atrium used to
+    delete the users row regardless, hit the host's restricting FK, and
+    500 with nothing naming the responsible subsystem.
+    """
+    admin = await seed_super_admin(engine)
+    victim = await seed_user(engine, email="victim2@example.com")
+    await login(client, admin.email, "super-pw-123", engine=engine)
+
+    async def _boom(_session, _user_id: int) -> None:
+        raise RuntimeError("host rows still present")
+
+    register_pre_user_delete("test-host", _boom)
+
+    with pytest.raises(RuntimeError, match="host rows still present"):
+        await client.delete(f"/admin/users/{victim.id}/permanent")
+
+    # The account survives — a failed cleanup leaves things as they were.
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as s:
+        still_here = (
+            await s.execute(select(User).where(User.id == victim.id))
+        ).scalar_one_or_none()
+    assert still_here is not None
+
+
+@pytest.mark.asyncio
+async def test_hard_delete_isolates_one_failing_account(
+    engine, _clean_hook_registry
+):
+    """One un-erasable account must not park every other erasure.
+
+    Head-of-line blocking on the GDPR path means accounts silently
+    outlive their deadline, so each user gets its own savepoint.
+    """
+    await _wipe_auth_config(engine)
+    poisoned = await seed_user(engine, email="poisoned@example.com")
+    healthy = await seed_user(engine, email="healthy@example.com")
+
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    past = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=1)
+    async with factory() as s:
+        for uid in (poisoned.id, healthy.id):
+            u = await s.get(User, uid)
+            u.deleted_at = past
+            u.scheduled_hard_delete_at = past
+        await s.commit()
+
+    async def _selective_boom(_session, user_id: int) -> None:
+        if user_id == poisoned.id:
+            raise RuntimeError("host rows still present")
+
+    register_pre_user_delete("test-host", _selective_boom)
+
+    async with factory() as s:
+        await account_hard_delete_handler(s, job=None, payload={})  # type: ignore[arg-type]
+        await s.commit()
+
+    async with factory() as s:
+        stuck = (
+            await s.execute(select(User).where(User.id == poisoned.id))
+        ).scalar_one_or_none()
+        erased = (
+            await s.execute(select(User).where(User.id == healthy.id))
+        ).scalar_one_or_none()
+    assert stuck is not None, "the failing account should be retried next tick"
+    assert erased is None, "a healthy account must not be blocked behind it"

--- a/backend/tests/unit/test_pre_user_delete_hooks.py
+++ b/backend/tests/unit/test_pre_user_delete_hooks.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""Coverage for the host pre-user-delete hook registry (#223).
+
+What's pinned:
+
+* A registered hook runs, and receives the id of the user about to go.
+* A hook that raises aborts the delete rather than letting atrium
+  remove the account with the host's rows still behind it.
+* Re-registering a name replaces rather than duplicates, so a host
+  whose ``init_app`` runs in both the API and worker processes doesn't
+  double-sweep.
+* Registering nothing leaves the delete path exactly as it was.
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.host_sdk.user_deletion import (
+    clear_pre_user_delete_hooks,
+    register_pre_user_delete,
+    run_pre_user_delete_hooks,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """The registry is process-global; a leaked hook would leak into
+    every other test in the session."""
+    clear_pre_user_delete_hooks()
+    yield
+    clear_pre_user_delete_hooks()
+
+
+@pytest.mark.asyncio
+async def test_hook_runs_with_the_target_user_id():
+    seen: list[int] = []
+
+    async def _hook(_session: AsyncSession, user_id: int) -> None:
+        seen.append(user_id)
+
+    register_pre_user_delete("pa", _hook)
+    ran = await run_pre_user_delete_hooks(None, 42)  # type: ignore[arg-type]
+
+    assert seen == [42]
+    assert ran == ["pa"]
+
+
+@pytest.mark.asyncio
+async def test_no_hooks_registered_is_a_no_op():
+    assert await run_pre_user_delete_hooks(None, 42) == []  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_a_throwing_hook_propagates():
+    """Deliberately unlike the job runner, which swallows.
+
+    If the host can't clear its rows the delete has to fail: the
+    alternative is deleting the account and orphaning host data, or
+    failing on the DELETE FROM users anyway with no indication of which
+    subsystem is responsible.
+    """
+
+    async def _boom(_session: AsyncSession, _user_id: int) -> None:
+        raise RuntimeError("host cannot clear its rows")
+
+    register_pre_user_delete("pa", _boom)
+
+    with pytest.raises(RuntimeError, match="host cannot clear its rows"):
+        await run_pre_user_delete_hooks(None, 42)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_reregistering_a_name_replaces_it():
+    calls: list[str] = []
+
+    async def _first(_session: AsyncSession, _user_id: int) -> None:
+        calls.append("first")
+
+    async def _second(_session: AsyncSession, _user_id: int) -> None:
+        calls.append("second")
+
+    register_pre_user_delete("pa", _first)
+    register_pre_user_delete("pa", _second)
+    await run_pre_user_delete_hooks(None, 42)  # type: ignore[arg-type]
+
+    assert calls == ["second"]
+
+
+@pytest.mark.asyncio
+async def test_every_registered_hook_runs():
+    calls: list[str] = []
+
+    async def _make(name: str):
+        async def _hook(_session: AsyncSession, _user_id: int) -> None:
+            calls.append(name)
+
+        return _hook
+
+    register_pre_user_delete("pa", await _make("pa"))
+    register_pre_user_delete("other", await _make("other"))
+    ran = await run_pre_user_delete_hooks(None, 42)  # type: ignore[arg-type]
+
+    assert sorted(calls) == ["other", "pa"]
+    assert sorted(ran) == ["other", "pa"]
+
+
+def test_empty_name_is_rejected():
+    async def _hook(_session: AsyncSession, _user_id: int) -> None:
+        return None
+
+    with pytest.raises(ValueError, match="non-empty"):
+        register_pre_user_delete("", _hook)


### PR DESCRIPTION
Closes #223.

## Problem

Deleting a user on a deployment running the atrium-pa host returns a 500:

```
IntegrityError: (1451, 'Cannot delete or update a parent row: a foreign key
constraint fails (`pa_captures`, CONSTRAINT `pa_captures_ibfk_1`
FOREIGN KEY (`owner_user_id`) REFERENCES `users` (`id`))')
```

Both delete paths hand the row to SQLAlchemy and rely on database `ON DELETE` rules. That's correct for platform-owned tables — `auth_sessions` and friends are `CASCADE`, `audit_log.actor_user_id` is `SET NULL`. It is not correct for a host: a host may declare restricting FKs into `users.id`, and on MySQL an *omitted* `ON DELETE` clause **is** `RESTRICT`. Atrium had no way to ask a host to clear up first — the SDK covers routes (`init_app`), worker jobs (`HostWorkerCtx`) and schema (`HostForeignKey`), but nothing in the user lifecycle.

### The worker call site is the worse one

`account_hard_delete_handler` is on the **GDPR path**. A user who self-serve deletes gets anonymised and scheduled; then the job throws on every tick once the grace window elapses. The runner marks the row FAILED and logs `job.failed`, so it fails quietly and forever — the account is never actually erased and nothing surfaces that to an operator.

## Change

`app.host_sdk.user_deletion` — a registry the host writes to during `init_app` / `init_worker`, drained immediately before the `users` row goes. Both call sites now `await run_pre_user_delete_hooks(session, user.id)` inside the existing transaction. A deployment that registers nothing behaves exactly as before.

**Hook exceptions propagate**, deliberately unlike `app.jobs.runner.run_one`. That module's "one bad handler can't bring the loop down" stance is right for jobs and wrong here: if a host can't clear its rows, the correct outcome is the whole delete rolling back with the culprit named — not atrium deleting the account and orphaning host data, or failing on the `DELETE FROM users` anyway with nothing to point at. It reads as inconsistent, so there's a comment at the definition explaining why.

The hard-delete job also gets **a savepoint per user**. One un-erasable account must not park every *other* pending erasure behind it — head-of-line blocking on the GDPR path means accounts silently outlive their deadline. A failure now rolls back that user alone, logs at error level with the id, and the next tick retries.

## Tests

- `tests/unit/test_pre_user_delete_hooks.py` — registry semantics: the hook receives the target id, a thrower propagates, re-registering a name replaces rather than duplicates, an empty registry is a no-op.
- `tests/api/test_account_deletion.py` — both wired call sites against real MySQL: the admin endpoint runs hooks and aborts when one fails, and the hard-delete job erases a healthy account while leaving the failing one for the next tick.

352 backend tests pass; `ruff check .` clean.

## Downstream

atrium-pa registers `atrium_pa` as a hook, guarded by `try/except ImportError` so it still boots against atrium releases predating this.