### PR TITLE
fix(deps): clear the three open supply-chain advisories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,13 @@ updates:
   # /examples/hello-world/frontend opens its own PR even though
   # the same package lives in /frontend.
   #
+  # "/" is the workspace overlay lock (packages/* + the hello-world
+  # example). It has to be listed explicitly: the dependency graph
+  # raises alerts for any lockfile it finds, but Dependabot only
+  # opens security-update PRs for directories declared here, so an
+  # advisory against the root lock would otherwise sit open forever
+  # with nothing to fix it.
+  #
   # Caveat this triggers: on a GROUPED multi-directory update
   # Dependabot bumps the package.json files but leaves both pnpm
   # lockfiles stale, failing `pnpm install --frozen-lockfile`. The
@@ -45,6 +52,7 @@ updates:
   # docs/dependabot-automation.md.
   - package-ecosystem: "npm"
     directories:
+      - "/"
       - "/frontend"
       - "/examples/hello-world/frontend"
     schedule:

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -457,14 +457,11 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.2"
+version = "8.5.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+    { url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z" },
 ]
 
 [[package]]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-i18next": "^17.0.8",
-    "react-router-dom": "^7.18.0"
+    "react-router-dom": "^7.18.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
@@ -71,7 +71,8 @@
       "undici": "^7.29.0",
       "form-data": "^4.0.6",
       "@babel/core": "^7.29.6",
-      "postcss": "^8.5.23",
+      "postcss": "^8.5.26",
+      "nanoid": "^3.3.18",
       "brace-expansion": "^5.0.8"
     }
   },

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,7 +8,8 @@ overrides:
   undici: ^7.29.0
   form-data: ^4.0.6
   '@babel/core': ^7.29.6
-  postcss: ^8.5.23
+  postcss: ^8.5.26
+  nanoid: ^3.3.18
   brace-expansion: ^5.0.8
 
 importers:
@@ -82,8 +83,8 @@ importers:
         specifier: ^17.0.8
         version: 17.0.8(i18next@26.3.1(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       react-router-dom:
-        specifier: ^7.18.0
-        version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^7.18.3
+        version: 7.18.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -117,7 +118,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(sugarss@5.0.1(postcss@8.5.23)))
+        version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(sugarss@5.0.1(postcss@8.5.26)))
       eslint:
         specifier: ^10.5.0
         version: 10.5.0
@@ -137,14 +138,14 @@ importers:
         specifier: ^13.4.1
         version: 13.4.1
       postcss:
-        specifier: ^8.5.23
-        version: 8.5.23
+        specifier: ^8.5.26
+        version: 8.5.26
       postcss-preset-mantine:
         specifier: ^1.18.0
-        version: 1.18.0(postcss@8.5.23)
+        version: 1.18.0(postcss@8.5.26)
       postcss-simple-vars:
         specifier: ^7.0.1
-        version: 7.0.1(postcss@8.5.23)
+        version: 7.0.1(postcss@8.5.26)
       prettier:
         specifier: ^3.8.4
         version: 3.8.4
@@ -156,10 +157,10 @@ importers:
         version: 8.61.1(eslint@10.5.0)(typescript@6.0.3)
       vite:
         specifier: ^8.0.14
-        version: 8.0.16(@types/node@26.0.0)(sugarss@5.0.1(postcss@8.5.23))
+        version: 8.0.16(@types/node@26.0.0)(sugarss@5.0.1(postcss@8.5.26))
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@types/node@26.0.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.0.0)(sugarss@5.0.1(postcss@8.5.23)))
+        version: 4.1.9(@types/node@26.0.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.0.0)(sugarss@5.0.1(postcss@8.5.26)))
 
 packages:
 
@@ -1588,8 +1589,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1675,24 +1676,24 @@ packages:
     resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
-      postcss: ^8.5.23
+      postcss: ^8.5.26
 
   postcss-mixins@12.1.2:
     resolution: {integrity: sha512-90pSxmZVfbX9e5xCv7tI5RV1mnjdf16y89CJKbf/hD7GyOz1FCxcYMl8ZYA8Hc56dbApTKKmU9HfvgfWdCxlwg==}
     engines: {node: ^20.0 || ^22.0 || >=24.0}
     peerDependencies:
-      postcss: ^8.5.23
+      postcss: ^8.5.26
 
   postcss-nested@7.0.2:
     resolution: {integrity: sha512-5osppouFc0VR9/VYzYxO03VaDa3e8F23Kfd6/9qcZTUI8P58GIYlArOET2Wq0ywSl2o2PjELhYOFI4W7l5QHKw==}
     engines: {node: '>=18.0'}
     peerDependencies:
-      postcss: ^8.5.23
+      postcss: ^8.5.26
 
   postcss-preset-mantine@1.18.0:
     resolution: {integrity: sha512-sP6/s1oC7cOtBdl4mw/IRKmKvYTuzpRrH/vT6v9enMU/EQEQ31eQnHcWtFghOXLH87AAthjL/Q75rLmin1oZoA==}
     peerDependencies:
-      postcss: ^8.5.23
+      postcss: ^8.5.26
 
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
@@ -1702,10 +1703,10 @@ packages:
     resolution: {integrity: sha512-5GLLXaS8qmzHMOjVxqkk1TZPf1jMqesiI7qLhnlyERalG0sMbHIbJqrcnrpmZdKCLglHnRHoEBB61RtGTsj++A==}
     engines: {node: '>=14.0'}
     peerDependencies:
-      postcss: ^8.5.23
+      postcss: ^8.5.26
 
-  postcss@8.5.23:
-    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -1829,15 +1830,15 @@ packages:
       '@types/react':
         optional: true
 
-  react-router-dom@7.18.0:
-    resolution: {integrity: sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==}
+  react-router-dom@7.18.3:
+    resolution: {integrity: sha512-ytVbyBBM7vMfRCam25r0WMhSVSom909A8p+8m0/f1w853dz/xfFu6etAT2SEbVoSnI+ZoPRDqIsQXVT89gp7kg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
 
-  react-router@7.18.0:
-    resolution: {integrity: sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==}
+  react-router@7.18.3:
+    resolution: {integrity: sha512-gyXgtdr5uACJ5b1Q4udzjVV+tb/rlHIMJKuJ0e89R4Kzgz47z/rgP0dIKxktqIEUhDHluGTPJJH/wRha7CyqsA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -1948,7 +1949,7 @@ packages:
     resolution: {integrity: sha512-ctS5RYCBVvPoZAnzIaX5QSShK8ZiZxD5HUqSxlusvEMC+QZQIPCPOIJg6aceFX+K2rf4+SH89eu++h1Zmsr2nw==}
     engines: {node: '>=18.0'}
     peerDependencies:
-      postcss: ^8.5.23
+      postcss: ^8.5.26
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -3024,10 +3025,10 @@ snapshots:
       '@typescript-eslint/types': 8.61.1
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@26.0.0)(sugarss@5.0.1(postcss@8.5.23)))':
+  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@26.0.0)(sugarss@5.0.1(postcss@8.5.26)))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0
-      vite: 8.0.16(@types/node@26.0.0)(sugarss@5.0.1(postcss@8.5.23))
+      vite: 8.0.16(@types/node@26.0.0)(sugarss@5.0.1(postcss@8.5.26))
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -3038,13 +3039,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.9(vite@8.0.16(@types/node@26.0.0)(sugarss@5.0.1(postcss@8.5.23)))':
+  '@vitest/mocker@4.1.9(vite@8.0.16(@types/node@26.0.0)(sugarss@5.0.1(postcss@8.5.26)))':
     dependencies:
       '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@26.0.0)(sugarss@5.0.1(postcss@8.5.23))
+      vite: 8.0.16(@types/node@26.0.0)(sugarss@5.0.1(postcss@8.5.26))
 
   '@vitest/pretty-format@4.1.9':
     dependencies:
@@ -3631,7 +3632,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -3703,42 +3704,42 @@ snapshots:
 
   pngjs@5.0.0: {}
 
-  postcss-js@4.1.0(postcss@8.5.23):
+  postcss-js@4.1.0(postcss@8.5.26):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.23
+      postcss: 8.5.26
 
-  postcss-mixins@12.1.2(postcss@8.5.23):
+  postcss-mixins@12.1.2(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.23
-      postcss-js: 4.1.0(postcss@8.5.23)
-      postcss-simple-vars: 7.0.1(postcss@8.5.23)
-      sugarss: 5.0.1(postcss@8.5.23)
+      postcss: 8.5.26
+      postcss-js: 4.1.0(postcss@8.5.26)
+      postcss-simple-vars: 7.0.1(postcss@8.5.26)
+      sugarss: 5.0.1(postcss@8.5.26)
       tinyglobby: 0.2.16
 
-  postcss-nested@7.0.2(postcss@8.5.23):
+  postcss-nested@7.0.2(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.23
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.1
 
-  postcss-preset-mantine@1.18.0(postcss@8.5.23):
+  postcss-preset-mantine@1.18.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.23
-      postcss-mixins: 12.1.2(postcss@8.5.23)
-      postcss-nested: 7.0.2(postcss@8.5.23)
+      postcss: 8.5.26
+      postcss-mixins: 12.1.2(postcss@8.5.26)
+      postcss-nested: 7.0.2(postcss@8.5.26)
 
   postcss-selector-parser@7.1.1:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-simple-vars@7.0.1(postcss@8.5.23):
+  postcss-simple-vars@7.0.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.23
+      postcss: 8.5.26
 
-  postcss@8.5.23:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -3886,13 +3887,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
-  react-router-dom@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-router-dom@7.18.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      react-router: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-router: 7.18.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
-  react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-router@7.18.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       cookie: 1.1.1
       react: 19.2.7
@@ -3995,9 +3996,9 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
-  sugarss@5.0.1(postcss@8.5.23):
+  sugarss@5.0.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.23
+      postcss: 8.5.26
 
   symbol-tree@3.2.4: {}
 
@@ -4097,22 +4098,22 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite@8.0.16(@types/node@26.0.0)(sugarss@5.0.1(postcss@8.5.23)):
+  vite@8.0.16(@types/node@26.0.0)(sugarss@5.0.1(postcss@8.5.26)):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.23
+      postcss: 8.5.26
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 26.0.0
       fsevents: 2.3.3
-      sugarss: 5.0.1(postcss@8.5.23)
+      sugarss: 5.0.1(postcss@8.5.26)
 
-  vitest@4.1.9(@types/node@26.0.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.0.0)(sugarss@5.0.1(postcss@8.5.23))):
+  vitest@4.1.9(@types/node@26.0.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.0.0)(sugarss@5.0.1(postcss@8.5.26))):
     dependencies:
       '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@26.0.0)(sugarss@5.0.1(postcss@8.5.23)))
+      '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@26.0.0)(sugarss@5.0.1(postcss@8.5.26)))
       '@vitest/pretty-format': 4.1.9
       '@vitest/runner': 4.1.9
       '@vitest/snapshot': 4.1.9
@@ -4129,7 +4130,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@26.0.0)(sugarss@5.0.1(postcss@8.5.23))
+      vite: 8.0.16(@types/node@26.0.0)(sugarss@5.0.1(postcss@8.5.26))
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.0.0

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "pnpm": {
     "overrides": {
       "undici": "^7.29.0",
-      "postcss": "^8.5.23"
+      "postcss": "^8.5.26",
+      "nanoid": "^3.3.18"
     }
   },
   "packageManager": "pnpm@10.33.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,8 @@ settings:
 
 overrides:
   undici: ^7.29.0
-  postcss: ^8.5.23
+  postcss: ^8.5.26
+  nanoid: ^3.3.18
 
 importers:
 
@@ -961,8 +962,8 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1001,8 +1002,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  postcss@8.5.23:
-    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   pretty-format@27.5.1:
@@ -2142,7 +2143,7 @@ snapshots:
 
   mute-stream@3.0.0: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   obug@2.1.1: {}
 
@@ -2177,9 +2178,9 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  postcss@8.5.23:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -2391,7 +2392,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.23
+      postcss: 8.5.26
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
Clears everything currently outstanding across the two Dependabot alerts and the informational `pip-audit` job in the Security workflow. **Code scanning (CodeQL + Trivy) had zero open alerts** — nothing to do there.

None of the three were exploitable in atrium; all three are patch-level fixes.

## Advisories

| Package | From → To | Advisory | Sev | Why it isn't exploitable here |
|---|---|---|---|---|
| `nanoid` | 3.3.16 → 3.3.18 | [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) / CVE-2026-67213 | high (5.9) | Transitive via postcss; a custom generator called with `size: 0` loops forever. Nothing in atrium calls nanoid directly. |
| `react-router` | 7.18.0 → 7.18.3 | [GHSA-qwww-vcr4-c8h2](https://github.com/advisories/GHSA-qwww-vcr4-c8h2) | high | CSRF bypass **specific to RSC mode**. The SPA is a plain `BrowserRouter` — no `@vitejs/plugin-rsc`, no `routeRSCServerRequest` — so the vulnerable path doesn't exist. |
| `click` | 8.3.2 → 8.5.0 | CVE-2026-7246 / PYSEC-2026-2132 | local, high-priv | Command injection in `click.edit()`, which atrium never calls. Transitive via uvicorn. |

`nanoid` is pinned through the existing `pnpm.overrides` block in both the root workspace and the standalone SPA, matching how `undici` / `form-data` / `brace-expansion` were handled. `postcss` goes to 8.5.26 alongside it (8.5.26 already requires `nanoid ^3.3.17`).

## Two gaps this also closes

**The click CVE was invisible in the Security tab.** The `pip-audit` job runs with `|| true` and uploads no SARIF, so the finding only ever existed as a line in the job log. Dependabot never raised it. Worth deciding separately whether that job should upload SARIF or fail the build — not changed here.

**Dependabot could never have fixed the nanoid alert.** The `npm` block in `.github/dependabot.yml` listed `/frontend` and `/examples/hello-world/frontend`, but not the repo root. The dependency graph raises alerts for every lockfile it finds, but Dependabot only opens security-update PRs for directories declared in the config — so the alert against the root workspace lock would have sat open indefinitely with nothing to fix it, while its `frontend/` twin was auto-dismissed as dev-only. This PR declares `"/"` in that block, with a comment explaining why.

## Verification

- `pnpm audit --audit-level high` in `frontend/`: **No known vulnerabilities found** (was 1 high)
- `pip-audit --strict` in `backend/`: **No known vulnerabilities found** (was 1)
- `frontend`: `tsc -b --noEmit` clean, 122 vitest tests across 14 files pass
- Root workspace: `pnpm build` + `pnpm typecheck` clean across all 4 host SDK packages and the hello-world example
- `pnpm install --frozen-lockfile` passes in both projects (root and `--ignore-workspace` SPA)
- click 8.5.0 drops its `colorama` dependency; verified `uvicorn`'s click CLI still constructs and `app.main` imports

Lockfile diffs are minimal and targeted — only the named packages plus their peer-suffix churn.

## Not addressed

- Secret scanning is **disabled** on the repo (Trivy's `secret` scanner gives partial fs coverage, but there's no push protection).
- Trivy runs with `ignore-unfixed: true` and `severity: HIGH,CRITICAL`, so MEDIUM/LOW and unfixed HIGHs never reach the Security tab. Deliberate noise trade-off, just noting the "0 open" is scoped.
- The hello-world example's vitest suite fails locally on Node 25 with a duplicate-React error (`react@19.2.7` vs `react-dom@19.2.6` in the root lock). This reproduces identically on unmodified master and passes on CI's Node 22 — pre-existing, unrelated to this change.