### PR TITLE
ci(security): gate the weekly scan on pip-audit findings

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,7 +5,7 @@ name: Security
 
 # Three supply-chain scans on a single workflow:
 #   - Trivy fs + image scan of the runtime image (SARIF -> Security tab)
-#   - pip-audit of the backend deps (informational)
+#   - pip-audit of the backend deps (advisory on PRs, gating weekly)
 #   - pnpm audit of the SPA deps (informational)
 #
 # Triggered on PRs and pushes to master, plus a weekly cron so a fresh
@@ -139,12 +139,35 @@ jobs:
       - name: Sync deps
         run: uv sync
 
-      # Non-blocking: Dependabot already proposes the fix, the audit
-      # is informational. Reports surface in the job log; SARIF
-      # upload would need a separate format conversion, not worth it
-      # while pip-audit is run as a backstop to Dependabot.
+      # Advisory on PRs and master pushes, GATING on the weekly cron.
+      #
+      # pip-audit is not just a Dependabot backstop for Python: it
+      # reads the PyPA/OSV database, which carries PYSEC advisories
+      # that never become GitHub advisories at all, so Dependabot
+      # structurally cannot raise them. CVE-2026-7246 in `click` was
+      # one of those -- no GHSA, no Dependabot alert -- and because
+      # this step could not fail it sat unnoticed in the job log
+      # until someone happened to read it.
+      #
+      # Failing on PRs instead would hold every unrelated PR hostage
+      # to an advisory with no released fix upstream (pip-audit has
+      # no --ignore-unfixed). Failing on the cron puts the signal on
+      # the one run nobody is watching, without blocking anyone: a
+      # red weekly Security run IS the notification.
+      #
+      # Uploading to the Security tab is the obvious alternative but
+      # pip-audit emits only columns/json/cyclonedx/markdown -- no
+      # SARIF -- so it would need a bespoke converter to maintain.
       - name: Run pip-audit
-        run: uv run --with pip-audit pip-audit --strict --progress-spinner off || true
+        id: pip_audit
+        continue-on-error: true
+        run: uv run --with pip-audit pip-audit --strict --progress-spinner off
+
+      - name: Gate the weekly scan on pip-audit findings
+        if: github.event_name == 'schedule' && steps.pip_audit.outcome == 'failure'
+        run: |
+          echo "::error::pip-audit reported vulnerabilities on the weekly scan - see the 'Run pip-audit' step above"
+          exit 1
 
   pnpm-audit:
     name: pnpm audit (SPA deps)
@@ -168,6 +191,10 @@ jobs:
       - name: Install deps
         run: pnpm install --frozen-lockfile
 
-      # Non-blocking, see pip-audit comment above.
+      # Non-blocking on every trigger, deliberately unlike pip-audit
+      # above. npm's advisory source of truth IS the GitHub advisory
+      # database, so anything pnpm audit finds here Dependabot has
+      # already alerted on and opened a PR for. Kept as a cheap
+      # second opinion, not as a gate.
       - name: Run pnpm audit
         run: pnpm audit --audit-level high || true


### PR DESCRIPTION
Follow-up to #233, which fixed a `click` CVE that had been sitting unnoticed in a job log. This makes that class of finding impossible to miss again.

## The problem

The `pip-audit` step ran with `|| true` and uploads no SARIF, so its findings reached **neither** the Security tab **nor** a failing check. They existed only as lines inside a job log.

That is not a redundant signal. `pip-audit` reads the PyPA/OSV database; Dependabot alerts are built entirely from GitHub's advisory database. PYSEC advisories that never become GitHub advisories are therefore invisible to Dependabot by construction. CVE-2026-7246 in `click` was exactly that case:

```
gh api /advisories/GHSA-47fr-3ffg-hgmw     → 404
gh api "/advisories?cve_id=CVE-2026-7246"  → empty
```

No GHSA → no Dependabot alert → the only place it ever surfaced was a log line nothing acted on.

## The change

`pip-audit` stays **advisory on `pull_request` / `push`**, but **gates the weekly cron**:

- `|| true` → `continue-on-error: true`. Same non-blocking behaviour, but the real result is preserved in `steps.pip_audit.outcome` instead of being swallowed by the shell.
- A follow-up step fails the job when that outcome is `failure` **and** `github.event_name == 'schedule'`.

`pnpm audit` is deliberately left non-blocking on every trigger. npm's advisory source of truth *is* the GitHub advisory database, so anything it finds Dependabot has already alerted on and opened a PR for — a gate there would only duplicate work already in flight. The comment now says so rather than pointing at the pip-audit comment.

## Alternatives rejected

**Fail on PRs too.** `pip-audit` has no `--ignore-unfixed`, so one advisory with no released fix upstream would wedge every unrelated PR until someone patched it. The cron run is the one nobody watches, which makes it the right place for a signal that shouldn't block anyone — a red weekly Security run *is* the notification.

**Upload SARIF.** `pip-audit` emits only `columns / json / cyclonedx-json / cyclonedx-xml / markdown` — no SARIF — so this needs a bespoke converter to build and maintain. Not worth it for one job. (This is why the original comment said as much; it was right.)

## Verification

The gate was tested end-to-end, not just by inspection. On a throwaway branch off master (which still carries the vulnerable `click` 8.3.2) with the condition temporarily flipped to `workflow_dispatch`, [run 33366541393](https://github.com/brendanbank/atrium/actions/runs/33366541393):

```
JOB: pip-audit (backend deps) -> failure
    Run pip-audit: success                              <- masked by continue-on-error
    Gate the weekly scan on pip-audit findings: failure <- read the true outcome, failed the job
##[error]pip-audit reported vulnerabilities on the weekly scan - see the 'Run pip-audit' step above
```

That confirms both halves: `continue-on-error` keeps the job green for the advisory path, and `steps.pip_audit.outcome` still reports the real failure for the gate to act on. The throwaway branch has been deleted.

`actionlint` is clean on the workflow.

Note this PR's own CI exercises the advisory path for real — it branches from master, so `pip-audit` will find the `click` CVE, and the job should still pass. Once #233 merges, both go quiet.

## Related

Secret scanning is now **enabled** on the repo (it's public, so it's free). Push protection was left **off** at your request.