### PR TITLE
ci: run the root workspace suite and guard against duplicate deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,60 @@ jobs:
       - name: Build
         run: pnpm build
 
+  # The repo-root workspace: `packages/*` (the published host SDK) +
+  # `examples/hello-world/frontend`. The `frontend` job above cannot
+  # cover these -- it runs with `--ignore-workspace` so it sees only
+  # atrium's SPA -- so without this job nothing ran root `pnpm test`
+  # and 69 tests were unguarded. A duplicate React reached master
+  # that way and broke every hello-world test (#236).
+  #
+  # `pnpm build` has to come first: `dist/` is not committed, and both
+  # the typecheck and the example's vitest run resolve
+  # `@brendanbank/atrium-*` through each package's published
+  # `exports`, which point at `dist/`.
+  host-sdk:
+    name: host-sdk (workspace packages + example)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86  # v6.0.10
+        with:
+          version: 10.33.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install workspace deps
+        run: pnpm install --frozen-lockfile
+
+      # Guards the class of bug that #236 fixed. `packages/*` carry
+      # react/react-dom as devDependencies for their own builds while
+      # the example carries its own copies, so a grouped Dependabot
+      # bump that moves one manifest and not the other leaves two
+      # instances of a package that must be a singleton. React and
+      # @tanstack/react-query both fail this way, and both failures
+      # are confusing at the point of use rather than at install.
+      #
+      # Note `resolve.dedupe` in the example's vitest config does NOT
+      # substitute for this -- it was tried in #236 and the suite
+      # still failed, because Vite's dedupe does not reach across the
+      # workspace link into a package's built `dist/`.
+      - name: Check for duplicate workspace dependencies
+        run: pnpm dedupe --check
+
+      - name: Build
+        run: pnpm build
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Unit tests
+        run: pnpm test
+
   scaffolder:
     # Smoke-test the create-atrium-host scaffolder. Two passes:
     #   1. Unit tests via Node's built-in runner — covers the


### PR DESCRIPTION
Follow-up to #236. That PR fixed a duplicate React that broke every hello-world test; this one makes sure the same thing can't reach master unnoticed again.

## The gap

**Nothing in CI ran root `pnpm test`:**

| job | what it actually covers |
|---|---|
| `frontend` | runs with `--ignore-workspace` → atrium's SPA only |
| `hello-world-e2e` | Playwright, not vitest |
| `scaffolder` | installs the workspace, but only runs `packages/create-atrium-host`'s node tests |

So **69 tests were unguarded** — 49 in `host-bundle-utils`, 18 in `test-utils`, 2 in the hello-world example. Not theoretical: a duplicate React reached master through exactly this gap and broke every hello-world test until #236, and it was only caught because the suite got run by hand.

## The job

A `host-sdk` job covering the repo-root workspace:

```
pnpm install --frozen-lockfile
pnpm dedupe --check      # recurrence guard
pnpm build               # must precede the next two
pnpm typecheck
pnpm test
```

`pnpm build` has to run first because `dist/` isn't committed, and both the typecheck and the example's vitest run resolve `@brendanbank/atrium-*` through each package's `exports`, which point at `dist/`.

## Why `dedupe --check` and not a config guard

It's the recurrence guard, not a tidiness pass. `packages/*` carry react/react-dom as devDependencies for their own builds while the example carries its own, so a grouped Dependabot bump that moves one manifest and not the other leaves two instances of something that has to be a singleton. It exits `1` on the pre-#236 lockfile and `0` on the current one, and it catches the whole class — the 0.26.0 notes record `@tanstack/react-query` failing the same way, and the #236 dedupe also collapsed duplicate `jsdom`, `vitest` and `tinyglobby`.

Worth recording the negative result from #236: **`resolve.dedupe` in the example's vitest config does not substitute for this.** It was tried against the duplicated lockfile and the suite still failed — Vite's dedupe doesn't reach across the workspace link into a package's built `dist/`.

## Verification

Ran the job's exact sequence locally from a clean tree (`node_modules` and `packages/*/dist` removed):

```
install: ok
dedupe --check: ok
build: ok
typecheck: ok
host-bundle-utils  49 passed
test-utils         18 passed
hello-world         2 passed
```

`actionlint` reports no new findings — the two `SC2034` warnings it prints are pre-existing on master (confirmed by running it against master's copy of the file).

## Note

The job runs unconditionally, matching `backend-*` and `frontend`. It isn't wired into the `changes` path filter, which currently only gates `hello-world-e2e`. If you want it added to branch protection as a required check, that's a repo setting rather than a file change.