### PR TITLE
Ship the host atrium-bump watcher as a reusable action

### DIFF
--- a/.github/actions/host-atrium-bump/action.yml
+++ b/.github/actions/host-atrium-bump/action.yml
@@ -1,0 +1,352 @@
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: Host atrium bump
+description: >-
+  Poll atrium for a new release and open a lockstep version-bump PR in a
+  host repo — image tag and the version-locked host SDK packages together.
+
+# Poll, not push. Atrium holds no credential for any host repo and fires
+# nothing at them: each host reaches out on its own schedule over the
+# public API. Adding a host costs atrium nothing and grants it nothing,
+# which is why this is an action a host calls rather than a dispatch
+# atrium sends.
+#
+# The caller is expected to have checked out the host repo with the same
+# token passed here (so the push is authenticated) and to have set up its
+# own package manager — the lockfile must be regenerated with the version
+# the host's own CI uses, or the relock churns.
+
+inputs:
+  token:
+    description: >-
+      Token used to push the branch and open the PR. Must be a PAT or app
+      token, NOT GITHUB_TOKEN: a PR opened by GITHUB_TOKEN does not
+      trigger `pull_request` workflows, so the host's CI would never
+      exercise the new image. Needs contents:write, pull-requests:write,
+      and workflows:write if any pinned file lives under .github/workflows.
+    required: true
+  version:
+    description: "Version to adopt (e.g. 0.29.0). Blank = atrium's latest release."
+    required: false
+    default: ""
+  atrium-repo:
+    description: "Repository to read releases from."
+    required: false
+    default: brendanbank/atrium
+  image:
+    description: "Image repository, without a tag."
+    required: false
+    default: ghcr.io/brendanbank/atrium
+  canonical-file:
+    description: "File the currently-pinned version is read from."
+    required: false
+    default: .env.example
+  pin-files:
+    description: >-
+      Newline-separated files containing the image tag. All are rewritten
+      together; the bump refuses if any disagrees with canonical-file.
+    required: false
+    default: |
+      .env.example
+      Dockerfile
+      compose.yaml
+  npm-packages:
+    description: >-
+      Newline-separated npm packages version-locked to the image tag.
+      Empty disables the npm half entirely.
+    required: false
+    default: |
+      @brendanbank/atrium-host-bundle-utils
+      @brendanbank/atrium-host-types
+  frontend-dir:
+    description: "Directory holding package.json and the lockfile."
+    required: false
+    default: frontend
+  package-manager:
+    description: "pnpm or npm."
+    required: false
+    default: pnpm
+  base-branch:
+    description: "Branch the PR targets."
+    required: false
+    default: main
+  branch-prefix:
+    description: "Prefix for the bump branch; the version is appended."
+    required: false
+    default: atrium-bump/
+
+outputs:
+  bumped:
+    description: "true when a PR was opened."
+    value: ${{ steps.pr.outputs.bumped }}
+  from:
+    description: "Version that was pinned before."
+    value: ${{ steps.gate.outputs.current }}
+  to:
+    description: "Version adopted."
+    value: ${{ steps.gate.outputs.target }}
+  pull-request-url:
+    description: "URL of the PR, empty when nothing was opened."
+    value: ${{ steps.pr.outputs.url }}
+
+runs:
+  using: composite
+  steps:
+    - name: Compare the pin against the latest release
+      id: gate
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        ATRIUM_REPO: ${{ inputs.atrium-repo }}
+        IMAGE: ${{ inputs.image }}
+        CANONICAL: ${{ inputs.canonical-file }}
+        BRANCH_PREFIX: ${{ inputs.branch-prefix }}
+        INPUT_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+
+        if [ -n "${INPUT_VERSION:-}" ]; then
+          target="${INPUT_VERSION#v}"
+          forced=yes
+        else
+          target="$(gh release view --repo "$ATRIUM_REPO" --json tagName --jq .tagName)"
+          target="${target#v}"
+          forced=no
+        fi
+
+        if ! printf '%s' "$target" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+          echo "::error::'$target' does not look like an atrium version (X.Y.Z)"
+          exit 1
+        fi
+
+        current="$(grep -oE "${IMAGE}:[0-9]+\.[0-9]+\.[0-9]+" "$CANONICAL" | head -n1 | sed 's/.*://')"
+        if [ -z "$current" ]; then
+          echo "::error::no '$IMAGE:X.Y.Z' pin found in $CANONICAL"
+          exit 1
+        fi
+
+        echo "current=$current" >> "$GITHUB_OUTPUT"
+        echo "target=$target"   >> "$GITHUB_OUTPUT"
+        echo "pinned: $current   upstream: $target"
+
+        if [ "$current" = "$target" ]; then
+          echo "::notice::already on atrium $current"
+          echo "candidate=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Never walk backwards on a schedule: a deleted or re-cut tag
+        # upstream must not silently downgrade a host. A human can still
+        # force one by passing `version`.
+        newest="$(printf '%s\n%s\n' "$current" "$target" | sort -V | tail -n1)"
+        if [ "$newest" != "$target" ] && [ "$forced" != yes ]; then
+          echo "::warning::latest release $target is older than the pin $current — ignoring"
+          echo "candidate=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        branch="${BRANCH_PREFIX}${target}"
+        echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+        # Idempotence for a daily cron: don't reopen work in flight, and
+        # don't resurrect a bump that was reviewed and closed on purpose.
+        # Both lookups distinguish "no" from "could not tell" — a command
+        # substitution inside `[ ... ]` hides its exit status from set -e,
+        # so an API failure would otherwise read as a confident answer.
+        set +e
+        git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1
+        rc=$?
+        set -e
+        case "$rc" in
+          0)
+            echo "::notice::$branch already exists — bump is in flight"
+            echo "candidate=false" >> "$GITHUB_OUTPUT"
+            exit 0
+            ;;
+          2) ;;
+          *)
+            echo "::error::git ls-remote failed (exit $rc) — cannot tell whether $branch exists"
+            exit 1
+            ;;
+        esac
+
+        if ! prs="$(gh pr list --head "$branch" --state all --json number --jq 'length')"; then
+          echo "::error::gh pr list failed — cannot tell whether a PR for $branch exists"
+          exit 1
+        fi
+        if [ "$prs" != "0" ]; then
+          echo "::notice::a PR for $branch already exists — nothing to do"
+          echo "candidate=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "candidate=true" >> "$GITHUB_OUTPUT"
+
+    # A `v*` tag fires atrium's publish-images.yml and publish-npm.yml,
+    # which take minutes. A daily poll can land inside that window and
+    # see a release whose artifacts do not exist yet. That is not a
+    # failure — the bump is simply not ready.
+    - name: Confirm the release artifacts are published
+      id: published
+      if: steps.gate.outputs.candidate == 'true'
+      shell: bash
+      env:
+        IMAGE: ${{ inputs.image }}
+        NPM_PACKAGES: ${{ inputs.npm-packages }}
+        TARGET: ${{ steps.gate.outputs.target }}
+      run: |
+        set -euo pipefail
+        missing=""
+
+        # Anonymous registry pull-token rather than `docker pull` or a
+        # login: the manifest HEAD is enough to know the tag exists, and
+        # it keeps this action free of any registry credential.
+        repo_path="${IMAGE#*/}"
+        registry="${IMAGE%%/*}"
+        reg_token="$(curl -fsS "https://${registry}/token?scope=repository:${repo_path}:pull" \
+          | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])')"
+        code="$(curl -s -o /dev/null -w '%{http_code}' \
+          -H "Authorization: Bearer ${reg_token}" \
+          -H "Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json" \
+          "https://${registry}/v2/${repo_path}/manifests/${TARGET}")"
+        [ "$code" = "200" ] || missing="the image (HTTP $code)"
+
+        probe="$(printf '%s\n' "$NPM_PACKAGES" | grep -v '^[[:space:]]*$' | head -n1 | tr -d '[:space:]')"
+        if [ -n "$probe" ]; then
+          npm view "${probe}@${TARGET}" version >/dev/null 2>&1 \
+            || missing="${missing:+$missing and }the npm packages"
+        fi
+
+        if [ -n "$missing" ]; then
+          echo "::notice::atrium $TARGET is tagged but $missing not published yet — retrying next run"
+          echo "go=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        echo "go=true" >> "$GITHUB_OUTPUT"
+
+    - name: Apply the lockstep bump
+      if: steps.published.outputs.go == 'true'
+      shell: bash
+      env:
+        ATRIUM_IMAGE: ${{ inputs.image }}
+        PIN_CANONICAL: ${{ inputs.canonical-file }}
+        PIN_FILES: ${{ inputs.pin-files }}
+        NPM_PACKAGES: ${{ inputs.npm-packages }}
+        FRONTEND_DIR: ${{ inputs.frontend-dir }}
+        PKG_MANAGER: ${{ inputs.package-manager }}
+        TARGET: ${{ steps.gate.outputs.target }}
+      run: |
+        "${{ github.action_path }}/bump.sh" "$TARGET" --ci
+
+    - name: Commit, push, and open the PR
+      id: pr
+      if: steps.published.outputs.go == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        ATRIUM_REPO: ${{ inputs.atrium-repo }}
+        IMAGE: ${{ inputs.image }}
+        BASE: ${{ inputs.base-branch }}
+        BRANCH: ${{ steps.gate.outputs.branch }}
+        CURRENT: ${{ steps.gate.outputs.current }}
+        TARGET: ${{ steps.gate.outputs.target }}
+      run: |
+        set -euo pipefail
+
+        if git diff --quiet; then
+          echo "::error::bump.sh reported success but changed nothing"
+          exit 1
+        fi
+
+        gh release view "v$TARGET" --repo "$ATRIUM_REPO" --json name --jq .name \
+          > "$RUNNER_TEMP/release-name"
+        gh release view "v$TARGET" --repo "$ATRIUM_REPO" --json body --jq .body \
+          > "$RUNNER_TEMP/release-notes.md"
+
+        # Release names read "v0.28.0 — secrets that belong to one person";
+        # keep the headline, drop the version we already have.
+        headline="$(sed -E "s/^v?${TARGET}[[:space:]]*[-—][[:space:]]*//" "$RUNNER_TEMP/release-name" | head -c 120)"
+        if [ -n "$headline" ]; then
+          subject="Adopt atrium $TARGET — $headline"
+        else
+          subject="Adopt atrium $TARGET"
+        fi
+
+        # Quoted heredocs with @PLACEHOLDER@ substituted afterwards:
+        # upstream release text is untrusted input and must never reach
+        # the shell as code.
+        printf '%s\n\n' "$subject" > "$RUNNER_TEMP/commit-msg"
+        cat >> "$RUNNER_TEMP/commit-msg" <<'EOF'
+        Automated lockstep bump opened by the host-atrium-bump action.
+
+        Image tag @CURRENT@ -> @TARGET@ across the pinned files, the
+        version-locked host SDK packages with it, and the frontend
+        lockfile regenerated.
+
+        Release notes: https://github.com/@ATRIUM_REPO@/releases/tag/v@TARGET@
+
+        Migrations, breaking registry changes and new required env vars are
+        not checked by the bump — the release notes still need a human.
+        EOF
+
+        cat > "$RUNNER_TEMP/pr-body.md" <<'EOF'
+        The atrium watcher found **atrium @TARGET@** upstream and applied the
+        lockstep bump.
+
+        Pin: `@CURRENT@` → `@TARGET@`, with the version-locked
+        `@brendanbank/atrium-host-*` packages and the lockfile moved with it.
+        The image tag and the SDK packages are not independently upgradable —
+        a host running image X with SDK packages from Y fails at runtime, when
+        the served bundle calls endpoints the image does not serve.
+
+        CI on this PR builds against `@IMAGE@:@TARGET@`, so the new image is
+        exercised here before you merge.
+
+        ### Nothing below this line is automated
+
+        - [ ] New or removed alembic migrations.
+        - [ ] Breaking `__ATRIUM_REGISTRY__` changes affecting the host bundle.
+        - [ ] New **required** env vars. 0.27.0's `SECRET_ENCRYPTION_KEY` is the
+              precedent: a missing one takes prod down at boot, not at deploy.
+        - [ ] New optional host hooks worth opting into.
+
+        ---
+
+        <details>
+        <summary>atrium v@TARGET@ release notes</summary>
+
+        EOF
+
+        # Temp file + mv rather than sed -i, whose argument handling
+        # differs between BSD and GNU.
+        for f in "$RUNNER_TEMP/commit-msg" "$RUNNER_TEMP/pr-body.md"; do
+          sed -e "s/@TARGET@/$TARGET/g" \
+              -e "s/@CURRENT@/$CURRENT/g" \
+              -e "s|@IMAGE@|$IMAGE|g" \
+              -e "s|@ATRIUM_REPO@|$ATRIUM_REPO|g" "$f" > "$f.new"
+          mv "$f.new" "$f"
+        done
+
+        # GitHub rejects a PR body over 65536 bytes; a long dependency
+        # changelog could reach that and fail the run at the last step.
+        head -c 40000 "$RUNNER_TEMP/release-notes.md" >> "$RUNNER_TEMP/pr-body.md"
+        if [ "$(wc -c < "$RUNNER_TEMP/release-notes.md")" -gt 40000 ]; then
+          printf '\n\n_(release notes truncated — read the full text upstream)_\n' \
+            >> "$RUNNER_TEMP/pr-body.md"
+        fi
+        printf '\n\n</details>\n' >> "$RUNNER_TEMP/pr-body.md"
+
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git switch -c "$BRANCH"
+        git add -A
+        git commit -F "$RUNNER_TEMP/commit-msg"
+        git push -u origin "$BRANCH"
+
+        url="$(gh pr create --base "$BASE" --head "$BRANCH" \
+          --title "$(head -n1 "$RUNNER_TEMP/commit-msg")" \
+          --body-file "$RUNNER_TEMP/pr-body.md")"
+        echo "$url"
+        echo "url=$url" >> "$GITHUB_OUTPUT"
+        echo "bumped=true" >> "$GITHUB_OUTPUT"

--- a/.github/actions/host-atrium-bump/bump.sh
+++ b/.github/actions/host-atrium-bump/bump.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Brendan Bank
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Bump a host repo's pinned atrium version across every place it
+# appears, and regenerate the frontend lockfile.
+#
+# The image tag and the @brendanbank/atrium-host-* npm packages are
+# version-locked: a host running image X with SDK packages from Y is
+# not a supported combination, and the failure is a runtime one (the
+# served bundle calls endpoints the image does not serve). This script
+# therefore edits all of them together or refuses — partial bumps are
+# not expressible.
+#
+# Configuration arrives as environment variables so the same script
+# serves hosts with different pin layouts. The generated host from
+# create-atrium-host pins in three files; a host that also pins in its
+# README or CI workflow lists those too.
+#
+#   ATRIUM_IMAGE      image repo, no tag   (default ghcr.io/brendanbank/atrium)
+#   PIN_CANONICAL     file the current version is read from
+#   PIN_FILES         newline-separated files holding the image tag
+#   NPM_PACKAGES      newline-separated npm packages pinned to the same version
+#   FRONTEND_DIR      directory holding package.json  (default frontend)
+#   PKG_MANAGER       pnpm | npm                      (default pnpm)
+#
+# Usage:
+#   bump.sh <new-version>            # edit + relock
+#   bump.sh <new-version> --check    # dry-run, print what would change
+#   bump.sh <new-version> --ci       # relock without running package scripts
+
+set -euo pipefail
+
+NEW="${1:-}"
+MODE="${2:-apply}"
+
+if [[ -z "$NEW" ]]; then
+  echo "usage: bump.sh <new-version> [--check | --ci]" >&2
+  exit 2
+fi
+case "$MODE" in
+  apply|--check|--ci) ;;
+  *) echo "error: mode must be --check or --ci (got: $MODE)" >&2; exit 2 ;;
+esac
+
+# Tolerate a leading "v" — release tags carry one, image tags do not.
+NEW="${NEW#v}"
+if ! [[ "$NEW" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "error: version must look like X.Y.Z (got: $NEW)" >&2
+  exit 1
+fi
+
+ATRIUM_IMAGE="${ATRIUM_IMAGE:-ghcr.io/brendanbank/atrium}"
+PIN_CANONICAL="${PIN_CANONICAL:-.env.example}"
+FRONTEND_DIR="${FRONTEND_DIR:-frontend}"
+PKG_MANAGER="${PKG_MANAGER:-pnpm}"
+
+# Newline-separated inputs, blank lines and surrounding space dropped.
+# Built with a read loop rather than `readarray` so the script also runs
+# under the bash 3.2 that ships with macOS — hosts wire this into a
+# `make atrium-bump` target and run it on a laptop, not only on a runner.
+_split_lines() {
+  local _line
+  _RESULT=()
+  while IFS= read -r _line; do
+    _line="${_line#"${_line%%[![:space:]]*}"}"
+    _line="${_line%"${_line##*[![:space:]]}"}"
+    [ -n "$_line" ] && _RESULT+=("$_line")
+  done < <(printf '%s\n' "$1")
+}
+
+_split_lines "${PIN_FILES:-}";    IMG_FILES=("${_RESULT[@]:-}")
+_split_lines "${NPM_PACKAGES:-}"; NPM_PKGS=("${_RESULT[@]:-}")
+# An empty split yields one empty element under the :- guard; drop it.
+[ "${#IMG_FILES[@]}" -eq 1 ] && [ -z "${IMG_FILES[0]}" ] && IMG_FILES=()
+[ "${#NPM_PKGS[@]}" -eq 1 ]  && [ -z "${NPM_PKGS[0]}" ]  && NPM_PKGS=()
+
+if [[ ${#IMG_FILES[@]} -eq 0 ]]; then
+  echo "error: PIN_FILES is empty — nothing to rewrite" >&2
+  exit 1
+fi
+
+# Read the current version from the canonical file. Any occurrence of
+# the image tag will do; the lockstep check below is what guarantees
+# the rest of the files agree with it.
+CUR="$(grep -oE "${ATRIUM_IMAGE//./\\.}:[0-9]+\.[0-9]+\.[0-9]+" "$PIN_CANONICAL" 2>/dev/null | head -n1 | sed 's/.*://')"
+if [[ -z "$CUR" ]]; then
+  echo "error: no '$ATRIUM_IMAGE:X.Y.Z' pin found in $PIN_CANONICAL" >&2
+  exit 1
+fi
+
+if [[ "$CUR" == "$NEW" ]]; then
+  echo "current pin is already $CUR — nothing to do."
+  exit 0
+fi
+
+OLD_TAG="${ATRIUM_IMAGE}:${CUR}"
+NEW_TAG="${ATRIUM_IMAGE}:${NEW}"
+
+echo "Bumping atrium: $CUR -> $NEW"
+echo
+
+# Refuse if any pinned file disagrees with the canonical one. A repo
+# that is already out of lockstep must be fixed by hand — bumping from
+# a stale value would silently leave the odd file behind, which is the
+# failure this script exists to prevent.
+missing=0
+for f in "${IMG_FILES[@]}"; do
+  if [[ ! -f "$f" ]]; then
+    echo "error: $f does not exist" >&2
+    missing=1
+  elif ! grep -qF "$OLD_TAG" "$f"; then
+    echo "error: $f does not contain expected pin '$OLD_TAG'" >&2
+    missing=1
+  fi
+done
+[[ $missing -eq 0 ]] || {
+  echo >&2
+  echo "Refusing to proceed: pinned files are not in lockstep." >&2
+  exit 1
+}
+
+PKG_JSON="$FRONTEND_DIR/package.json"
+if [[ ${#NPM_PKGS[@]} -gt 0 ]]; then
+  [[ -f "$PKG_JSON" ]] || { echo "error: $PKG_JSON not found" >&2; exit 1; }
+  for pkg in "${NPM_PKGS[@]}"; do
+    if ! grep -qE "\"${pkg}\": \"\\^?${CUR//./\\.}\"" "$PKG_JSON"; then
+      echo "error: $PKG_JSON does not have $pkg pinned at $CUR" >&2
+      exit 1
+    fi
+  done
+fi
+
+if [[ "$MODE" == "--check" ]]; then
+  echo "(dry-run) Would rewrite:"
+  for f in "${IMG_FILES[@]}"; do
+    n=$(grep -cF "$OLD_TAG" "$f" || true)
+    printf "  %-32s %d occurrence(s)\n" "$f" "$n"
+  done
+  for pkg in "${NPM_PKGS[@]:-}"; do
+    [[ -n "$pkg" ]] && printf "  %-32s %s -> %s\n" "$PKG_JSON" "$pkg@$CUR" "$NEW"
+  done
+  exit 0
+fi
+
+# --- Apply ---------------------------------------------------------------
+
+# Literal substitution via awk, not sed -i: sed -i's argument handling
+# differs between BSD and GNU, and the tag contains '/' and '.' which
+# would need escaping in a regex.
+for f in "${IMG_FILES[@]}"; do
+  tmp="$(mktemp)"
+  awk -v old="$OLD_TAG" -v new="$NEW_TAG" '{
+    n = old; gsub(/[][\\.^$(){}|*+?]/, "\\\\&", n)
+    gsub(n, new)
+    print
+  }' "$f" > "$tmp"
+  mv "$tmp" "$f"
+  echo "  edited $f"
+done
+
+if [[ ${#NPM_PKGS[@]} -gt 0 ]]; then
+  # Only the listed packages: a bare "^$CUR" match would also rewrite
+  # unrelated dependencies that happen to sit on the same version.
+  for pkg in "${NPM_PKGS[@]}"; do
+    tmp="$(mktemp)"
+    awk -v pkg="$pkg" -v cur="$CUR" -v new="$NEW" '
+      index($0, "\"" pkg "\":") { sub(cur, new) }
+      { print }
+    ' "$PKG_JSON" > "$tmp"
+    mv "$tmp" "$PKG_JSON"
+  done
+  echo "  edited $PKG_JSON"
+
+  for pkg in "${NPM_PKGS[@]}"; do
+    if ! grep -qE "\"${pkg}\": \"\\^?${NEW//./\\.}\"" "$PKG_JSON"; then
+      echo "error: $PKG_JSON edit failed for $pkg — inspect by hand" >&2
+      exit 1
+    fi
+  done
+
+  # Relock. --ci uses --lockfile-only --ignore-scripts because the
+  # workflow that runs it holds a write-capable token, and a full
+  # install would execute lifecycle scripts from freshly-resolved
+  # packages beside it. The host's own CI does the real install on the
+  # resulting PR and fails on a bad relock.
+  echo
+  case "$PKG_MANAGER:$MODE" in
+    pnpm:--ci) ( cd "$FRONTEND_DIR" && pnpm install --lockfile-only --ignore-scripts ) ;;
+    pnpm:*)    ( cd "$FRONTEND_DIR" && pnpm install ) ;;
+    npm:--ci)  ( cd "$FRONTEND_DIR" && npm install --package-lock-only --ignore-scripts ) ;;
+    npm:*)     ( cd "$FRONTEND_DIR" && npm install ) ;;
+    *) echo "error: unknown PKG_MANAGER '$PKG_MANAGER'" >&2; exit 1 ;;
+  esac
+fi
+
+echo
+echo "atrium pin: $CUR -> $NEW (working tree updated, not committed)"

--- a/docs/host-dev-recipe.md
+++ b/docs/host-dev-recipe.md
@@ -203,6 +203,108 @@ updates:
       actions: { patterns: ["*"] }
 ```
 
+## Staying on the current atrium
+
+A host pins atrium in more places than it looks: the image tag appears in
+`.env.example`, the `Dockerfile` `ARG`, `compose.yaml`, and often a CI
+workflow and the README, while `@brendanbank/atrium-host-bundle-utils` and
+`@brendanbank/atrium-host-types` carry the same version in
+`frontend/package.json`. Those are **not independently upgradable**. A host
+running image X with SDK packages from Y fails at runtime rather than at
+build time — the served bundle calls endpoints the image does not serve —
+and Dependabot will happily propose the npm half on its own, because from
+npm's side nothing is wrong.
+
+`.github/actions/host-atrium-bump` moves all of them together or refuses.
+Hosts scaffolded by `create-atrium-host` get the caller workflow already
+wired; an existing host adds this:
+
+```yaml
+name: Atrium release watch
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to adopt. Blank = latest release."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.ATRIUM_BUMP_TOKEN }}
+      - uses: pnpm/action-setup@v4
+        with: { version: 10.33.1 }
+      - uses: actions/setup-node@v4
+        with: { node-version: "22" }
+      - uses: brendanbank/atrium/.github/actions/host-atrium-bump@master
+        with:
+          token: ${{ secrets.ATRIUM_BUMP_TOKEN }}
+          version: ${{ inputs.version }}
+          pin-files: |
+            .env.example
+            Dockerfile
+            compose.yaml
+            .github/workflows/ci.yml
+            README.md
+```
+
+`pin-files` is the only input most hosts set — list every file that
+carries the image tag, and add to it the moment you pin the tag somewhere
+new. `image`, `canonical-file`, `npm-packages`, `frontend-dir`,
+`package-manager`, `base-branch` and `branch-prefix` all have defaults
+matching the scaffolded layout.
+
+### The token
+
+`ATRIUM_BUMP_TOKEN` must be a fine-grained PAT or app token, **not**
+`GITHUB_TOKEN`. A PR opened by `GITHUB_TOKEN` does not trigger
+`pull_request` workflows, so the host's CI would never exercise the new
+image — which is the entire point of the bump PR. Scope it to the one
+repo, with:
+
+| Permission | Level | Why |
+|---|---|---|
+| Contents | Read and write | push the bump branch |
+| Pull requests | Read and write | open the PR |
+| Workflows | Read and write | only if a pinned file lives under `.github/workflows` |
+
+The Workflows permission is the one that bites late: GitHub rejects a PAT
+push touching any workflow file without it, so a host that pins the tag in
+its CI workflow looks fine until the first real release.
+
+### What it does not do
+
+It does not merge, and it does not deploy. The PR carries the upstream
+release notes and a checklist, because the things that break a host on an
+atrium bump — a new required env var, an alembic migration, a breaking
+`__ATRIUM_REGISTRY__` change — are not detectable from the version number.
+0.27.0 is the worked example: it made `SECRET_ENCRYPTION_KEY` mandatory,
+and a host that took that bump without reading anything would come back up
+only as far as the API's startup validation.
+
+A host that wants bumps merged automatically can add a `workflow_run` gate
+that squash-merges the PR once every check on its head commit is green.
+Prefer that over GitHub's native auto-merge unless the default branch has
+required status checks: without them `gh pr merge --auto` merges
+immediately, before CI starts.
+
+### If a release is only half published
+
+A `v*` tag fires `publish-images.yml` and `publish-npm.yml`, and they take
+minutes. A poll landing in that window sees a release whose artifacts do
+not exist yet. The action checks the registry manifest and npm before
+touching anything and simply retries on the next run, so a host never
+opens a PR that cannot build.
+
 ## Backend test stack
 
 Use `testcontainers-mysql` against MySQL 8.0 — the same engine

--- a/packages/create-atrium-host/template/.github/workflows/atrium-watch.yml
+++ b/packages/create-atrium-host/template/.github/workflows/atrium-watch.yml
@@ -1,0 +1,71 @@
+name: Atrium release watch
+
+# Polls atrium for a new release once a day and opens a lockstep bump
+# PR — the image tag across every file that pins it, plus the
+# version-locked @brendanbank/atrium-host-* packages and the lockfile.
+# All the logic lives in the action; this file is just the trigger and
+# this host's pin layout.
+#
+# Setup, once: create a fine-grained PAT scoped to this repo with
+# Contents + Pull requests set to read and write, add Workflows write
+# too if any file listed in pin-files lives under .github/workflows,
+# and store it as the ATRIUM_BUMP_TOKEN secret. It must not be
+# GITHUB_TOKEN — a PR opened by GITHUB_TOKEN does not trigger
+# `pull_request` workflows, so CI would never exercise the new image.
+#
+# Note: GitHub disables `schedule` on a repo with 60 days of no
+# activity. If this repo goes quiet the poll stops silently; re-enable
+# it from the Actions tab or run `gh workflow run atrium-watch.yml`.
+
+on:
+  schedule:
+    # Deliberately off the hour — GitHub queues cron heavily at :00 and
+    # delays or drops runs scheduled there.
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "atrium version to adopt (e.g. 0.29.0). Blank = latest release."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: atrium-watch
+  cancel-in-progress: false
+
+jobs:
+  watch:
+    name: Check for a new atrium release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Same token the action pushes with, so the push is
+          # authenticated as the PAT rather than GITHUB_TOKEN.
+          token: ${{ secrets.ATRIUM_BUMP_TOKEN }}
+
+      # The lockfile must be regenerated with the same package manager
+      # version this host's CI uses, or the relock churns. That is why
+      # the action does not set this up itself.
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - uses: brendanbank/atrium/.github/actions/host-atrium-bump@master
+        with:
+          token: ${{ secrets.ATRIUM_BUMP_TOKEN }}
+          version: ${{ inputs.version }}
+          # Every file in this host that carries the image tag. They are
+          # rewritten together and the bump refuses if any disagrees, so
+          # add a file here the moment you pin the tag in it.
+          pin-files: |
+            .env.example
+            Dockerfile
+            compose.yaml


### PR DESCRIPTION
Every host repo pins atrium in more places than it looks: the image tag in
`.env.example`, the `Dockerfile` `ARG`, `compose.yaml`, often a CI workflow and
the README, plus `@brendanbank/atrium-host-bundle-utils` and
`@brendanbank/atrium-host-types` carrying the same version in
`frontend/package.json`.

Those are **not independently upgradable**. A host running image X with SDK
packages from Y fails at runtime rather than at build time — the served bundle
calls endpoints the image does not serve. And Dependabot proposes the npm half
on its own, because from npm's side nothing is wrong. `atrium-casa-bookings`
had exactly that PR open against 0.28.0 while its image pin sat on 0.27.0.

Casa solved this locally and has been running it — daily poll, publish-readiness
gate, lockstep bump PR with the release notes inlined, CI exercising the new
image on that PR before merge. It took 0.28.0 end to end. `atrium-ddns` and the
others want the same, so this lifts it here rather than leaving each host to
copy three files and diverge.

## Poll, not push

Atrium holds no credential for any host repo and fires nothing at them. Each
host reaches out on its own schedule over the public API, so adding a host
costs this repo nothing and grants it nothing. That's why this is an action a
host calls, not a `repository_dispatch` atrium sends.

## What's here

- **`.github/actions/host-atrium-bump/action.yml`** — composite action. Resolves
  the latest release, refuses to walk backwards, skips a bump already in flight,
  confirms the image manifest *and* the npm packages exist before touching
  anything, applies the bump, opens the PR.
- **`bump.sh`** — the editing rules, config-driven so hosts with different pin
  layouts share one implementation. Refuses when the pinned files disagree with
  the canonical one rather than bumping from a stale value — that's the failure
  it exists to prevent.
- **Scaffolder template** — a new host is subscribed to its own base image from
  the first commit.
- **`docs/host-dev-recipe.md`** — wiring, token, and what it deliberately does
  not do.

## Two design points worth review

**The publish gate.** A `v*` tag fires `publish-images.yml` and
`publish-npm.yml` and they take minutes, so a daily poll can land mid-publish.
Half-published is not a failure, so the action retries next run rather than
opening a PR that cannot build. It probes the registry with an anonymous pull
token rather than `docker pull`, so it needs neither Docker nor a login.

**The token cannot be `GITHUB_TOKEN`.** A PR opened by `GITHUB_TOKEN` does not
trigger `pull_request` workflows, so the host's CI would never exercise the new
image — the entire point of the bump PR. It also needs Workflows write whenever
a pinned file lives under `.github/workflows`; GitHub rejects such a push
without it, and a host that pins the tag in CI looks fine right up until its
first real release.

## Verification

- **Replayed casa's 0.28.0 adoption.** Run against casa at the commit before
  that bump, `bump.sh` reproduces the merged result byte-for-byte across all
  seven changed files, lockfile included.
- **Gate step** against the live casa repo: correct no-op when already current,
  correct proceed for a forced future version with the branch and PR lookups
  running clean.
- **Publish step** against the live registry and npm: `go=true` for 0.28.0,
  `not published yet` for 0.29.0.
- All 16 scaffolder tests pass with the new template file.
- `bump.sh` parses under both bash 5 and the bash 3.2 that ships with macOS —
  hosts wire it into a `make atrium-bump` target and run it on a laptop.

Not exercised: a full action run inside GitHub Actions, which needs this on a
branch a host can reference. The individual steps were each run directly.

## Follow-up, not in this PR

The scaffolder template pins the action at `@master`. If you'd rather hosts pin
a tag, that wants a release-time step to rewrite the ref, since the bump script
only rewrites image tags and npm versions.
