### PR TITLE
fix(host-sdk): mark the row dirty when a UserSecret is assigned

### DIFF
--- a/backend/app/host_sdk/crypto.py
+++ b/backend/app/host_sdk/crypto.py
@@ -51,6 +51,7 @@ from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from sqlalchemy import LargeBinary, event
 from sqlalchemy.dialects.mysql import MEDIUMBLOB
 from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import flag_dirty
 from sqlalchemy.types import TypeDecorator
 
 from app.settings import get_settings
@@ -681,6 +682,18 @@ class UserSecret:
         # yet (``Device(secret=…, user_id=…)`` binds keywords in the
         # order written), and the key may not be unlocked yet either.
         instance.__dict__[self._pending_slot] = value
+        # The slot is not a mapped attribute, so writing it tells
+        # SQLAlchemy nothing and the row never reaches
+        # ``session.dirty`` -- which is what ``before_flush`` iterates.
+        # On a clean persistent row that silently discarded the write:
+        # commit succeeded, ciphertext unchanged. Rotating a credential
+        # without touching another column is the single most common
+        # thing a host's edit form does, so the one case that failed
+        # was the main one. The ``None`` branch above never had the bug
+        # because it assigns a mapped column. ``flag_dirty`` is a no-op
+        # on a transient instance, so the constructor path is
+        # unaffected.
+        flag_dirty(instance)
 
     # -- flush ------------------------------------------------------- #
 

--- a/backend/tests/integration/test_user_scope_secrets.py
+++ b/backend/tests/integration/test_user_scope_secrets.py
@@ -278,3 +278,60 @@ async def test_key_cache_does_not_outlive_the_session(engine, host_table, users)
         device = await s.get(Device, device_id)
         with pytest.raises(SecretLockedError):
             _ = device.secret
+
+
+@pytest.mark.asyncio
+async def test_rotating_only_the_secret_on_a_clean_row_persists(
+    engine, host_table, users
+):
+    """Issue #230: the shape of "the user changed only the credential".
+
+    ``__set__`` parks the plaintext in an unmapped ``__dict__`` slot,
+    so without an explicit ``flag_dirty`` the row never reaches
+    ``session.dirty`` and ``before_flush`` never visits it. The commit
+    then succeeds with the old ciphertext still in the column -- no
+    exception, no warning, a 200 back to whoever asked.
+
+    The tests above all mutate something else on the row (or create it
+    outright), which marks it dirty for free and hides this.
+    """
+    owner, _ = users
+    device_id = await _write_secret(engine, owner.id, "original-secret")
+
+    async with _factory(engine)() as s:
+        device = await s.get(Device, device_id)  # clean, persistent
+        await unlock_user_secrets(s, device.user_id)
+        device.secret = "rotated-secret"  # nothing else on the row changes
+        await s.commit()
+
+    async with _factory(engine)() as s:
+        device = await s.get(Device, device_id)
+        await unlock_user_secrets(s, device.user_id)
+        assert device.secret.reveal() == "rotated-secret"
+
+
+@pytest.mark.asyncio
+async def test_rotating_twice_in_a_row_keeps_the_last_value(
+    engine, host_table, users
+):
+    """A rotation is not a one-shot: the second one has to land too.
+
+    Guards the fix being a stale-dirty-flag artefact rather than the
+    write genuinely being tracked -- if the row only happened to be
+    dirty from the previous statement, the second rotation would be
+    the one to fall through.
+    """
+    owner, _ = users
+    device_id = await _write_secret(engine, owner.id, "first")
+
+    for value in ("second", "third"):
+        async with _factory(engine)() as s:
+            device = await s.get(Device, device_id)
+            await unlock_user_secrets(s, device.user_id)
+            device.secret = value
+            await s.commit()
+
+    async with _factory(engine)() as s:
+        device = await s.get(Device, device_id)
+        await unlock_user_secrets(s, device.user_id)
+        assert device.secret.reveal() == "third"


### PR DESCRIPTION
Closes #230.

Assigning a `UserSecret` on an otherwise-unmodified persistent row was **silently discarded** — commit succeeded, audit row written, API returned 200, old ciphertext still in the column.

## Cause

`__set__` parks the plaintext in `instance.__dict__[_pending_slot]`, which is not a mapped attribute. SQLAlchemy is told nothing, so the row never reaches `session.dirty` — exactly what the `before_flush` hook iterates:

```python
for instance in list(session.new) + list(session.dirty):
```

The `None` branch never had the bug, because it assigns a mapped column (`setattr(instance, self.column, None)`) and that marks the row dirty as a side effect. So **clearing a secret worked and replacing one did not** — the wrong way round, since rotating a credential without touching another column is the single most common thing a host's credential form does.

## Fix

`flag_dirty(instance)` in `__set__`.

I checked whether it needs guarding for transient instances (the `Device(secret=…, user_id=…)` constructor path, where the object isn't in a session yet). It does not — `flag_dirty` is a no-op there, so no guard is needed and the constructor path is unaffected.

## Regression tests

Both from the issue, both failing before this change:

```
test_rotating_only_the_secret_on_a_clean_row_persists
    AssertionError: assert 'original-secret' == 'rotated-secret'

test_rotating_twice_in_a_row_keeps_the_last_value
    AssertionError: assert 'first' == 'third'
```

The second one is mine rather than the issue's. A single rotation passing could still be a stale-dirty-flag artefact — if the row were only incidentally dirty from the previous statement, the *second* rotation is the one that would fall through. It pins the write as genuinely tracked.

## Why the existing suite missed it

Every other test in `test_user_scope_secrets.py` either creates the object or mutates another column in the same unit of work. Both mark the row dirty for free, so the one uncovered path was the main one.

## Verification

- Both new tests fail on master, pass with the fix
- Full backend suite green: **399 passed**
- `ruff check app tests` clean