### PR TITLE
fix(host-sdk): widen SecretBlob to MEDIUMBLOB via @compiles

### DIFF
--- a/backend/app/host_sdk/crypto.py
+++ b/backend/app/host_sdk/crypto.py
@@ -50,6 +50,7 @@ from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from sqlalchemy import LargeBinary, event
 from sqlalchemy.dialects.mysql import MEDIUMBLOB
+from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import Session
 from sqlalchemy.types import TypeDecorator
 
@@ -379,12 +380,34 @@ class SecretBlob(LargeBinary):
     :class:`EncryptedText` without pretending to be transparent about
     it. The :class:`UserSecret` descriptor beside it does the crypto,
     because it is the only one of the two that can see the row.
+
+    The widening is the ``@compiles`` hook below, **not**
+    ``load_dialect_impl``. Being a plain ``TypeEngine`` is exactly why:
+    SQLAlchemy only calls ``load_dialect_impl`` on a ``TypeDecorator``,
+    so the obvious symmetry with :class:`EncryptedText` is a trap here
+    and cost this column its widening once already (#229).
     """
 
-    def load_dialect_impl(self, dialect):
-        if dialect.name in ("mysql", "mariadb"):
-            return dialect.type_descriptor(MEDIUMBLOB())
-        return dialect.type_descriptor(LargeBinary())
+
+@compiles(SecretBlob, "mysql", "mariadb")
+def _secret_blob_mediumblob(element, compiler, **kw) -> str:
+    """Widen :class:`SecretBlob` to ``MEDIUMBLOB`` on MySQL/MariaDB.
+
+    ``load_dialect_impl`` -- which :class:`EncryptedText` uses for the
+    same widening -- is a ``TypeDecorator`` hook. ``SecretBlob`` is a
+    plain ``LargeBinary``, so SQLAlchemy never calls it and the column
+    compiled to ``BLOB``: the 64 KB ceiling the widening exists to
+    avoid, on the one scope (user) most likely to hold something large
+    like a service-account JSON key or a certificate bundle.
+
+    ``@compiles`` is the ``TypeEngine`` equivalent and keeps
+    ``SecretBlob`` a plain ``LargeBinary`` -- making it a
+    ``TypeDecorator`` instead would work, but only by pretending to a
+    transparency it deliberately does not have.
+
+    Every other dialect keeps ``LargeBinary``'s default mapping.
+    """
+    return "MEDIUMBLOB"
 
 
 class SecretLockedError(RuntimeError):

--- a/backend/tests/unit/test_host_sdk_crypto.py
+++ b/backend/tests/unit/test_host_sdk_crypto.py
@@ -21,6 +21,7 @@ from app.host_sdk.crypto import (
     EncryptedJSON,
     EncryptedText,
     MaskedSecret,
+    SecretBlob,
     SecretDecryptError,
     _derive_key,
     apply_secret_update,
@@ -278,6 +279,42 @@ def test_mysql_widens_to_mediumblob():
 def test_other_dialects_keep_large_binary():
     impl = EncryptedText(purpose="cred.api_key").load_dialect_impl(sqlite.dialect())
     assert isinstance(impl, LargeBinary)
+
+
+# The two assertions above call ``load_dialect_impl`` directly, which
+# proves the hook returns the right type but not that SQLAlchemy ever
+# calls it. It does for ``EncryptedText`` (a ``TypeDecorator``) and did
+# not for ``SecretBlob`` (a plain ``LargeBinary``) — issue #229, where
+# the column shipped as ``BLOB`` while the hook, the docstring and a
+# hook-style test all said ``MEDIUMBLOB``. Everything below goes
+# through ``.compile()`` instead, which is what actually reaches the
+# DDL.
+
+
+def test_encrypted_text_compiles_to_mediumblob_on_mysql():
+    assert "MEDIUMBLOB" in EncryptedText(purpose="cred.api_key").compile(
+        dialect=mysql.dialect()
+    )
+
+
+def test_secret_blob_compiles_to_mediumblob_on_mysql():
+    """#229: the storage side of a user-scope secret has to match
+    EncryptedText, and user scope is where the large payloads live."""
+    assert "MEDIUMBLOB" in SecretBlob().compile(dialect=mysql.dialect())
+
+
+def test_secret_blob_keeps_the_default_mapping_on_other_dialects():
+    assert "MEDIUMBLOB" not in SecretBlob().compile(dialect=sqlite.dialect())
+
+
+def test_secret_blob_column_ddl_is_mediumblob():
+    """The end of the chain: what CREATE TABLE actually emits."""
+    from sqlalchemy import Column, MetaData, Table
+    from sqlalchemy.schema import CreateTable
+
+    table = Table("t", MetaData(), Column("ct", SecretBlob()))
+    ddl = str(CreateTable(table).compile(dialect=mysql.dialect()))
+    assert "MEDIUMBLOB" in ddl
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Closes #229.

`SecretBlob` documented that it widens to `MEDIUMBLOB` on MySQL, and carried a `load_dialect_impl` to do it. It compiled to `BLOB` — the 64 KB ceiling the widening exists to avoid.

```
SecretBlob().compile(dialect=mysql.dialect())    → 'BLOB'
EncryptedText(purpose='x').compile(same)         → 'MEDIUMBLOB'
```

## Cause

`load_dialect_impl` is a **`TypeDecorator`** hook. `EncryptedText` is a `TypeDecorator`, so its override runs. `SecretBlob` subclasses `LargeBinary`, a plain `TypeEngine`, where SQLAlchemy never calls it — I confirmed with a probe subclass that raises inside the hook and still compiles to `BLOB` without the hook ever firing.

The method was dead code, and the comment explaining *why* the class is not a `TypeDecorator` sat directly above a hook that only works on one.

## Fix

`@compiles(SecretBlob, "mysql", "mariadb")` — the `TypeEngine` equivalent. This is option (1) from the issue: it keeps `SecretBlob` a plain `LargeBinary`. Making it a `TypeDecorator` would also have worked, but only by pretending to a transparency it deliberately disclaims. Other dialects keep the default mapping.

The class docstring now says which mechanism does the widening and why the obvious symmetry with `EncryptedText` is a trap here.

## Why it mattered

ADR 0003 records the widening as deliberate, from production: *"the default `LargeBinary` mapping is a 64 KB `BLOB`, which PA found too small in prod."* Site scope got the fix and **user scope silently did not** — and user scope is where per-tenant provider credentials live, so it's the one more likely to hold a service-account JSON key or a certificate bundle.

## Tests

Four, two of which fail before this change:

```
test_secret_blob_compiles_to_mediumblob_on_mysql          FAILED → assert 'MEDIUMBLOB' in 'BLOB'
test_secret_blob_column_ddl_is_mediumblob                 FAILED
test_encrypted_text_compiles_to_mediumblob_on_mysql       (passes both ways — never broken)
test_secret_blob_keeps_the_default_mapping_on_other_dialects  (guards against over-widening)
```

They go through `.compile()` rather than calling the hook, **because the hook-style assertion is what let this through.** The existing `test_mysql_widens_to_mediumblob` calls `load_dialect_impl` directly, and that style passes for `SecretBlob` today:

```
direct hook call   -> MEDIUMBLOB   (isinstance: True)
actual DDL compile -> BLOB
```

So porting the existing test to `SecretBlob`, as the issue suggests, would have produced a green test over a broken column. One of the new tests goes all the way to `CreateTable`, which is what actually reaches the database. I left the two existing hook-style tests in place and added a comment above the new block explaining the distinction.

## Note for hosts

Atrium ships no `SecretBlob` column of its own (the primitive exists for host apps), so **there is no atrium migration here**. A host table already created under the old behaviour keeps its 64 KB `BLOB` until the host `ALTER`s it; new tables get `MEDIUMBLOB` from this version on. Worth a line in the release notes.

## Verification

- Full backend suite green: **401 passed**
- `ruff check app tests` clean