### PR TITLE
ci(security): rebuild the released image weekly instead of letting it rot

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -12,6 +12,15 @@ name: Publish image
 # `workflow_dispatch` lets a maintainer re-run an existing tag (eg.
 # registry outage recovery) without retagging.
 #
+# The weekly `schedule` re-publishes the *current* release tag so a
+# released image never drifts more than seven days behind Debian
+# security. CI validates the recipe on every PR but nothing used to
+# re-validate the artifact, so `v0.28.0` sat on openssl 3.5.6 for two
+# weeks and only downstream consumers ever saw it (issue #239). The
+# rebuild is only meaningful because the runtime `apt-get upgrade`
+# layer is cache-busted by `APT_REFRESH` — without that the warm
+# `type=gha` cache would make the scheduled run a silent no-op.
+#
 # Per-arch parallel builds: amd64 on ubuntu-24.04, arm64 on
 # ubuntu-24.04-arm. Each matrix job pushes its image by digest only
 # (no tags); the merge job assembles the multi-arch manifest list
@@ -26,6 +35,12 @@ on:
   push:
     tags:
       - "v*"
+  # Monday 05:00 UTC — an hour ahead of the weekly Security scan so
+  # the published-image job in `security.yml` scans the image this
+  # run just refreshed. That ordering is deliberate: if the rebuild
+  # ever no-ops, the scan is what makes it visible.
+  schedule:
+    - cron: "0 5 * * 1"
   workflow_dispatch:
     inputs:
       ref:
@@ -53,8 +68,52 @@ concurrency:
 # push.
 
 jobs:
+  # Every trigger carries the target tag somewhere different:
+  #   push               -> github.ref_name       (refs/tags/v1.2.3)
+  #   workflow_dispatch  -> inputs.ref            (github.ref is master)
+  #   schedule           -> nowhere; ask the API for the current release
+  # Resolving once here keeps checkout, the metadata-action semver
+  # values and the manifest tags reading the same string, instead of
+  # repeating a `||` chain at every use site (which had no schedule
+  # branch at all and would have published `latest` only).
+  resolve:
+    name: Resolve target tag
+    runs-on: ubuntu-24.04
+    outputs:
+      ref: ${{ steps.pick.outputs.ref }}
+      apt_refresh: ${{ steps.pick.outputs.apt_refresh }}
+    steps:
+      - name: Pick tag + apt cache-buster
+        id: pick
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_REF: ${{ github.event.inputs.ref }}
+          PUSH_REF: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          case "$EVENT_NAME" in
+            push)              ref="$PUSH_REF" ;;
+            workflow_dispatch) ref="$INPUT_REF" ;;
+            # `releases/latest` excludes drafts and pre-releases, so
+            # this is exactly the tag a consumer following `latest`
+            # is running.
+            schedule)          ref=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" -q .tag_name) ;;
+            *)                 ref="" ;;
+          esac
+          if [ -z "$ref" ]; then
+            echo "::error::could not resolve a tag to publish for event '$EVENT_NAME'" >&2
+            exit 1
+          fi
+          echo "Publishing $ref"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          # Stamped once, here, so both arch builds share a value even
+          # if one of them straddles midnight UTC.
+          echo "apt_refresh=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build (${{ matrix.platform }})
+    needs: resolve
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -77,7 +136,7 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
-          ref: ${{ github.event.inputs.ref || github.ref }}
+          ref: ${{ needs.resolve.outputs.ref }}
 
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4.3.0
 
@@ -134,15 +193,52 @@ jobs:
           file: Dockerfile
           target: runtime
           platforms: ${{ matrix.platform }}
+          # `pull: true` re-resolves `python:3.13-slim` instead of
+          # reusing whatever digest the runner had; `APT_REFRESH`
+          # busts the runtime `apt-get upgrade` layer. Both are needed
+          # for a rebuild of an unchanged tag to actually pick up
+          # Debian point releases (issue #239).
+          pull: true
           build-args: |
             VITE_API_BASE_URL=/api
             VITE_DEFAULT_LANGUAGE=en
+            APT_REFRESH=${{ needs.resolve.outputs.apt_refresh }}
           # No tags here — push-by-digest is what lets the merge job
           # below assemble the multi-arch manifest list under the
           # real semver tags.
           outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=runtime-${{ env.PLATFORM_PAIR }}
           cache-to: type=gha,scope=runtime-${{ env.PLATFORM_PAIR }},mode=max
+
+      # Regression guard for issue #239. The image we just pushed is
+      # supposed to have run `apt-get -y upgrade`; if the build cache
+      # served a stale layer instead, the guard below sees packages
+      # still pending and fails the job before the merge step moves
+      # any tag onto the digest. Simulating the upgrade (`-s`) rather
+      # than diffing versions keeps this independent of which package
+      # happens to be behind this week.
+      #
+      # Runs on both arches on purpose: the `type=gha` cache is scoped
+      # per platform, so an amd64-only check would miss an arm64
+      # cache hit.
+      - name: Verify no pending Debian security updates
+        run: |
+          set -euo pipefail
+          image="${IMAGE_NAME}@${{ steps.build.outputs.digest }}"
+          # `Error-Mode=any` + `set -e` inside the container matter:
+          # plain `apt-get update` exits 0 when it cannot reach a
+          # mirror (fetch failures are warnings), so an unreachable
+          # archive would produce empty output and read as "nothing
+          # pending" — a silent pass on the very check that exists to
+          # catch silent passes.
+          pending=$(docker run --rm --user root --entrypoint sh "$image" -c \
+            'set -e; apt-get update -qq -o APT::Update::Error-Mode=any >/dev/null; apt-get -s -y upgrade 2>/dev/null | grep "^Inst " || true')
+          if [ -n "$pending" ]; then
+            echo "::error::Published image still has upgradable Debian packages - the apt layer came from cache (issue #239)" >&2
+            echo "$pending" >&2
+            exit 1
+          fi
+          echo "No pending Debian upgrades in $image"
 
       - name: Export digest
         run: |
@@ -160,7 +256,7 @@ jobs:
 
   merge:
     name: Merge manifest
-    needs: build
+    needs: [resolve, build]
     runs-on: ubuntu-24.04
     steps:
       - name: Resolve image name
@@ -192,18 +288,16 @@ jobs:
           # ``type=semver`` defaults to extracting from ``github.ref``,
           # which is correct for the ``on: push: tags`` path
           # (``refs/tags/v1.2.3``) but wrong for ``workflow_dispatch``
-          # — that always runs against the workflow file's branch
-          # (``refs/heads/master``), and the dispatch ``ref`` input is
-          # carried separately in ``github.event.inputs.ref``. Without
-          # an explicit ``value=`` override, a manual re-publish drops
-          # every semver tag and only ``type=raw,value=latest`` lands,
-          # which is what bit the v0.11.2 re-dispatch. Plumbing the
-          # input through (with ``github.ref_name`` as the push-trigger
-          # fallback) keeps both paths emitting the full tag set.
+          # and ``schedule`` — both run against the workflow file's
+          # branch (``refs/heads/master``). Without an explicit
+          # ``value=`` override, a re-publish drops every semver tag
+          # and only ``type=raw,value=latest`` lands, which is what
+          # bit the v0.11.2 re-dispatch. The ``resolve`` job above
+          # normalises all three triggers to one string.
           tags: |
-            type=semver,pattern={{version}},value=${{ github.event.inputs.ref || github.ref_name }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ github.event.inputs.ref || github.ref_name }}
-            type=semver,pattern={{major}},value=${{ github.event.inputs.ref || github.ref_name }}
+            type=semver,pattern={{version}},value=${{ needs.resolve.outputs.ref }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.resolve.outputs.ref }}
+            type=semver,pattern={{major}},value=${{ needs.resolve.outputs.ref }}
             type=raw,value=latest
 
       - name: Create manifest list and push

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,10 +3,16 @@
 
 name: Security
 
-# Three supply-chain scans on a single workflow:
+# Four supply-chain scans on a single workflow:
 #   - Trivy fs + image scan of the runtime image (SARIF -> Security tab)
+#   - Trivy image scan of the *published* release tag (weekly)
 #   - pip-audit of the backend deps (advisory on PRs, gating weekly)
 #   - pnpm audit of the SPA deps (informational)
+#
+# The first scans the recipe; the second scans the artifact. They are
+# not the same thing: a tag published two weeks ago accumulates Debian
+# CVEs that an image built this minute never shows, and until issue
+# #239 only downstream consumers ever saw the difference.
 #
 # Triggered on PRs and pushes to master, plus a weekly cron so a fresh
 # CVE on an unchanged repo still surfaces within seven days.
@@ -60,6 +66,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Without this the `type=gha` cache below would restore the
+      # runtime `apt-get upgrade` layer from whenever it was last
+      # built, so the scan would report the package set of a
+      # week-old build rather than of today's Debian archive
+      # (issue #239). Daily granularity: the first run of the day
+      # pays for the upgrade, the rest still hit cache.
+      - name: Stamp apt cache-buster
+        run: echo "APT_REFRESH=$(date -u +%Y-%m-%d)" >> "$GITHUB_ENV"
+
       - name: Build runtime image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
@@ -67,10 +82,12 @@ jobs:
           file: Dockerfile
           target: runtime
           load: true
+          pull: true
           tags: atrium:scan
           build-args: |
             VITE_API_BASE_URL=/api
             VITE_DEFAULT_LANGUAGE=en
+            APT_REFRESH=${{ env.APT_REFRESH }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -116,6 +133,61 @@ jobs:
         with:
           sarif_file: trivy-image.sarif
           category: trivy-image
+
+  # Scans the artifact consumers actually pull, not the recipe. The
+  # weekly cron runs an hour after `publish-images.yml` refreshes the
+  # current release tag, so this doubles as the check that the
+  # scheduled rebuild wasn't a silent cache no-op: a green run here
+  # means the tag in the registry is genuinely current.
+  #
+  # Not run on PRs or master pushes - the published tag doesn't change
+  # on either, so it would be the same scan over and over.
+  trivy-published:
+    name: Trivy (published release tag)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      # upload-sarif resolves the analysis against the checked-out
+      # commit, so the checkout is required even though nothing in
+      # the scan reads the tree.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve published image ref
+        id: image
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          owner="${{ github.repository_owner }}"
+          # `releases/latest` skips drafts and pre-releases. The git
+          # tag is `vX.Y.Z`; metadata-action publishes the registry
+          # tag without the `v`, hence the ${tag#v} strip.
+          tag=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" -q .tag_name)
+          echo "ref=ghcr.io/${owner,,}/atrium:${tag#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Trivy scan of the published image
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+        with:
+          scan-type: image
+          image-ref: ${{ steps.image.outputs.ref }}
+          format: sarif
+          output: trivy-published.sarif
+          ignore-unfixed: true
+          severity: HIGH,CRITICAL
+
+      - name: Upload Trivy published SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9
+        with:
+          sarif_file: trivy-published.sarif
+          category: trivy-published
 
   pip-audit:
     name: pip-audit (backend deps)

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,20 @@ WORKDIR /app
 # refresh. Trivy on this repo and on downstream consumers
 # (atrium-pa, etc.) was firing on every published image until this
 # was added — see milestone "Security alerts (May 2026)".
-RUN apt-get update \
+#
+# ``APT_REFRESH`` is a cache-buster, not a setting. BuildKit keys a
+# ``RUN`` on its expanded command string plus its parent layer, and
+# neither changes when Debian publishes a point release — so a warm
+# ``type=gha`` cache restores a weeks-old ``apt-get upgrade`` layer
+# and republishes the same stale packages while looking like it
+# worked (issue #239). ``publish-images.yml`` and ``security.yml``
+# feed today's UTC date, so the upgrade re-runs at most once a day
+# per cache scope; local builds keep the default and stay cached.
+# The expensive layers (pnpm build, uv sync) are in other stages and
+# are unaffected.
+ARG APT_REFRESH=static
+RUN echo "apt refresh marker: ${APT_REFRESH}" \
+ && apt-get update \
  && apt-get -y upgrade \
  && apt-get install -y --no-install-recommends curl \
  && rm -rf /var/lib/apt/lists/* \

--- a/docs/published-images.md
+++ b/docs/published-images.md
@@ -91,6 +91,37 @@ deliberate version bump. Pin to `X.Y` in production for patch uptake; pin to
 
 The image is built for `linux/amd64` and `linux/arm64`.
 
+### Tags are mutable; digests are not
+
+Even `X.Y.Z` is a **moving pointer**. A tag names one version of atrium's
+own code, but the image under it also contains a Debian userland that keeps
+accruing CVEs after release day. So `publish-images.yml` re-publishes the
+current release tag **every Monday** (05:00 UTC): same source, rebuilt
+against today's Debian archive, and the `X.Y.Z` / `X.Y` / `X` / `latest`
+tags all move onto the new digest.
+
+Concretely: `v0.28.0` shipped `openssl 3.5.6`, Debian released `3.5.7` a few
+days later, and every consumer of the immutable-looking `0.28.0` tag kept
+pulling the vulnerable build until it was rebuilt (issue #239).
+
+What this means for a host project:
+
+- **Pin to a tag, not a digest**, unless you have a specific reason to
+  freeze bit-for-bit. A `FROM ghcr.io/<org>/atrium@sha256:…` never picks up
+  a security rebuild, and no alert in this repo will tell you that.
+- **Re-pull on deploy.** `docker compose pull` before `up -d`; a cached
+  local `0.28.0` is not necessarily the current `0.28.0`.
+- **Don't add your own `apt-get upgrade`** on top of the base image. It
+  papers over a stale base for one build and then rots the same way. If a
+  rebuild looks overdue, say so on the atrium issue tracker instead.
+
+Two CI guards keep this honest, because the failure mode is a rebuild that
+*looks* like it worked: the publish job fails if the image it just pushed
+still has upgradable Debian packages (a warm buildx cache would otherwise
+restore the old `apt-get upgrade` layer), and `security.yml` Trivy-scans the
+**published** tag weekly — the artifact consumers pull, not a freshly built
+one.
+
 ## Using atrium as a base image
 
 A host project's `Dockerfile` (one image extending atrium with both backend


### PR DESCRIPTION
## Summary

Published tags were effectively write-once. `publish-images.yml` only ran on a tag push, so the image built on release day is the image every consumer pulls forever. `v0.28.0` shipped `openssl 3.5.6`; Debian released `3.5.7` days later; 30 Trivy alerts landed on a downstream host while this repo's Security tab stayed empty. The Dockerfile was never wrong — CI validated the recipe on every PR, and nothing ever validated the artifact.

Four changes, three of them structural:

**Weekly rebuild.** `publish-images.yml` gets a Monday 05:00 UTC cron that re-publishes the current release tag. A new `resolve` job normalises the target tag across all three triggers — `push` carries it in `github.ref_name`, `workflow_dispatch` in `inputs.ref`, `schedule` nowhere (it asks `releases/latest`). Checkout, the semver metadata values and the manifest tags now read that one output instead of repeating a `||` chain that had no schedule branch and would have published only `latest`.

**Cache-busting the apt layer.** BuildKit keys a `RUN` on its expanded command string plus its parent layer, and neither changes when Debian publishes a point release — so a warm `type=gha` cache restores a weeks-old `apt-get upgrade` and republishes the same stale packages while looking like it worked. A new `APT_REFRESH` build arg, fed today's UTC date, makes the layer re-run at most once a day per cache scope. It defaults to a constant so local and compose builds stay cached, and only the apt layer is affected — `pnpm build` and `uv sync` live in other stages and keep their cache. Worth noting this also closes a hole on the *release* path: two releases a week apart with a warm cache would have shared the apt layer, so a brand-new tag could ship stale packages too.

**A guard, because the failure mode is a silent pass.** The publish job now fails if the image it just pushed still has upgradable Debian packages, before the merge job moves any tag onto the digest. It simulates the upgrade (`apt-get -s -y upgrade`) rather than diffing named versions, so it stays correct whatever is behind that week, and runs on both arches because the `type=gha` cache is scoped per platform. `APT::Update::Error-Mode=any` is deliberate: plain `apt-get update` exits 0 when it can't reach a mirror, which would have turned a network blip into a clean bill of health on the one check that exists to catch clean-looking failures.

**Scanning the artifact, not just the recipe.** `security.yml` gains a weekly Trivy scan of the published release tag, uploaded under its own `trivy-published` SARIF category. It runs an hour after the rebuild, so a green result also confirms the rebuild wasn't a no-op. The existing image-scan job now gets `APT_REFRESH` as well — its own gha cache could otherwise have it reporting a week-old package set.

Docs: a new *Tags are mutable; digests are not* section in `docs/published-images.md` explains the weekly refresh, why hosts should pin to a tag rather than a digest, why they should `docker compose pull` on deploy, and why adding their own `apt-get upgrade` on top is the wrong fix.

## Test plan

Workflow changes can't be exercised by the test suite, so the pieces were verified individually:

- `actionlint` clean on both changed workflows.
- **The cache-bust actually busts.** Built a minimal stage twice against a warm *external* buildx cache (`type=local`, the same shape as `type=gha`), with the builder torn down between runs. Same `APT_REFRESH` → `CACHED`, identical stamp. Changed `APT_REFRESH` → layer re-ran, new stamp. So normal builds stay fast and a rebuild is genuinely a rebuild.
- **The guard catches the real bug.** Run against today's `python:3.13-slim` it reports exactly the three packages from the issue: `openssl`, `libssl3t64`, `openssl-provider-legacy`, `3.5.6-1~deb13u2` → `3.5.7-1~deb13u2`. Run against the same base with `apt-get upgrade` applied, it passes. This is the check that would have failed the stale republish.
- **End to end.** Built the real `runtime` target from this branch: guard passes, and `openssl version` in the image reports `OpenSSL 3.5.7`.
- **Guard fails closed.** With `--network none` the container exits 100 rather than reporting an empty (clean) package list.

## Note on the immediate fix

Re-dispatching `v0.28.0` right now would check out v0.28.0's Dockerfile, which predates `APT_REFRESH` — so that one-off still depends on the GHA cache having evicted, as the issue anticipated. Cutting a `v0.28.1` off this branch gets the guaranteed path (and the guard would fail the build if the apt layer came from cache).

Closes #239