### PR TITLE
Fix the silent set -e exit that broke the first real host bump

### DIFF
--- a/.github/actions/host-atrium-bump/bump.sh
+++ b/.github/actions/host-atrium-bump/bump.sh
@@ -65,15 +65,31 @@ _split_lines() {
   while IFS= read -r _line; do
     _line="${_line#"${_line%%[![:space:]]*}"}"
     _line="${_line%"${_line##*[![:space:]]}"}"
-    [ -n "$_line" ] && _RESULT+=("$_line")
+    # `if`, not `[ -n "$_line" ] && _RESULT+=(...)`. A YAML block scalar
+    # keeps its trailing newline, so the last line read here is empty:
+    # the && list then returns 1, that becomes the while loop's status
+    # and so the function's return value, and `set -e` kills the script
+    # with no output at all. That is exactly how this failed on its
+    # first real release.
+    if [ -n "$_line" ]; then
+      _RESULT+=("$_line")
+    fi
   done < <(printf '%s\n' "$1")
+  return 0
 }
 
 _split_lines "${PIN_FILES:-}";    IMG_FILES=("${_RESULT[@]:-}")
 _split_lines "${NPM_PACKAGES:-}"; NPM_PKGS=("${_RESULT[@]:-}")
 # An empty split yields one empty element under the :- guard; drop it.
-[ "${#IMG_FILES[@]}" -eq 1 ] && [ -z "${IMG_FILES[0]}" ] && IMG_FILES=()
-[ "${#NPM_PKGS[@]}" -eq 1 ]  && [ -z "${NPM_PKGS[0]}" ]  && NPM_PKGS=()
+# Spelled as `if` for the same reason as in _split_lines: a trailing
+# && that short-circuits is a silent-exit hazard under set -e, and it
+# costs nothing to keep every one of them out of this script.
+if [ "${#IMG_FILES[@]}" -eq 1 ] && [ -z "${IMG_FILES[0]}" ]; then
+  IMG_FILES=()
+fi
+if [ "${#NPM_PKGS[@]}" -eq 1 ] && [ -z "${NPM_PKGS[0]}" ]; then
+  NPM_PKGS=()
+fi
 
 if [[ ${#IMG_FILES[@]} -eq 0 ]]; then
   echo "error: PIN_FILES is empty — nothing to rewrite" >&2
@@ -83,9 +99,17 @@ fi
 # Read the current version from the canonical file. Any occurrence of
 # the image tag will do; the lockstep check below is what guarantees
 # the rest of the files agree with it.
-CUR="$(grep -oE "${ATRIUM_IMAGE//./\\.}:[0-9]+\.[0-9]+\.[0-9]+" "$PIN_CANONICAL" 2>/dev/null | head -n1 | sed 's/.*://')"
+# Captured through an explicit `if !` rather than a bare assignment:
+# under `set -e` with pipefail, a grep that matches nothing aborts the
+# script on the assignment itself, so the error below could never print.
+# Silent exit 1 is the worst failure mode this script has.
+if ! _pin="$(grep -oE "${ATRIUM_IMAGE}:[0-9]+\.[0-9]+\.[0-9]+" "$PIN_CANONICAL" | head -n1)"; then
+  echo "error: no '$ATRIUM_IMAGE:X.Y.Z' pin found in $PIN_CANONICAL (cwd: $PWD)" >&2
+  exit 1
+fi
+CUR="${_pin##*:}"
 if [[ -z "$CUR" ]]; then
-  echo "error: no '$ATRIUM_IMAGE:X.Y.Z' pin found in $PIN_CANONICAL" >&2
+  echo "error: could not parse a version out of '$_pin'" >&2
   exit 1
 fi
 
@@ -138,7 +162,12 @@ if [[ "$MODE" == "--check" ]]; then
     printf "  %-32s %d occurrence(s)\n" "$f" "$n"
   done
   for pkg in "${NPM_PKGS[@]:-}"; do
-    [[ -n "$pkg" ]] && printf "  %-32s %s -> %s\n" "$PKG_JSON" "$pkg@$CUR" "$NEW"
+    # Last command in the loop body: a bare `&&` here makes the whole
+    # for-loop exit 1 when the final element is empty, which under
+    # set -e kills --check silently.
+    if [[ -n "$pkg" ]]; then
+      printf "  %-32s %s -> %s\n" "$PKG_JSON" "$pkg@$CUR" "$NEW"
+    fi
   done
   exit 0
 fi


### PR DESCRIPTION
`atrium-casa-bookings`' watcher failed on **0.29.0** — the first release to run
through this action — with no output whatsoever. 14 ms, exit 1, not one byte on
stdout or stderr:

```
##[endgroup]
##[error]Process completed with exit code 1
```

## Cause

`_split_lines` ended its loop body with:

```bash
[ -n "$_line" ] && _RESULT+=("$_line")
```

A YAML block scalar keeps its trailing newline, so `pin-files` arrives with a
final **empty** line — visible in the runner's own env dump. On that iteration
the test is false, the `&&` list returns 1, and since it's the last command in
the `while` body that becomes the loop's status and so the function's return
value. `set -e` turns that into an immediate silent exit, before the script has
printed anything.

It passed every test I ran because I passed inputs as `$'a\nb'` — no trailing
newline. The runner passes them with one. **That gap between the test harness
and the real caller is the whole bug**, and it's the reason it survived a
byte-for-byte equivalence test against a real historical bump.

## Fixes

- `if` instead of `&&`, plus an explicit `return 0`.
- Two other short-circuits carried the same hazard and are converted: the
  empty-array guards, and the `--check` loop over `NPM_PKGS`, whose trailing
  `&&` makes the whole `for` exit 1 when the last element is empty.
- **The pin lookup now fails loudly.** It was a bare assignment, so under
  `set -e` with pipefail a grep matching nothing aborted on the assignment
  itself and the `if [[ -z "$CUR" ]]` error could never print — the same silent
  exit 1 from a second source. Now `if ! _pin=...`, reporting the cwd, and
  dropping the escaped-dot pattern for the plain image string the gate step
  already uses.

## Verification

Run against casa at its current pin with inputs shaped exactly as the runner
passes them, trailing newlines included:

- `bump.sh` takes 0.28.0 → 0.29.0 across five files, both SDK packages and the
  lockfile
- `--check` no longer exits silently
- a missing pin prints `no 'IMAGE:X.Y.Z' pin found in FILE (cwd: ...)` and exits 1
- parses under bash 5 and macOS bash 3.2

The failure signature was also reproduced in isolation: a `grep` that finds
nothing inside an assignment under `set -euo pipefail` gives exit 1 with zero
output, identical to what the runner reported.
