### PR TITLE
Label the published image, and document what host auto-merge needs

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -185,6 +185,28 @@ jobs:
           fi
           echo "SPA bundle contains /api prefix ($bundle)"
 
+      # OCI labels for the image config. Without these the published
+      # image carries no version marker at all: there is no
+      # /app/VERSION, `uv sync` does not install atrium-backend as a
+      # distribution so importlib.metadata raises PackageNotFoundError
+      # inside the container, and `docker inspect` reported
+      # Config.Labels as null. A host verifying a deploy therefore had
+      # to exec into a running container and read /app/pyproject.toml.
+      # With these, `docker buildx imagetools inspect` answers it from
+      # the registry.
+      #
+      # Same `value=` override as the merge job: type=semver defaults to
+      # reading github.ref, which is the branch on workflow_dispatch and
+      # schedule, so the resolved tag has to be fed in explicitly or the
+      # version label silently goes missing.
+      - name: Compute image labels
+        id: labels
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.resolve.outputs.ref }}
+
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
@@ -193,6 +215,9 @@ jobs:
           file: Dockerfile
           target: runtime
           platforms: ${{ matrix.platform }}
+          # Baked into the image config, so they survive the merge job
+          # assembling the manifest list from per-arch digests.
+          labels: ${{ steps.labels.outputs.labels }}
           # `pull: true` re-resolves `python:3.13-slim` instead of
           # reusing whatever digest the runner had; `APT_REFRESH`
           # busts the runtime `apt-get upgrade` layer. Both are needed

--- a/docs/host-dev-recipe.md
+++ b/docs/host-dev-recipe.md
@@ -291,11 +291,74 @@ atrium bump — a new required env var, an alembic migration, a breaking
 and a host that took that bump without reading anything would come back up
 only as far as the API's startup validation.
 
-A host that wants bumps merged automatically can add a `workflow_run` gate
+### Merging bumps automatically
+
+A host that wants bumps merged without a click adds a `workflow_run` gate
 that squash-merges the PR once every check on its head commit is green.
 Prefer that over GitHub's native auto-merge unless the default branch has
 required status checks: without them `gh pr merge --auto` merges
-immediately, before CI starts.
+immediately, before CI starts. And required checks are not a free fix —
+if the host's workflows carry `paths-ignore: "**.md"`, a required check
+never reports on a doc-only PR and blocks it forever.
+
+Four details are load-bearing. Each one was found the hard way:
+
+```yaml
+on:
+  workflow_run:
+    # Every workflow that reports checks. Whichever finishes last is the
+    # one that merges; the earlier ones find checks pending and bail.
+    workflows: ["CI", "security", "codeql"]
+    types: [completed]
+
+jobs:
+  merge:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'atrium-bump/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      # `gh pr checks` reads statusCheckRollup, and that single call
+      # needs three scopes: the check runs (checks), the commit statuses
+      # beside them (statuses), and the Actions API (actions), because
+      # the query resolves each check back to its producing run via
+      # checkSuite.workflowRun. Miss one and the whole query 403s with
+      # "Resource not accessible by integration", naming only the first
+      # field it could not reach — so they surface one at a time.
+      # Job-level permissions REPLACE the workflow-level block, so
+      # everything needed must be listed here.
+      checks: read
+      statuses: read
+      actions: read
+```
+
+1. **Exclude the gate's own check by name.** A `workflow_run` run reports a
+   check against the same head commit, so a gate that reads "all checks"
+   sees itself pending and never merges anything.
+2. **Merge only the commit the checks ran on.** Compare the PR's
+   `headRefOid` against `github.event.workflow_run.head_sha`; otherwise a
+   push landing after a green run inherits that run's success.
+3. **Refuse when zero checks are reported.** No evidence is not a pass —
+   and this is the branch that catches a misconfigured token, instead of
+   reading an unreadable answer as a green light.
+4. **Wait on the security workflow too, not just CI.** A large share of
+   atrium releases are security releases; the workflow running Trivy
+   against the new image is exactly the one that tells you whether the
+   bump achieved anything.
+
+### Do not add `cache: pnpm` to the watcher
+
+The caller sets up a package manager but the watch job does nothing on
+almost every run. `actions/setup-node` with `cache: pnpm` fails its post
+step when the store was never populated — `Path Validation Error: Path(s)
+specified in the action for caching do(es) not exist` — which reds the
+whole run on every quiet day. That is the noise that teaches you to ignore
+the workflow, and it hides a real failure behind an expected red X. There
+is nothing worth caching either: the only install this job ever performs
+is one lockfile-only relock on a bump day.
 
 ### If a release is only half published
 


### PR DESCRIPTION
Two gaps found by running the host bump machinery for real in
`atrium-casa-bookings`, across the 0.28.0 and 0.29.0 adoptions.

## 1. The published image has no version marker

Checked against `ghcr.io/brendanbank/atrium:0.28.0`:

- `/app/VERSION` — absent
- `importlib.metadata.version("atrium-backend")` — `PackageNotFoundError`, because
  `uv sync` doesn't install the project as a distribution
- `docker inspect --format '{{json .Config.Labels}}'` — `null`

So a host verifying a deploy has to exec into a running container and read
`/app/pyproject.toml` (which is what casa's post-bump check now does, and what
`_atrium_version()` falls back to). Nothing is broken, but it means the question
"is the running image the one I pinned?" can't be answered from the registry.

`publish-images.yml` now stamps OCI labels on the image config via
`metadata-action`, with the same explicit `value=` override the merge job already
uses — `type=semver` defaults to reading `github.ref`, which is the *branch* on
`workflow_dispatch` and `schedule`, so the version label would silently go
missing on those paths. Labels are baked into the image config at build time, so
they survive the merge job assembling the manifest list from per-arch digests.

## 2. The auto-merge guidance is a stub

`host-dev-recipe.md` said only *"add a `workflow_run` gate"*. Following that costs
a host four discoveries, all of which casa made the expensive way:

- **`gh pr checks` needs `checks`, `statuses` AND `actions`** — one call, three
  scopes, because it resolves each check back to its producing run via
  `checkSuite.workflowRun`. GitHub names only the *first* field it can't reach,
  so they surface one round at a time. Job-level `permissions` **replace** the
  workflow-level block rather than adding to it.
- **The gate must exclude its own check by name**, or it sees itself pending and
  never merges anything.
- **It must merge only the commit the checks ran against**, or a push landing
  after a green run inherits that success.
- **Zero checks reported must refuse.** That branch is what caught the scope
  error, instead of treating an unreadable answer as a green light.

Also documents why the caller must not set `cache: pnpm` — the watch job installs
nothing on a no-op, so `setup-node`'s post step fails the run on nearly every day,
which is the noise that teaches you to ignore the workflow. The template and docs
example already omit it, but nothing said why, so it read as an oversight rather
than a decision.

And notes that branch protection isn't a free alternative: with
`paths-ignore: "**.md"` on a host's workflows, a required check never reports on
a doc-only PR and blocks it forever.

## Verification

Docs are prose. The labels change is verified only by YAML parse and by matching
the `value=` pattern the merge job already proves works on both trigger paths —
the real check is the next release, where
`docker buildx imagetools inspect ghcr.io/brendanbank/atrium:<next>` should show
`org.opencontainers.image.version` instead of nothing.
